### PR TITLE
feat(library): add project-type colored tags to skill list

### DIFF
--- a/apps/webui/src/client/features/library/LibraryBrowser.tsx
+++ b/apps/webui/src/client/features/library/LibraryBrowser.tsx
@@ -3,6 +3,7 @@ import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, Badge, Button } from "@/client/shared/ui/index.js";
 import { fetchLibrarySkills, copyLibrarySkillToProject } from "@/client/entities/skill/index.js";
 import type { SkillMetadata } from "@/client/entities/skill/index.js";
+import { ProjectTypeTags } from "./ProjectTypeTags.js";
 
 interface LibraryBrowserProps {
   projectSlug: string;
@@ -58,6 +59,7 @@ export function LibraryBrowser({ projectSlug, existingSkills, onCopied, onClose 
                   {s.description && (
                     <div className="text-xs text-fg-3 mt-0.5 truncate">{s.description}</div>
                   )}
+                  <ProjectTypeTags metadata={s.metadata} />
                 </div>
                 {isAdded ? (
                   <Badge variant="accent">{t("libraryBrowser.added")}</Badge>

--- a/apps/webui/src/client/features/library/LibraryView.tsx
+++ b/apps/webui/src/client/features/library/LibraryView.tsx
@@ -3,6 +3,7 @@ import { useUIDispatch } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, TabBar } from "@/client/shared/ui/index.js";
 import { LibraryEditorView, type LibraryEditorConfig } from "./LibraryEditorView.js";
+import { ProjectTypeTags } from "./ProjectTypeTags.js";
 import {
   fetchLibrarySkills,
   fetchLibrarySkill,
@@ -21,6 +22,7 @@ type Tab = "skills" | "renderers";
 interface SkillItem {
   name: string;
   description: string;
+  metadata?: Record<string, string>;
 }
 
 interface RendererItem {
@@ -85,6 +87,7 @@ function SkillsView() {
           {skill.description && (
             <div className="text-xs text-fg-3 mt-0.5 truncate">{skill.description}</div>
           )}
+          <ProjectTypeTags metadata={skill.metadata} />
         </>
       )}
     />

--- a/apps/webui/src/client/features/library/ProjectTypeTags.tsx
+++ b/apps/webui/src/client/features/library/ProjectTypeTags.tsx
@@ -1,0 +1,42 @@
+/** Deterministic color palette for project-type tags */
+const TAG_PALETTE = [
+  { bg: "bg-accent/12", text: "text-accent" },
+  { bg: "bg-warm/12", text: "text-warm" },
+  { bg: "bg-[#a78bfa]/12", text: "text-[#a78bfa]" },
+  { bg: "bg-[#f472b6]/12", text: "text-[#f472b6]" },
+  { bg: "bg-[#60a5fa]/12", text: "text-[#60a5fa]" },
+  { bg: "bg-[#34d399]/12", text: "text-[#34d399]" },
+  { bg: "bg-[#fb923c]/12", text: "text-[#fb923c]" },
+] as const;
+
+function hashTagColor(tag: string): (typeof TAG_PALETTE)[number] {
+  let h = 0;
+  for (let i = 0; i < tag.length; i++) h = ((h << 5) - h + tag.charCodeAt(i)) | 0;
+  return TAG_PALETTE[((h % TAG_PALETTE.length) + TAG_PALETTE.length) % TAG_PALETTE.length];
+}
+
+export function parseProjectTypes(metadata?: Record<string, string>): string[] {
+  const raw = metadata?.["project-type"];
+  if (!raw || typeof raw !== "string") return [];
+  return raw.split(",").map((s) => s.trim()).filter(Boolean);
+}
+
+export function ProjectTypeTags({ metadata }: { metadata?: Record<string, string> }) {
+  const tags = parseProjectTypes(metadata);
+  if (tags.length === 0) return null;
+  return (
+    <div className="flex flex-wrap gap-1 mt-1">
+      {tags.map((tag) => {
+        const color = hashTagColor(tag);
+        return (
+          <span
+            key={tag}
+            className={`inline-flex items-center px-1.5 py-0.5 text-[11px] leading-none rounded-full font-medium ${color.bg} ${color.text}`}
+          >
+            {tag}
+          </span>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/webui/src/client/features/library/index.ts
+++ b/apps/webui/src/client/features/library/index.ts
@@ -2,3 +2,4 @@ export { LibraryView } from "./LibraryView.js";
 export { LibraryBrowser } from "./LibraryBrowser.js";
 export { LibraryEditorView, type LibraryEditorConfig } from "./LibraryEditorView.js";
 export { SkillEditor } from "./SkillEditor.js";
+export { ProjectTypeTags, parseProjectTypes } from "./ProjectTypeTags.js";

--- a/example_data/library/skills/character-chat/SKILL.md
+++ b/example_data/library/skills/character-chat/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   author: agentchan
   version: "1.0"
   recommended-renderer: chat
+  project-type: "chat"
 ---
 
 # 캐릭터 채팅 스킬

--- a/example_data/library/skills/dynamic-lorebook/SKILL.md
+++ b/example_data/library/skills/dynamic-lorebook/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   author: agentchan
   version: "1.0"
   type: framework
+  project-type: "chat, novel"
 ---
 
 # Dynamic Lorebook Skill

--- a/example_data/library/skills/hidden-spoiler/SKILL.md
+++ b/example_data/library/skills/hidden-spoiler/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   type: style
   display-name: Hidden Spoiler
   color: "#6366f1"
+  project-type: "novel, chat"
 ---
 
 # 히든 스포일러 시스템

--- a/example_data/library/skills/impersonate-character-chat/SKILL.md
+++ b/example_data/library/skills/impersonate-character-chat/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   author: agentchan
   version: "1.0"
   recommended-renderer: chat
+  project-type: "chat"
 ---
 
 # Impersonate 캐릭터 채팅 스킬

--- a/example_data/library/skills/long-term-memory/SKILL.md
+++ b/example_data/library/skills/long-term-memory/SKILL.md
@@ -5,6 +5,7 @@ metadata:
   author: agentchan
   version: "1.0"
   type: framework
+  project-type: "chat"
 ---
 
 # Long-Term Memory Skill

--- a/example_data/library/skills/novel-writing/SKILL.md
+++ b/example_data/library/skills/novel-writing/SKILL.md
@@ -8,6 +8,7 @@ metadata:
   author: agentchan
   version: "1.0"
   recommended-renderer: novel
+  project-type: "novel"
 ---
 
 # 소설 집필 스킬


### PR DESCRIPTION
## Summary
- Parse `project-type` from skill metadata (comma-separated string in YAML frontmatter) and display as colored pill badges in the Library editor sidebar and Library browser popup
- Add `ProjectTypeTags` component with a 7-color deterministic palette (hash-based) matching the Obsidian Teal design system
- Add `project-type` metadata to 6 existing example skills: character-chat, impersonate-character-chat, novel-writing, dynamic-lorebook, hidden-spoiler, long-term-memory

## Test plan
- [ ] Open Library page -> Skills tab: verify colored tags appear next to skill names (e.g., "chat", "novel")
- [ ] Open a project and click "Add from Library": verify tags also appear in the browser popup
- [ ] Edit a skill's YAML and change `project-type` value, save, verify tags update
- [ ] Verify skills without `project-type` (e.g., example, character/world skills) show no tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)