### PR TITLE
feat: resizable split pane between output and chat

### DIFF
--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,7 +1,12 @@
+import { useState, useRef, useCallback, useEffect } from "react";
 import { useProjectState } from "@/client/entities/project/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { RenderedView } from "@/client/features/project/index.js";
 import { AgentPanel, BottomInput, useConversation } from "@/client/features/chat/index.js";
+
+const DEFAULT_PANEL_WIDTH = 420;
+const MIN_PANEL_WIDTH = 280;
+const MAX_PANEL_RATIO = 0.6;
 
 interface ProjectPageProps {
   agentPanelOpen: boolean;
@@ -12,6 +17,40 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
   const project = useProjectState();
   const { t } = useI18n();
   const { create } = useConversation();
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const panelWidthRef = useRef(DEFAULT_PANEL_WIDTH);
+  const cleanupRef = useRef<(() => void) | null>(null);
+  panelWidthRef.current = panelWidth;
+
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startWidth = panelWidthRef.current;
+
+    const onMouseMove = (ev: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const maxWidth = container.getBoundingClientRect().width * MAX_PANEL_RATIO;
+      setPanelWidth(Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, startWidth + (startX - ev.clientX))));
+    };
+
+    const cleanup = () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", cleanup);
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      cleanupRef.current = null;
+    };
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", cleanup);
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    cleanupRef.current = cleanup;
+  }, []);
 
   return (
     <>
@@ -25,9 +64,9 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
       />
 
       {/* Top area: split pane */}
-      <div className="flex-1 flex min-h-0 relative z-10">
+      <div ref={containerRef} className="flex-1 flex min-h-0 relative z-10">
         {/* Left: Rendered View */}
-        <div className={`flex-1 flex flex-col min-w-0 border-r border-edge/6 ${agentPanelOpen ? "" : "border-r-0"}`}>
+        <div className={`flex-1 flex flex-col min-w-0 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
           {project.activeProjectSlug ? (
             <RenderedView />
           ) : (
@@ -38,9 +77,22 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
           )}
         </div>
 
+        {/* Resize handle */}
+        {agentPanelOpen && (
+          <div
+            onMouseDown={handleResizeStart}
+            className="hidden lg:block flex-shrink-0 w-px bg-edge/6 cursor-col-resize relative z-20"
+          >
+            <div className="absolute inset-y-0 -left-[3px] -right-[3px] hover:bg-accent/12 active:bg-accent/20 transition-colors duration-150" />
+          </div>
+        )}
+
         {/* Right: Agent Panel (collapsible) */}
         {agentPanelOpen ? (
-          <div className="w-[420px] flex-shrink-0 flex flex-col border-l border-edge/6 bg-base/40 hidden lg:flex">
+          <div
+            style={{ width: panelWidth }}
+            className="flex-shrink-0 flex flex-col bg-base/40 hidden lg:flex"
+          >
             <AgentPanel />
           </div>
         ) : (


### PR DESCRIPTION
## Summary
- 왼쪽 렌더링 뷰와 오른쪽 에이전트 패널 사이에 드래그 가능한 리사이즈 핸들 추가
- 마우스 오버 시 `col-resize` 커서 + accent 하이라이트 표시
- 패널 너비: 최소 280px, 최대 컨테이너의 60%

## Details
- 1px 시각적 라인 + 7px 투명 hit area로 자연스러운 UX
- `useRef`로 현재 width 추적하여 `useCallback` deps 안정화 (`[]`)
- `useEffect` cleanup으로 unmount 시 document 리스너 누수 방지
- 기존 `w-[420px]` 고정 너비를 `style={{ width }}` 동적 너비로 교체

## Test plan
- [ ] 리사이즈 핸들에 마우스 오버 시 `col-resize` 커서 확인
- [ ] 드래그로 패널 크기 조절 가능 확인
- [ ] 최소/최대 제한이 올바르게 작동하는지 확인
- [ ] 패널 토글(열기/닫기) 후에도 리사이즈 정상 작동 확인
- [ ] 드래그 중 패널 토글 시 리스너 정리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)