### PR TITLE
feat: store skill references for automatic content refresh

### DIFF
--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -154,7 +154,7 @@ export function MessageBubble({
     node.role === "user" &&
     node.content.length === 1 &&
     node.content[0].type === "text" &&
-    node.content[0].text.startsWith("<skill_content")
+    (node.content[0].text.startsWith("<skill_activated") || node.content[0].text.startsWith("<skill_content"))
   ) {
     const nameMatch = node.content[0].text.match(/name="([^"]+)"/);
     const skillName = nameMatch?.[1] ?? "unknown";

--- a/apps/webui/src/server/routes/conversations.ts
+++ b/apps/webui/src/server/routes/conversations.ts
@@ -16,6 +16,7 @@ import {
   fullCompact,
   resolveModel,
   discoverProjectSkills,
+  buildSkillReference,
   type AgentEvent,
   type AssistantMessage,
   type Message,
@@ -209,14 +210,24 @@ async function streamAgentAndPersist(
     // The first message is the user prompt, already persisted by the route handler — skip it.
     const storedNew = storedNewAll[0]?.role === "user" ? storedNewAll.slice(1) : storedNewAll;
 
-    // Convert to TreeNodes
+    // Convert to TreeNodes (compact skill content to references for storage)
     const newNodes: TreeNode[] = [];
     let lastNodeId = parentNodeId;
     for (const msg of storedNew) {
+      let content = msg.content;
+      let meta: string | undefined;
+      if (msg.role === "user" && msg.content.length === 1 && msg.content[0].type === "text") {
+        const nameMatch = msg.content[0].text.match(/^<skill_content\s+name="([^"]+)">/);
+        if (nameMatch) {
+          content = [{ type: "text", text: buildSkillReference(nameMatch[1]) }];
+          meta = "skill-activation";
+        }
+      }
       const node: TreeNode = {
         id: nanoid(12), parentId: lastNodeId,
-        role: msg.role, content: msg.content, createdAt: Date.now(),
+        role: msg.role, content, createdAt: Date.now(),
         ...(msg.role === "assistant" ? { provider: config.provider, model: config.model } : {}),
+        ...(meta ? { meta } : {}),
       };
       newNodes.push(node);
       lastNodeId = node.id;

--- a/packages/creative-agent/src/agent/orchestrator.ts
+++ b/packages/creative-agent/src/agent/orchestrator.ts
@@ -14,6 +14,7 @@ import { discoverProjectSkills } from "../skills/discovery.js";
 import { SkillManager } from "../skills/manager.js";
 import { generateCatalog } from "../skills/catalog.js";
 import { RESTRICTED_TOOLS, collectGrantedRestrictedTools, type SkillMetadata } from "../skills/types.js";
+import { buildSkillContent, extractSkillReferenceName } from "../skills/content.js";
 import { storedToPiMessages } from "./convert.js";
 import { microCompact, KEEP_RECENT } from "./compact.js";
 import { analyzeContext } from "./context-analysis.js";
@@ -149,6 +150,17 @@ export async function setupCreativeAgent(
   let systemPrompt = DEFAULT_SYSTEM_PROMPT;
   if (skills.size > 0) {
     systemPrompt += "\n\n" + generateCatalog([...skills.values()]);
+  }
+
+  // Substitute skill references in history with current disk content
+  for (const msg of history) {
+    if (msg.role !== "user" || msg.content.length !== 1 || msg.content[0].type !== "text") continue;
+    const name = extractSkillReferenceName(msg.content[0].text);
+    if (!name) continue;
+    const skill = skills.get(name);
+    if (skill) {
+      msg.content = [{ type: "text" as const, text: buildSkillContent(name, skill, options.projectDir) }];
+    }
   }
 
   // Convert history

--- a/packages/creative-agent/src/index.ts
+++ b/packages/creative-agent/src/index.ts
@@ -12,6 +12,7 @@ export { createProjectTools } from "./tools/index.js";
 export { discoverSkills, discoverProjectSkills } from "./skills/discovery.js";
 export { generateCatalog } from "./skills/catalog.js";
 export { SkillManager } from "./skills/manager.js";
+export { buildSkillContent, buildSkillReference, extractSkillReferenceName } from "./skills/content.js";
 export type { SkillRecord, SkillMetadata } from "./skills/types.js";
 export { RESTRICTED_TOOLS, collectGrantedRestrictedTools } from "./skills/types.js";
 

--- a/packages/creative-agent/src/skills/content.ts
+++ b/packages/creative-agent/src/skills/content.ts
@@ -1,0 +1,33 @@
+import { relative } from "node:path";
+import type { SkillRecord } from "./types.js";
+
+/**
+ * Build the full skill content injected into the agent via steer.
+ * Extracted from SkillManager so it can be reused for runtime substitution.
+ */
+export function buildSkillContent(name: string, skill: SkillRecord, projectDir: string): string {
+  let content = `<skill_content name="${name}">\n`;
+
+  if (skill.meta.compatibility) {
+    content += `Compatibility: ${skill.meta.compatibility}\n\n`;
+  }
+
+  content += skill.body + "\n\n";
+  const skillDir = relative(projectDir, skill.baseDir);
+  content += `Skill directory: ${skillDir}\n`;
+  content += `Resource paths are relative to the skill directory. Prefix with the skill directory path when using file tools (e.g., read("${skillDir}/path/to/file")).\n`;
+
+  content += "</skill_content>";
+  return content;
+}
+
+/** Compact reference stored in conversation JSONL instead of the full body. */
+export function buildSkillReference(name: string): string {
+  return `<skill_activated name="${name}" />`;
+}
+
+/** Extract skill name from a `<skill_activated …/>` reference. Returns null if not a match. */
+export function extractSkillReferenceName(text: string): string | null {
+  const m = text.match(/^<skill_activated\s+name="([^"]+)"\s*\/>\s*$/);
+  return m ? m[1] : null;
+}

--- a/packages/creative-agent/src/skills/manager.ts
+++ b/packages/creative-agent/src/skills/manager.ts
@@ -1,10 +1,10 @@
-import { relative } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import type { UserMessage } from "@mariozechner/pi-ai";
 import { textResult } from "../tools/util.js";
 import * as log from "../logger.js";
 import type { SkillRecord } from "./types.js";
+import { buildSkillContent } from "./content.js";
 
 export const ACTIVATE_SKILL_TOOL_NAME = "activate_skill";
 
@@ -55,7 +55,7 @@ Important:
           ));
         }
 
