### PR TITLE
feat(client): expose new-project options as a menu

### DIFF
--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -1,5 +1,6 @@
 import { useReducer, useRef, useEffect, useCallback } from "react";
 import { ContextMenu } from "@base-ui/react/context-menu";
+import { Menu } from "@base-ui/react/menu";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { Indicator } from "@/client/shared/ui/index.js";
@@ -300,15 +301,52 @@ export function ProjectTabs() {
           className={`w-full px-3 py-2 rounded-xl text-sm font-mono bg-elevated border text-accent outline-none placeholder:text-fg-4 ${mode.error ? "border-danger/60 animate-shake" : "border-accent/30"}`}
         />
       ) : (
-        <button
-          onClick={() => modeDispatch({ type: "START_CREATE" })}
-          className="w-full px-3 py-2.5 rounded-xl text-sm border border-dashed border-edge/10 hover:border-accent/30 hover:bg-accent/5 text-fg-3 hover:text-accent transition-all duration-200 flex items-center gap-2"
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-          </svg>
-          {t("project.new")}
-        </button>
+        <Menu.Root>
+          <Menu.Trigger
+            render={
+              <button
+                className="w-full px-3 py-2.5 rounded-xl text-sm border border-dashed border-edge/10 hover:border-accent/30 hover:bg-accent/5 text-fg-3 hover:text-accent transition-all duration-200 flex items-center gap-2"
+              />
+            }
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
+            </svg>
+            {t("project.new")}
+          </Menu.Trigger>
+          <Menu.Portal>
+            <Menu.Positioner sideOffset={6} align="start">
+              <Menu.Popup className="bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50 min-w-[220px]">
+                <Menu.Item
+                  onClick={() => modeDispatch({ type: "START_CREATE" })}
+                  className="px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent flex items-center gap-2"
+                >
+                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
+                  </svg>
+                  {t("project.newOptionsEmpty")}
+                </Menu.Item>
+                {projects.length > 0 && (
+                  <>
+                    <div className="my-1 border-t border-edge/8" />
+                    <div className="px-4 py-1 text-[10px] uppercase tracking-wider text-fg-4">
+                      {t("project.newOptionsCopyFrom")}
+                    </div>
+                    {projects.map((p) => (
+                      <Menu.Item
+                        key={p.slug}
+                        onClick={() => modeDispatch({ type: "START_DUPLICATE", sourceSlug: p.slug })}
+                        className="px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent truncate"
+                      >
+                        {p.name}
+                      </Menu.Item>
+                    ))}
+                  </>
+                )}
+              </Menu.Popup>
+            </Menu.Positioner>
+          </Menu.Portal>
+        </Menu.Root>
       )}
     </div>
   );

--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -6,6 +6,19 @@ import { useI18n } from "@/client/i18n/index.js";
 import { Indicator } from "@/client/shared/ui/index.js";
 import { useProject } from "./useProject.js";
 
+// -- Shared menu styles ---
+
+const MENU_POPUP_CLASS =
+  "bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50";
+const MENU_ITEM_CLASS =
+  "px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent";
+
+const plusIcon = (
+  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+    <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
+  </svg>
+);
+
 // -- State Machine ---
 
 type TabsMode =
