### PR TITLE
feat(chat): skill slash commands in input autocomplete

### DIFF
--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useConfigState } from "@/client/entities/config/index.js";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
@@ -19,7 +19,18 @@ export function BottomInput() {
   const { create } = useConversation();
   const [text, setText] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const slash = useSlashCommands(text, setText);
+
+  const sendText = useCallback(async (message: string) => {
+    if (!session.activeConversationId) {
+      await create();
+      setText(message);
+      return;
+    }
+    setText("");
+    await send(message);
+  }, [session.activeConversationId, create, send]);
+
+  const slash = useSlashCommands(text, setText, sendText);
 
   const contextTokens = session.sessionUsage.contextTokens;
   const contextWindow = config.contextWindow ?? 128_000;
@@ -44,19 +55,8 @@ export function BottomInput() {
   const handleSubmit = async () => {
     const trimmed = text.trim();
     if (!trimmed || isStreaming) return;
-
-    // Check slash command first
     if (slash.tryExecuteCommand(trimmed)) return;
-
-    // Auto-create conversation if none active
-    if (!session.activeConversationId) {
-      await create();
-      setText(trimmed);
-      return;
-    }
-
-    setText("");
-    await send(trimmed);
+    await sendText(trimmed);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {

--- a/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
+++ b/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
@@ -26,24 +26,33 @@ export function SlashCommandPopup({ commands, selectedIndex, onSelect, onHover }
       ref={listRef}
       className="absolute bottom-full left-0 right-0 mb-2 bg-elevated border border-white/8 rounded-xl shadow-lg shadow-void/50 overflow-y-auto max-h-[240px] animate-fade z-50"
     >
-      {commands.map((cmd, i) => (
-        <button
-          key={cmd.name}
-          onClick={() => onSelect(cmd)}
-          onMouseEnter={() => onHover(i)}
-          className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
-            i === selectedIndex
-              ? "bg-accent/10 text-accent"
-              : "text-fg-2 hover:bg-white/4"
-          }`}
-        >
-          <span className="font-mono text-sm">/{cmd.name}</span>
-          <span className="text-xs text-fg-3 flex-1">{cmd.description}</span>
-          {cmd.needsArg && cmd.argPlaceholder && (
-            <span className="text-[10px] text-fg-3 font-mono opacity-70">{cmd.argPlaceholder}</span>
-          )}
-        </button>
-      ))}
+      {commands.map((cmd, i) => {
+        const prevCmd = i > 0 ? commands[i - 1] : null;
+        const isDivider = cmd.kind === "skill" && prevCmd?.kind === "command";
+        return (
+          <button
+            key={`${cmd.kind}-${cmd.name}`}
+            onClick={() => onSelect(cmd)}
+            onMouseEnter={() => onHover(i)}
+            className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+              isDivider ? "border-t border-white/6" : ""
+            } ${
+              i === selectedIndex
+                ? "bg-accent/10 text-accent"
+                : "text-fg-2 hover:bg-white/4"
+            }`}
+          >
+            <span className="font-mono text-sm">/{cmd.name}</span>
+            <span className="text-xs text-fg-3 flex-1">{cmd.description}</span>
+            {cmd.kind === "skill" && (
+              <span className="text-[10px] text-fg-3 font-mono opacity-50">skill</span>
+            )}
+            {cmd.kind === "command" && cmd.needsArg && cmd.argPlaceholder && (
+              <span className="text-[10px] text-fg-3 font-mono opacity-70">{cmd.argPlaceholder}</span>
+            )}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/apps/webui/src/client/features/chat/commands.ts
+++ b/apps/webui/src/client/features/chat/commands.ts
@@ -3,13 +3,14 @@ export interface SlashCommand {
   description: string;
   needsArg: boolean;
   argPlaceholder?: string;
+  kind: "command" | "skill";
 }
 
 export const COMMANDS: SlashCommand[] = [
-  { name: "new", description: "Create new session", needsArg: false },
-  { name: "clear", description: "Clear / new session", needsArg: false },
-  { name: "compact", description: "Summarize and continue in new session", needsArg: false },
-  { name: "model", description: "Change model", needsArg: true, argPlaceholder: "<model-name>" },
-  { name: "provider", description: "Change provider", needsArg: true, argPlaceholder: "<provider-name>" },
-  { name: "help", description: "Show available commands", needsArg: false },
+  { name: "new", description: "Create new session", needsArg: false, kind: "command" },
+  { name: "clear", description: "Clear / new session", needsArg: false, kind: "command" },
+  { name: "compact", description: "Summarize and continue in new session", needsArg: false, kind: "command" },
+  { name: "model", description: "Change model", needsArg: true, argPlaceholder: "<model-name>", kind: "command" },
+  { name: "provider", description: "Change provider", needsArg: true, argPlaceholder: "<provider-name>", kind: "command" },
+  { name: "help", description: "Show available commands", needsArg: false, kind: "command" },
 ];

--- a/apps/webui/src/client/features/chat/useSlashCommands.ts
+++ b/apps/webui/src/client/features/chat/useSlashCommands.ts
@@ -1,21 +1,39 @@
 import { useState, useMemo, useCallback } from "react";
 import { useConfigDispatch, updateConfig } from "@/client/entities/config/index.js";
+import { useSkillState } from "@/client/entities/skill/index.js";
 import { useConversation } from "./useConversation.js";
 import { COMMANDS, type SlashCommand } from "./commands.js";
 
-export function useSlashCommands(text: string, setText: (s: string) => void) {
+export function useSlashCommands(
+  text: string,
+  setText: (s: string) => void,
+  onSendText?: (text: string) => Promise<void>,
+) {
   const configDispatch = useConfigDispatch();
   const { create, compact } = useConversation();
+  const { skills } = useSkillState();
   const [selectedIndex, setSelectedIndex] = useState(0);
 
   const query = text.startsWith("/") ? text.slice(1) : "";
   const isOpen = text.startsWith("/") && !query.includes(" ");
 
+  const skillCommands = useMemo<SlashCommand[]>(
+    () =>
+      skills.map((s) => ({
+        name: s.name,
+        description: s.description,
+        needsArg: false,
+        kind: "skill" as const,
+      })),
+    [skills],
+  );
+
   const filteredCommands = useMemo(() => {
     if (!isOpen) return [];
-    if (query === "") return COMMANDS;
-    return COMMANDS.filter((cmd) => cmd.name.startsWith(query.toLowerCase()));
-  }, [isOpen, query]);
+    const all = [...COMMANDS, ...skillCommands];
+    if (query === "") return all;
+    return all.filter((cmd) => cmd.name.toLowerCase().startsWith(query.toLowerCase()));
+  }, [isOpen, query, skillCommands]);
 
   // Clamp selectedIndex when filtered list changes
   const clampedIndex = Math.min(selectedIndex, Math.max(filteredCommands.length - 1, 0));
@@ -52,6 +70,11 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
 
   const selectCommand = useCallback(
     (cmd: SlashCommand) => {
+      if (cmd.kind === "skill") {
+        void onSendText?.("/" + cmd.name);
+        setSelectedIndex(0);
+        return;
+      }
       if (cmd.needsArg) {
         setText("/" + cmd.name + " ");
       } else {
@@ -59,7 +82,7 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
       }
       setSelectedIndex(0);
     },
-    [executeCommand, setText],
+    [executeCommand, setText, onSendText],
   );
 
   const tryExecuteCommand = useCallback(


### PR DESCRIPTION
## Summary
- `/` 입력 시 시스템 커맨드와 프로젝트 스킬이 함께 자동완성 팝업에 표시됩니다
- 스킬 선택 시 `/{name}`이 plain text로 전송됩니다 (특수 실행 없음)
- 커맨드/스킬 섹션 사이에 구분선, 스킬 항목에 `skill` 라벨 표시

## Changes
- `commands.ts`: `SlashCommand`에 `kind: "command" | "skill"` 필드 추가
- `useSlashCommands.ts`: `SkillContext`에서 스킬을 가져와 커맨드 리스트에 병합, `onSendText` 콜백으로 plain text 전송
- `SlashCommandPopup.tsx`: 스킬 시각 구분 (border divider + label)
- `BottomInput.tsx`: `sendText` 공통 함수로 중복 제거, `handleSubmit`이 위임

## Test plan
- [ ] `/` 입력 시 시스템 커맨드 + 스킬 모두 표시 확인
- [ ] 스킬 항목에 `skill` 라벨, 섹션 구분선 확인
- [ ] 팝업에서 스킬 선택 → `/{name}` plain text로 전송 확인
- [ ] 직접 `/skillname` 타이핑 + Enter → plain text 전송 확인
- [ ] 기존 시스템 커맨드 (/new, /model 등) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)