-        const content = this.buildSkillContent(params.name, skill);
+        const content = buildSkillContent(params.name, skill, this.projectDir);
 
         if (this.onSteer) {
           this.onSteer({ role: "user", content, timestamp: Date.now() });
@@ -65,22 +65,6 @@ Important:
         return Promise.resolve(textResult(`Skill "${params.name}" loaded.`));
       },
     };
-  }
-
-  private buildSkillContent(name: string, skill: SkillRecord): string {
-    let content = `<skill_content name="${name}">\n`;
-
-    if (skill.meta.compatibility) {
-      content += `Compatibility: ${skill.meta.compatibility}\n\n`;
-    }
-
-    content += skill.body + "\n\n";
-    const skillDir = relative(this.projectDir, skill.baseDir);
-    content += `Skill directory: ${skillDir}\n`;
-    content += `Resource paths are relative to the skill directory. Prefix with the skill directory path when using file tools (e.g., read("${skillDir}/path/to/file")).\n`;
-
-    content += "</skill_content>";
-    return content;
   }
 
   update(skills: Map<string, SkillRecord>, projectDir: string): void {


### PR DESCRIPTION
## Summary
- Skill activations now store a compact `<skill_activated name="X" />` reference in conversation JSONL instead of the full skill body
- `setupCreativeAgent()` substitutes references with the latest disk content before each agent turn, so skill edits take effect immediately
- Extracted `buildSkillContent` from `SkillManager` into a shared `content.ts` module for reuse across write and read paths

## Test plan
- [ ] Activate a skill in a session → verify JSONL contains `<skill_activated name="X" />` (not full body)
- [ ] Edit the skill's SKILL.md on disk → send another message → verify agent uses updated content
- [ ] UI shows "Skill loaded: X" pill for both old (`<skill_content>`) and new (`<skill_activated>`) formats
- [ ] Verify compact flow still works (scans assistant `tool_use` blocks, unaffected by storage change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)