### PR TITLE
refactor: drop skill compatibility field

### DIFF
--- a/example_data/library/skills/novel-writing/SKILL.md
+++ b/example_data/library/skills/novel-writing/SKILL.md
@@ -2,7 +2,6 @@
 name: novel-writing
 description: 소설의 기획, 집필, 교정을 체계적으로 지원한다. 소설 쓰기, 줄거리 구성, 캐릭터 개발, 챕터 집필, 원고 교정 등의 작업에서 활성화한다.
 license: MIT
-compatibility: 헬퍼 스크립트는 모두 TypeScript이며 내장 Bun 런타임으로 실행됩니다 (별도 설치 불필요)
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/novel-writing/SKILL.md
+++ b/example_data/projects/novel/skills/novel-writing/SKILL.md
@@ -2,7 +2,6 @@
 name: novel-writing
 description: 소설의 기획, 집필, 교정을 체계적으로 지원한다. 소설 쓰기, 줄거리 구성, 캐릭터 개발, 챕터 집필, 원고 교정 등의 작업에서 활성화한다.
 license: MIT
-compatibility: 헬퍼 스크립트는 모두 TypeScript이며 내장 Bun 런타임으로 실행됩니다 (별도 설치 불필요)
 metadata:
   author: agentchan
   version: "1.0"

--- a/packages/creative-agent/src/skills/discovery.ts
+++ b/packages/creative-agent/src/skills/discovery.ts
@@ -95,7 +95,6 @@ function parseWithFrontmatter(
       name: skillName,
       description,
       ...(raw.license ? { license: raw.license as string } : {}),
-      ...(raw.compatibility ? { compatibility: raw.compatibility as string } : {}),
       ...(raw.metadata ? { metadata: raw.metadata as Record<string, string> } : {}),
     },
     location: resolve(location),

--- a/packages/creative-agent/src/skills/manager.ts
+++ b/packages/creative-agent/src/skills/manager.ts
@@ -70,10 +70,6 @@ Important:
   private buildSkillContent(name: string, skill: SkillRecord): string {
     let content = `<skill_content name="${name}">\n`;
 
-    if (skill.meta.compatibility) {
-      content += `Compatibility: ${skill.meta.compatibility}\n\n`;
-    }
-
     content += skill.body + "\n\n";
     const skillDir = relative(this.projectDir, skill.baseDir);
     content += `Skill directory: ${skillDir}\n`;

--- a/packages/creative-agent/src/skills/types.ts
+++ b/packages/creative-agent/src/skills/types.ts
@@ -2,7 +2,6 @@ export interface SkillMetadata {
   name: string;
   description: string;
   license?: string;
-  compatibility?: string;
   metadata?: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary
- Remove the `compatibility` frontmatter field from `SkillMetadata`, the discovery parser, and the `buildSkillContent` output in `SkillManager`
- Drop the now-empty `compatibility:` line from the `novel-writing` SKILL.md in both `example_data/library/` and `example_data/projects/novel/`

## Why
The field existed to warn the LLM about runtime prerequisites for bash helper scripts shipped in skills. After #22 replaced the bash tool with the script tool (which runs `.ts`/`.js` via the bundled Bun runtime), there are no prerequisites left to communicate — every skill script just works out of the box. The field had no remaining readers other than the SkillManager that printed it back into the prompt, so it's pure dead weight.

Note: the related `allowed-tools` opt-in infrastructure (`RESTRICTED_TOOLS`, `parseAllowedTools`, `collectGrantedRestrictedTools`, `SkillMetadata.allowedTools`) was already removed in #22, so no further code changes were needed there.

## Test plan
- [x] `bunx tsc --noEmit` in `packages/creative-agent` and `apps/webui`
- [x] `bun run lint`
- [x] `diff -r` between the library and project copies of `novel-writing` to confirm they stay in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)