### PR TITLE
fix: allow custom providers without API key

### DIFF
--- a/apps/webui/src/server/services/agent.service.ts
+++ b/apps/webui/src/server/services/agent.service.ts
@@ -65,8 +65,10 @@ export function createAgentService(
     const config = configService.getConfig();
     const projectDir = join(projectsDir, slug);
 
+    const providerInfo = configService.findProvider(config.provider);
     const apiKey = configService.getApiKey(config.provider);
-    if (!apiKey) {
+    // Custom providers (e.g. local Ollama) may not require an API key.
+    if (!apiKey && !providerInfo?.custom) {
       await stream.writeSSE({
         event: "error",
         data: JSON.stringify({ message: `API key not configured for provider: ${config.provider}` }),
@@ -76,11 +78,10 @@ export function createAgentService(
     }
 
     try {
-      const providerInfo = configService.findProvider(config.provider);
       const { agent, historyLength } = await setupCreativeAgent(
         {
           provider: config.provider, model: config.model, projectDir,
-          apiKey,
+          apiKey: apiKey ?? "",
           temperature: config.temperature,
           maxTokens: config.maxTokens, contextWindow: config.contextWindow,
           thinkingLevel: config.thinkingLevel,

--- a/apps/webui/src/server/services/conversation.service.ts
+++ b/apps/webui/src/server/services/conversation.service.ts
@@ -76,18 +76,19 @@ export function createConversationService(
       const piMessages = storedToPiMessages(history);
 
       const config = configService.getConfig();
+      const compactProvider = configService.findProvider(config.provider);
       const apiKey = configService.getApiKey(config.provider);
-      if (!apiKey) {
+      // Custom providers (e.g. local Ollama) may not require an API key.
+      if (!apiKey && !compactProvider?.custom) {
         throw new Error(`API key not configured for provider: ${config.provider}`);
       }
 
-      const compactProvider = configService.findProvider(config.provider);
       const result = await fullCompact({
         messages: piMessages,
         model: resolveModel(config.provider, config.model,
           compactProvider?.custom ? { baseUrl: compactProvider.custom.url, apiFormat: compactProvider.custom.format } : undefined,
         ),
-        apiKey,
+        apiKey: apiKey ?? "",
       });
 
       // Re-inject activated skill content for continuity


### PR DESCRIPTION
## Summary
- Custom providers (e.g. local Ollama) no longer require an API key to send messages or run compact
- Built-in providers (google/openai/anthropic) still enforce the key check
- `apiKey` is forwarded as an empty string to `setupCreativeAgent` / `fullCompact` when absent

## Test plan
- [ ] Register a custom provider without saving an API key, send a message — verify it streams a response instead of erroring with "API key not configured"
- [ ] Run compact on a conversation using the custom provider — verify it succeeds
- [ ] Confirm built-in providers (e.g. google) still surface the "API key not configured" error when no key is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)