### PR TITLE
refactor: migrate inline SVGs to lucide-react

### DIFF
--- a/apps/webui/package.json
+++ b/apps/webui/package.json
@@ -29,6 +29,7 @@
     "@lezer/highlight": "^1.2.3",
     "hono": "^4.7.0",
     "idiomorph": "^0.7.4",
+    "lucide-react": "^1.7.0",
     "nanoid": "^5.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/apps/webui/src/client/app/AppShell.tsx
+++ b/apps/webui/src/client/app/AppShell.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy } from "react";
+import { Menu } from "lucide-react";
 import { useUIState, useUIDispatch } from "./context/UIContext.js";
 import { Sidebar } from "./Sidebar.js";
 import { ProjectPage } from "@/client/pages/ProjectPage.js";
@@ -39,13 +40,7 @@ export function AppShell() {
         onClick={() => uiDispatch({ type: "TOGGLE_SIDEBAR" })}
         className="fixed top-3 left-3 z-50 p-2 rounded-lg bg-elevated border border-edge/6 hover:border-edge/12 lg:hidden transition-all duration-150"
       >
-        <svg width="18" height="18" viewBox="0 0 20 20" fill="currentColor" className="text-fg-2">
-          <path
-            fillRule="evenodd"
-            d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z"
-            clipRule="evenodd"
-          />
-        </svg>
+        <Menu size={18} strokeWidth={2.5} className="text-fg-2" />
       </button>
 
       {/* Sidebar */}

--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { BookOpen, Settings } from "lucide-react";
 import { useUIState, useUIDispatch } from "./context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { IconButton } from "@/client/shared/ui/index.js";
@@ -28,10 +29,7 @@ export function Sidebar() {
             onClick={() => uiDispatch({ type: "NAVIGATE", route: { page: "settings" } })}
             title={t("globalSettings.title")}
           >
-            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="12" cy="12" r="3" />
-              <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-            </svg>
+            <Settings size={15} strokeWidth={1.8} />
           </IconButton>
         </div>
       </div>
@@ -46,10 +44,7 @@ export function Sidebar() {
               : "text-fg-2 hover:text-fg hover:bg-elevated/50"
           }`}
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
-            <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
-          </svg>
+          <BookOpen size={14} strokeWidth={2} />
           {t("sidebar.library")}
         </button>
       </div>

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { CornerUpLeft } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { useSessionState } from "@/client/entities/session/index.js";
 import type { TreeNode } from "@/client/entities/session/index.js";
@@ -122,10 +123,7 @@ export function AgentPanel() {
       {session.replyToNodeId && (
         <div className="px-3 py-2 bg-accent/5 border-b border-accent/10 flex items-center justify-between">
           <span className="text-[11px] text-accent tracking-wide flex items-center gap-1.5">
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M7 17L2 12L7 7" />
-              <path d="M2 12H16C18.2091 12 20 10.2091 20 8V4" />
-            </svg>
+            <CornerUpLeft size={10} strokeWidth={2} />
             {t("chat.branching")}
           </span>
           <button

--- a/apps/webui/src/client/features/chat/Avatars.tsx
+++ b/apps/webui/src/client/features/chat/Avatars.tsx
@@ -1,10 +1,9 @@
+import { Layers, User } from "lucide-react";
+
 export function UserAvatar() {
   return (
     <div className="flex-shrink-0 w-7 h-7 rounded-lg bg-warm/12 flex items-center justify-center">
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-warm">
-        <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
-        <circle cx="12" cy="7" r="4" />
-      </svg>
+      <User size={13} strokeWidth={2} className="text-warm" />
     </div>
   );
 }
@@ -12,11 +11,7 @@ export function UserAvatar() {
 export function AgentAvatar() {
   return (
     <div className="flex-shrink-0 w-7 h-7 rounded-lg bg-accent/12 flex items-center justify-center">
-      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-accent">
-        <path d="M12 2L2 7l10 5 10-5-10-5z" />
-        <path d="M2 17l10 5 10-5" />
-        <path d="M2 12l10 5 10-5" />
-      </svg>
+      <Layers size={13} strokeWidth={2} className="text-accent" />
     </div>
   );
 }

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useEffect } from "react";
+import { ArrowUp, ChevronsLeft } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useConfigState } from "@/client/entities/config/index.js";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
@@ -88,10 +89,7 @@ export function BottomInput() {
               className="m-1.5 p-2 rounded-lg text-fg-3 hover:text-accent hover:bg-accent/8 transition-all"
               title={t("empty.showAgentPanel")}
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                <path d="M11 17l-5-5 5-5" />
-                <path d="M18 17l-5-5 5-5" />
-              </svg>
+              <ChevronsLeft size={16} strokeWidth={2} />
             </button>
           )}
 
@@ -114,19 +112,7 @@ export function BottomInput() {
             disabled={!text.trim() || isStreaming}
             className="m-1.5 p-2.5 rounded-xl bg-accent text-void disabled:opacity-20 disabled:cursor-not-allowed hover:brightness-110 active:scale-95 transition-all duration-150"
           >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.5"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M12 19V5" />
-              <path d="M5 12l7-7 7 7" />
-            </svg>
+            <ArrowUp size={16} strokeWidth={2.5} />
           </button>
         </div>
         </div>

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -1,4 +1,5 @@
 import { useState, type ReactNode } from "react";
+import { AlignLeft, ChevronLeft, ChevronRight } from "lucide-react";
 import type { TreeNode } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { UserAvatar, AgentAvatar } from "./Avatars.js";
@@ -25,9 +26,7 @@ function BranchNavigator({
         disabled={currentIndex === 0}
         className="px-1 hover:text-accent disabled:opacity-20 disabled:cursor-default transition-colors"
       >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-          <path d="M6 2L3 5L6 8" />
-        </svg>
+        <ChevronLeft size={10} strokeWidth={1.5} />
       </button>
       <span className="px-0.5 text-fg-3 tabular-nums select-none">
         {currentIndex + 1}/{siblings.length}
@@ -37,9 +36,7 @@ function BranchNavigator({
         disabled={currentIndex === siblings.length - 1}
         className="px-1 hover:text-accent disabled:opacity-20 disabled:cursor-default transition-colors"
       >
-        <svg width="10" height="10" viewBox="0 0 10 10" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-          <path d="M4 2L7 5L4 8" />
-        </svg>
+        <ChevronRight size={10} strokeWidth={1.5} />
       </button>
     </div>
   );
@@ -60,9 +57,7 @@ function CompactSummaryBubble({
 
   const inner = (
     <div className="flex items-center gap-2 text-xs text-fg-3 py-1.5">
-      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 opacity-50">
-        <path d="M4 6h16M4 12h16M4 18h10" />
-      </svg>
+      <AlignLeft size={14} strokeWidth={2} className="shrink-0 opacity-50" />
       <span className="opacity-70">{t("chat.compactSummary")}</span>
       <button
         onClick={() => setExpanded(!expanded)}

--- a/apps/webui/src/client/features/chat/SessionTabs.tsx
+++ b/apps/webui/src/client/features/chat/SessionTabs.tsx
@@ -1,3 +1,4 @@
+import { ChevronsRight, Plus, X } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useUIDispatch } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -40,17 +41,7 @@ export function SessionTabs() {
                 }}
                 className="opacity-0 group-hover:opacity-100 flex-shrink-0 hover:text-danger transition-all cursor-pointer"
               >
-                <svg
-                  width="8"
-                  height="8"
-                  viewBox="0 0 12 12"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                >
-                  <path d="M3 3l6 6M9 3l-6 6" />
-                </svg>
+                <X size={8} strokeWidth={1.5} />
               </span>
             </button>
           );
@@ -62,9 +53,7 @@ export function SessionTabs() {
           className="flex-shrink-0 p-1.5 rounded-md text-fg-3 hover:text-accent hover:bg-accent/8 transition-all duration-150"
           title={t("session.new")}
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-          </svg>
+          <Plus size={12} strokeWidth={2.5} />
         </button>
       </div>
 
@@ -74,18 +63,7 @@ export function SessionTabs() {
         className="flex-shrink-0 px-2 py-1.5 text-fg-3 hover:text-fg-2 transition-colors"
         title={t("session.closePanel")}
       >
-        <svg
-          width="14"
-          height="14"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-        >
-          <path d="M13 17l5-5-5-5" />
-          <path d="M6 17l5-5-5-5" />
-        </svg>
+        <ChevronsRight size={14} strokeWidth={2} />
       </button>
     </div>
   );

--- a/apps/webui/src/client/features/library/LibraryBrowser.tsx
+++ b/apps/webui/src/client/features/library/LibraryBrowser.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { X } from "lucide-react";
 import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, Badge, Button } from "@/client/shared/ui/index.js";
 import { fetchLibrarySkills, copyLibrarySkillToProject } from "@/client/entities/skill/index.js";
@@ -35,9 +36,7 @@ export function LibraryBrowser({ projectSlug, existingSkills, onCopied, onClose 
       <div className="flex items-center justify-between px-4 py-3 border-b border-edge/6">
         <h3 className="text-sm font-medium text-fg-2">{t("libraryBrowser.title")}</h3>
         <IconButton size="sm" onClick={onClose}>
-          <svg width="14" height="14" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-            <path d="M3 3l6 6M9 3l-6 6" />
-          </svg>
+          <X size={14} strokeWidth={1.5} />
         </IconButton>
       </div>
       <div className="flex-1 overflow-y-auto p-3 space-y-1">

--- a/apps/webui/src/client/features/library/LibraryEditorView.tsx
+++ b/apps/webui/src/client/features/library/LibraryEditorView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, type ReactNode } from "react";
+import { Plus } from "lucide-react";
 import { useI18n, type TranslationKey } from "@/client/i18n/index.js";
 import { Button, TextInput } from "@/client/shared/ui/index.js";
 import { type EditorLanguage } from "@/client/shared/ui/TextEditor.js";
@@ -89,9 +90,7 @@ export function LibraryEditorView<T>({
             }}
             className="w-full px-3 py-2 rounded-xl text-sm border border-dashed border-edge/10 hover:border-accent/30 hover:bg-accent/5 text-fg-3 hover:text-accent transition-all flex items-center gap-2"
           >
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-            </svg>
+            <Plus size={12} strokeWidth={2.5} />
             {t(config.labels.newButton)}
           </button>
         </div>

--- a/apps/webui/src/client/features/library/LibraryView.tsx
+++ b/apps/webui/src/client/features/library/LibraryView.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ArrowLeft } from "lucide-react";
 import { useUIDispatch } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, TabBar } from "@/client/shared/ui/index.js";
@@ -117,9 +118,7 @@ export function LibraryView() {
           onClick={() => uiDispatch({ type: "NAVIGATE", route: { page: "main" } })}
           title={t("settings.back")}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
+          <ArrowLeft size={16} strokeWidth={2} />
         </IconButton>
         <h2 className="font-display text-lg font-bold tracking-tight">{t("library.title")}</h2>
         <TabBar

--- a/apps/webui/src/client/features/project/ProjectSettingsView.tsx
+++ b/apps/webui/src/client/features/project/ProjectSettingsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
+import { ArrowLeft, BookOpen, Code, Plus } from "lucide-react";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
 import type { PageRoute } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -62,9 +63,7 @@ export function ProjectSettingsView() {
           onClick={() => uiDispatch({ type: "NAVIGATE", route: { page: "main" } })}
           title={t("settings.back")}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
+          <ArrowLeft size={16} strokeWidth={2} />
         </IconButton>
         <h2 className="font-display text-lg font-bold tracking-tight">{project.name}</h2>
         <TabBar
@@ -237,10 +236,7 @@ function SkillsTab({ slug }: { slug: string }) {
             onClick={() => setBrowsing(true)}
             className="w-full px-3 py-2 rounded-xl text-sm border border-dashed border-accent/20 hover:border-accent/40 hover:bg-accent/5 text-accent transition-all flex items-center gap-2"
           >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <path d="M4 19.5A2.5 2.5 0 016.5 17H20" />
-              <path d="M6.5 2H20v20H6.5A2.5 2.5 0 014 19.5v-15A2.5 2.5 0 016.5 2z" />
-            </svg>
+            <BookOpen size={12} strokeWidth={2} />
             {t("settings.fromLibrary")}
           </button>
           <button
@@ -251,9 +247,7 @@ function SkillsTab({ slug }: { slug: string }) {
             }}
             className="w-full px-3 py-2 rounded-xl text-sm border border-dashed border-edge/10 hover:border-accent/30 hover:bg-accent/5 text-fg-3 hover:text-accent transition-all flex items-center gap-2"
           >
-            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-              <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-            </svg>
+            <Plus size={12} strokeWidth={2.5} />
             {t("settings.newSkill")}
           </button>
         </div>
@@ -424,10 +418,7 @@ function RendererTab({ slug }: { slug: string }) {
             }`}
           >
             <div className="flex items-center gap-2 font-medium">
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="16 18 22 12 16 6" />
-                <polyline points="8 6 2 12 8 18" />
-              </svg>
+              <Code size={12} strokeWidth={2} />
               {t("settings.rendererTs")}
             </div>
             <div className="text-xs text-fg-3 mt-0.5">
@@ -517,10 +508,7 @@ function RendererTab({ slug }: { slug: string }) {
         ) : (
           /* No renderer yet */
           <div className="flex flex-col items-center justify-center h-full gap-3">
-            <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="text-fg-3">
-              <polyline points="16 18 22 12 16 6" />
-              <polyline points="8 6 2 12 8 18" />
-            </svg>
+            <Code size={32} strokeWidth={1.5} className="text-fg-3" />
             <div className="text-fg-3 text-sm">{t("settings.noRendererYet")}</div>
             <div className="text-fg-3 text-xs">
               {libraryRenderers.length > 0

--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -1,4 +1,5 @@
 import { useReducer, useRef, useEffect, useCallback } from "react";
+import { Check, Plus, Settings, X } from "lucide-react";
 import { ContextMenu } from "@base-ui/react/context-menu";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -182,18 +183,14 @@ export function ProjectTabs() {
                 className="p-0.5 hover:text-fg cursor-pointer transition-colors"
                 title={t("project.confirmDelete")}
               >
-                <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-                  <path d="M3 8l4 4 6-7" />
-                </svg>
+                <Check size={12} strokeWidth={2} />
               </span>
               <span
                 onClick={() => modeDispatch({ type: "RESET" })}
                 className="p-0.5 hover:text-fg-2 cursor-pointer transition-colors"
                 title={t("project.cancelDelete")}
               >
-                <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                  <path d="M3 3l6 6M9 3l-6 6" />
-                </svg>
+                <X size={10} strokeWidth={1.5} />
               </span>
             </div>
           );
@@ -230,10 +227,7 @@ export function ProjectTabs() {
                 } p-0.5 hover:text-accent transition-all cursor-pointer`}
                 title={t("sidebar.projectSettings")}
               >
-                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <circle cx="12" cy="12" r="3" />
-                  <path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" />
-                </svg>
+                <Settings size={10} strokeWidth={2} />
               </span>
               {isActive && projects.length > 1 && (
                 <span
@@ -243,9 +237,7 @@ export function ProjectTabs() {
                   }}
                   className="opacity-0 group-hover:opacity-100 p-0.5 hover:text-danger transition-all cursor-pointer"
                 >
-                  <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round">
-                    <path d="M3 3l6 6M9 3l-6 6" />
-                  </svg>
+                  <X size={10} strokeWidth={1.5} />
                 </span>
               )}
             </ContextMenu.Trigger>
@@ -304,9 +296,7 @@ export function ProjectTabs() {
           onClick={() => modeDispatch({ type: "START_CREATE" })}
           className="w-full px-3 py-2.5 rounded-xl text-sm border border-dashed border-edge/10 hover:border-accent/30 hover:bg-accent/5 text-fg-3 hover:text-accent transition-all duration-200 flex items-center gap-2"
         >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M8 2a.75.75 0 01.75.75v4.5h4.5a.75.75 0 010 1.5h-4.5v4.5a.75.75 0 01-1.5 0v-4.5h-4.5a.75.75 0 010-1.5h4.5v-4.5A.75.75 0 018 2z" />
-          </svg>
+          <Plus size={12} strokeWidth={2.5} />
           {t("project.new")}
         </button>
       )}

--- a/apps/webui/src/client/features/settings/ModelBar.tsx
+++ b/apps/webui/src/client/features/settings/ModelBar.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { useConfigState, useConfigDispatch } from "@/client/entities/config/index.js";
 import type { ThinkingLevel } from "@/client/entities/config/index.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -147,17 +148,11 @@ export function ModelBar() {
                 {!expanded && paramTags.map(({ label, key }) => (
                   <Badge variant="param" key={key}>{label}</Badge>
                 ))}
-                <svg
-                  width="10"
-                  height="10"
-                  viewBox="0 0 10 10"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
+                <ChevronDown
+                  size={10}
+                  strokeWidth={1.5}
                   className={`text-fg-4 group-hover:text-fg-3 transition-transform duration-200 ${expanded ? "rotate-180" : ""}`}
-                >
-                  <path d="M2.5 3.5L5 6L7.5 3.5" />
-                </svg>
+                />
               </div>
             </div>
           </button>

--- a/apps/webui/src/client/features/settings/SettingsView.tsx
+++ b/apps/webui/src/client/features/settings/SettingsView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { ArrowLeft, Globe } from "lucide-react";
 import { useUIState, useUIDispatch } from "@/client/app/context/UIContext.js";
 import type { PageRoute } from "@/client/app/context/UIContext.js";
 import { useConfigState, useConfigDispatch, updateConfig, fetchApiKeys, updateApiKey, deleteApiKey, saveCustomProvider, deleteCustomProvider, fetchProviders, FORMAT_OPTIONS } from "@/client/entities/config/index.js";
@@ -29,9 +30,7 @@ export function SettingsView() {
           onClick={() => uiDispatch({ type: "NAVIGATE", route: { page: "main" } })}
           title={t("settings.back")}
         >
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
-            <path d="M19 12H5M12 19l-7-7 7-7" />
-          </svg>
+          <ArrowLeft size={16} strokeWidth={2} />
         </IconButton>
         <h2 className="font-display text-lg font-bold tracking-tight">{t("globalSettings.title")}</h2>
         <TabBar<SettingsTab>
@@ -67,13 +66,7 @@ function AppearanceTab() {
       value: "system",
       label: t("globalSettings.langSystem"),
       desc: t("globalSettings.langSystemDesc"),
-      icon: (
-        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
-          <circle cx="12" cy="12" r="10" />
-          <path d="M2 12h20" />
-          <path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z" />
-        </svg>
-      ),
+      icon: <Globe size={20} strokeWidth={1.8} />,
     },
     {
       value: "en",

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback, useEffect } from "react";
+import { ChevronsLeft } from "lucide-react";
 import { useProjectState } from "@/client/entities/project/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { RenderedView } from "@/client/features/project/index.js";
@@ -104,14 +105,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
             className="hidden lg:flex flex-shrink-0 w-7 items-center justify-center border-l border-edge/6 bg-base/20 hover:bg-accent/8 text-fg-3 hover:text-accent transition-all duration-200 cursor-pointer group"
             title={t("empty.openAgentPanel")}
           >
-            <svg
-              width="14" height="14" viewBox="0 0 24 24" fill="none"
-              stroke="currentColor" strokeWidth="2" strokeLinecap="round"
-              className="group-hover:scale-110 transition-transform"
-            >
-              <path d="M11 17l-5-5 5-5" />
-              <path d="M18 17l-5-5 5-5" />
-            </svg>
+            <ChevronsLeft size={14} strokeWidth={2} className="group-hover:scale-110 transition-transform" />
           </button>
         )}
       </div>

--- a/apps/webui/src/client/shared/ui/Select.tsx
+++ b/apps/webui/src/client/shared/ui/Select.tsx
@@ -1,4 +1,5 @@
 import { Select as BaseSelect } from "@base-ui/react/select";
+import { ChevronDown } from "lucide-react";
 
 interface SelectProps {
   value: string;
@@ -21,12 +22,7 @@ export function Select({ value, onChange, options, className, size = "sm" }: Sel
         >
           <BaseSelect.Value />
           <BaseSelect.Icon>
-            <svg
-              className="pointer-events-none text-fg-3"
-              width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5"
-            >
-              <path d="M3 4.5L6 7.5L9 4.5" />
-            </svg>
+            <ChevronDown size={12} strokeWidth={1.5} className="pointer-events-none text-fg-3" />
           </BaseSelect.Icon>
         </BaseSelect.Trigger>
         <BaseSelect.Portal>

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
         "@lezer/highlight": "^1.2.3",
         "hono": "^4.7.0",
         "idiomorph": "^0.7.4",
+        "lucide-react": "^1.7.0",
         "nanoid": "^5.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -804,6 +805,8 @@
     "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
 
     "lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
+
+    "lucide-react": ["lucide-react@1.7.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 


### PR DESCRIPTION
## Summary
- Add `lucide-react` as the icon library for `apps/webui`
- Replace 33 inline SVGs across 16 files with tree-shakable named imports (19 unique icons)
- Bump `strokeWidth` on `Plus`/`Menu` replacements to `2.5` to preserve visual weight after filled→stroked conversion

## Test plan
- [x] `bunx tsc --noEmit` in `apps/webui` passes
- [x] `bun run lint` (turbo) passes
- [ ] Visual smoke test: sidebar, project tabs, session tabs, settings, library pages, message bubbles

🤖 Generated with [Claude Code](https://claude.com/claude-code)