@@ -252,10 +265,10 @@ export function ProjectTabs() {
             </ContextMenu.Trigger>
             <ContextMenu.Portal>
               <ContextMenu.Positioner sideOffset={4}>
-                <ContextMenu.Popup className="bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50">
+                <ContextMenu.Popup className={MENU_POPUP_CLASS}>
                   <ContextMenu.Item
                     onClick={() => modeDispatch({ type: "START_DUPLICATE", sourceSlug: project.slug })}
-                    className="px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent"
+                    className={MENU_ITEM_CLASS}
                   >
                     {t("project.duplicateSettings")}
                   </ContextMenu.Item>
@@ -309,38 +322,36 @@ export function ProjectTabs() {
               />
             }
           >
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-            </svg>
+            {plusIcon}
             {t("project.new")}
           </Menu.Trigger>
           <Menu.Portal>
             <Menu.Positioner sideOffset={6} align="start">
-              <Menu.Popup className="bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50 min-w-[220px]">
+              <Menu.Popup className={`${MENU_POPUP_CLASS} min-w-[220px]`}>
                 <Menu.Item
                   onClick={() => modeDispatch({ type: "START_CREATE" })}
-                  className="px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent flex items-center gap-2"
+                  className={`${MENU_ITEM_CLASS} flex items-center gap-2`}
                 >
-                  <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-                  </svg>
+                  {plusIcon}
                   {t("project.newOptionsEmpty")}
                 </Menu.Item>
                 {projects.length > 0 && (
                   <>
-                    <div className="my-1 border-t border-edge/8" />
-                    <div className="px-4 py-1 text-[10px] uppercase tracking-wider text-fg-4">
-                      {t("project.newOptionsCopyFrom")}
-                    </div>
-                    {projects.map((p) => (
-                      <Menu.Item
-                        key={p.slug}
-                        onClick={() => modeDispatch({ type: "START_DUPLICATE", sourceSlug: p.slug })}
-                        className="px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10 data-[highlighted]:text-accent truncate"
-                      >
-                        {p.name}
-                      </Menu.Item>
-                    ))}
+                    <div className="my-1 border-t border-edge/8" role="separator" />
+                    <Menu.Group>
+                      <Menu.GroupLabel className="px-4 py-1 text-[10px] uppercase tracking-wider text-fg-4">
+                        {t("project.newOptionsCopyFrom")}
+                      </Menu.GroupLabel>
+                      {projects.map((p) => (
+                        <Menu.Item
+                          key={p.slug}
+                          onClick={() => modeDispatch({ type: "START_DUPLICATE", sourceSlug: p.slug })}
+                          className={`${MENU_ITEM_CLASS} truncate`}
+                        >
+                          {p.name}
+                        </Menu.Item>
+                      ))}
+                    </Menu.Group>
                   </>
                 )}
               </Menu.Popup>

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -65,6 +65,8 @@ export const translations = {
   "project.deleteFailed": "Failed to delete project: {{error}}",
   "project.duplicateSettings": "Copy settings to new project",
   "project.duplicateSettingsNamePlaceholder": "New project name...",
+  "project.newOptionsEmpty": "Start with empty project",
+  "project.newOptionsCopyFrom": "Copy from another project",
 
   // Project settings
   "settings.back": "Back",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -67,6 +67,8 @@ export const translations: Record<TranslationKey, string> = {
   "project.deleteFailed": "프로젝트 삭제 실패: {{error}}",
   "project.duplicateSettings": "새 프로젝트에 설정 복사",
   "project.duplicateSettingsNamePlaceholder": "새 프로젝트 이름...",
+  "project.newOptionsEmpty": "빈 프로젝트로 시작",
+  "project.newOptionsCopyFrom": "다른 프로젝트에서 복제",
 
   // Project settings
   "settings.back": "뒤로",


### PR DESCRIPTION
## Summary

`+ 새 프로젝트` 버튼을 클릭하면 메뉴가 펼쳐져 두 가지 옵션을 한 번에 선택할 수 있도록 한다:

- **빈 프로젝트로 시작** — 기존 동작
- **다른 프로젝트에서 복제** — 기존 프로젝트 리스트에서 선택. 우클릭 컨텍스트 메뉴로만 노출되어 있던 기능을 메인 진입점에서도 발견할 수 있게 함

```
[+ 새 프로젝트] click
  ↓
┌──────────────────────────┐
│ + 빈 프로젝트로 시작        │
├──────────────────────────┤
│ 다른 프로젝트에서 복제       │
│   novel                   │
│   chat                    │
│   rpg                     │
│   ...                     │
└──────────────────────────┘
```

기존 우클릭 컨텍스트 메뉴(`새 프로젝트에 설정 복사`)는 보조 진입점으로 그대로 유지된다.

## Implementation notes

- `tabsReducer`의 `START_CREATE`/`START_DUPLICATE` 액션과 `useProject`의 `createProject`/`duplicateProject`는 그대로 재사용. state machine/훅/API 변경 없이 메뉴 UI만 추가
- `@base-ui/react/menu`의 `Root/Trigger/Portal/Positioner/Popup/Item` 사용. 기존 `ContextMenu`와 동일한 라이브러리·popup 스타일링 클래스 재사용
- i18n 키 두 개 추가: `project.newOptionsEmpty`, `project.newOptionsCopyFrom`

## Test plan

- [x] `bunx tsc --noEmit` 통과
- [x] `+ 새 프로젝트` → 메뉴 펼침 확인 (빈 프로젝트 + 5개 프로젝트 항목)
- [x] `빈 프로젝트로 시작` → input placeholder `프로젝트 이름...` (creating 모드)
- [x] `chat` 복제 → input placeholder `새 프로젝트 이름...` (duplicating 모드) → 이름 입력 → 새 프로젝트 폴더에 `_project.json`/`renderer.ts`/`skills/` 복제, `output/`·`conversations/` 비어 있음 확인
- [x] 새 프로젝트 자동 활성화, 사이드바 스킬 갱신, 출력 영역 empty state 표시
- [x] 우클릭 컨텍스트 메뉴(기존 동작) 그대로 동작
- [ ] 프로젝트가 0개일 때 메뉴에 빈 프로젝트 옵션만 표시되는지 (코드상 처리되어 있으나 미실측)

🤖 Generated with [Claude Code](https://claude.com/claude-code)