### PR TITLE
feat: add hook system for agent lifecycle events

### DIFF
--- a/apps/webui/src/server/services/agent.service.ts
+++ b/apps/webui/src/server/services/agent.service.ts
@@ -8,8 +8,10 @@ import {
   extractUsage,
   flattenPathToMessages,
   pathToNode,
+  createHookRunner,
   type AgentEvent,
   type AssistantMessage,
+  type HookRunner,
   type Message,
   type ToolCall,
 } from "@agentchan/creative-agent";
@@ -61,6 +63,7 @@ export function createAgentService(
     userText: string,
     historyPath: string[],
     tree: Map<string, any>,
+    hookRunner?: HookRunner,
   ) {
     const config = configService.getConfig();
     const projectDir = join(projectsDir, slug);
@@ -86,6 +89,7 @@ export function createAgentService(
           maxTokens: config.maxTokens, contextWindow: config.contextWindow,
           thinkingLevel: config.thinkingLevel,
           ...(providerInfo?.custom && { baseUrl: providerInfo.custom.url, apiFormat: providerInfo.custom.format }),
+          ...(hookRunner && { hookRunner }),
         },
         flattenPathToMessages(tree, historyPath),
         conversationId,
@@ -211,6 +215,33 @@ export function createAgentService(
       parentNodeId: string | null,
       text: string,
     ) {
+      const projectDir = join(projectsDir, slug);
+      const hookRunner = await createHookRunner({
+        projectDir,
+        sessionId: conversationId,
+      });
+
+      // Run UserPromptSubmit before persisting — a block prevents the message
+      // from entering the conversation tree at all.
+      let finalText = text;
+      if (hookRunner.has("UserPromptSubmit")) {
+        const result = await hookRunner.run("UserPromptSubmit", { prompt: text });
+        if (result.blocked) {
+          await stream.writeSSE({
+            event: "error",
+            data: JSON.stringify({
+              message: result.reason ?? "Prompt blocked by UserPromptSubmit hook",
+              hookBlocked: true,
+            }),
+          });
+          await stream.writeSSE({ event: "done", data: "" });
+          return;
+        }
+        if (result.additionalContext) {
+          finalText = `${result.additionalContext}\n\n${text}`;
+        }
+      }
+
       const userNode: TreeNode = {
         id: nanoid(12), parentId: parentNodeId,
         role: "user", content: [{ type: "text", text }], createdAt: Date.now(),
@@ -227,7 +258,7 @@ export function createAgentService(
       const historyPath = parentNodeId ? pathToNode(tree, parentNodeId) : [];
 
       await stream.writeSSE({ event: "user_node", data: JSON.stringify(userNode) });
-      await streamAgentAndPersist(stream, slug, conversationId, userNode.id, text, historyPath, tree);
+      await streamAgentAndPersist(stream, slug, conversationId, userNode.id, finalText, historyPath, tree, hookRunner);
     },
 
     async regenerate(

--- a/example_data/projects/chat/hooks.json
+++ b/example_data/projects/chat/hooks.json
@@ -1,0 +1,8 @@
+{
+  "PostToolUse": [
+    { "matcher": "*", "file": "hooks/log-tool-use.ts" }
+  ],
+  "UserPromptSubmit": [
+    { "file": "hooks/timestamp.ts" }
+  ]
+}

--- a/example_data/projects/chat/hooks/log-tool-use.ts
+++ b/example_data/projects/chat/hooks/log-tool-use.ts
@@ -1,0 +1,17 @@
+/**
+ * PostToolUse hook: log every tool call to stderr.
+ *
+ * The simplest possible hook — read the JSON event from stdin, write a line
+ * to stderr, exit 0. Stderr is logged but not surfaced to the model.
+ */
+
+const input = JSON.parse(await Bun.stdin.text()) as {
+  hook_event_name: string;
+  tool_name?: string;
+  tool_input?: unknown;
+};
+
+const preview = JSON.stringify(input.tool_input ?? {}).slice(0, 120);
+process.stderr.write(
+  `[hook:${input.hook_event_name}] ${input.tool_name ?? "?"} ${preview}\n`,
+);

--- a/example_data/projects/chat/hooks/timestamp.ts
+++ b/example_data/projects/chat/hooks/timestamp.ts
@@ -1,0 +1,14 @@
+/**
+ * UserPromptSubmit hook: prepend the current time as additional context.
+ *
+ * The user sees their original message in the conversation tree; the model
+ * sees the timestamp + the message.
+ */
+
+const now = new Date().toISOString();
+
+process.stdout.write(
+  JSON.stringify({
+    hookSpecificOutput: { additionalContext: `[Current time: ${now}]` },
+  }),
+);

--- a/packages/creative-agent/src/agent/orchestrator.ts
+++ b/packages/creative-agent/src/agent/orchestrator.ts
@@ -18,6 +18,7 @@ import { storedToPiMessages } from "./convert.js";
 import { microCompact, KEEP_RECENT } from "./compact.js";
 import { analyzeContext } from "./context-analysis.js";
 import { createGoogleCacheHook, clearGoogleCache } from "./google-cache.js";
+import { createHookRunner, type HookRunner } from "../hooks/index.js";
 import { formatTokens } from "@agentchan/estimate-tokens";
 import * as log from "../logger.js";
 import type { StoredMessage } from "../types.js";
@@ -37,6 +38,12 @@ export interface CreativeAgentOptions {
   baseUrl?: string;
   /** Override API format, e.g. "openai-completions" (used by custom providers). */
   apiFormat?: string;
+  /**
+   * Pre-built hook runner. If omitted, setupCreativeAgent loads `hooks.json`
+   * and creates one. Pass an existing runner when the caller already needed
+   * hooks before setup (e.g. UserPromptSubmit) to avoid re-reading the file.
+   */
+  hookRunner?: HookRunner;
 }
 
 export interface CreativeAgentSetup {
@@ -163,8 +170,14 @@ export async function setupCreativeAgent(
     manager.update(skills, options.projectDir);
   }
 
-  // Build tools
-  const tools: any[] = createProjectTools(options.projectDir);
+  const hookRunner =
+    options.hookRunner ??
+    (await createHookRunner({
+      projectDir: options.projectDir,
+      sessionId: conversationId,
+    }));
+
+  const tools: any[] = createProjectTools(options.projectDir, hookRunner);
   if (skills.size > 0) tools.push(manager.createTool());
 
   // Build system prompt

--- a/packages/creative-agent/src/hooks/config.ts
+++ b/packages/creative-agent/src/hooks/config.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import * as log from "../logger.js";
+import type {
+  CompiledHook,
+  CompiledHookConfig,
+  HookConfig,
+  HookConfigEntry,
+  HookEventName,
+} from "./types.js";
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+const VALID_EVENTS: HookEventName[] = [
+  "PreToolUse",
+  "PostToolUse",
+  "UserPromptSubmit",
+];
+
+function compileMatcher(matcher: string | undefined): RegExp | undefined {
+  if (!matcher || matcher === "*") return undefined;
+  // Anchor to full tool name.
+  const pattern = matcher.startsWith("^") ? matcher : `^(?:${matcher})$`;
+  try {
+    return new RegExp(pattern);
+  } catch (err) {
+    log.warn("hooks", `invalid matcher "${matcher}": ${(err as Error).message}`);
+    return undefined;
+  }
+}
+
+function compileEntry(entry: HookConfigEntry): CompiledHook | null {
+  if (!entry || typeof entry.file !== "string" || !entry.file.trim()) {
+    log.warn("hooks", `skipping hook entry: missing "file"`);
+    return null;
+  }
+  return {
+    matcher: compileMatcher(entry.matcher),
+    file: entry.file,
+    timeout:
+      typeof entry.timeout === "number" && entry.timeout > 0
+        ? entry.timeout
+        : DEFAULT_TIMEOUT_MS,
+  };
+}
+
+/**
+ * Load and compile `hooks.json` from a project directory.
+ * Missing file → empty config (not an error).
+ */
+export async function loadHookConfig(projectDir: string): Promise<CompiledHookConfig> {
+  const path = join(projectDir, "hooks.json");
+  let raw: string;
+  try {
+    raw = await readFile(path, "utf-8");
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return {};
+    log.warn("hooks", `failed to read ${path}: ${err?.message ?? err}`);
+    return {};
+  }
+
+  let parsed: HookConfig;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn("hooks", `invalid JSON in ${path}: ${(err as Error).message}`);
+    return {};
+  }
+
+  const compiled: CompiledHookConfig = {};
+  for (const event of VALID_EVENTS) {
+    const entries = parsed[event];
+    if (!Array.isArray(entries)) continue;
+    const list: CompiledHook[] = [];
+    for (const entry of entries) {
+      const c = compileEntry(entry);
+      if (c) list.push(c);
+    }
+    if (list.length > 0) compiled[event] = list;
+  }
+
+  const totalHooks = Object.values(compiled).reduce((n, arr) => n + (arr?.length ?? 0), 0);
+  if (totalHooks > 0) {
+    log.info("hooks", `loaded ${totalHooks} hook(s) from ${path}`);
+  }
+  return compiled;
+}

--- a/packages/creative-agent/src/hooks/index.ts
+++ b/packages/creative-agent/src/hooks/index.ts
@@ -1,0 +1,11 @@
+export { createHookRunner } from "./runner.js";
+export { wrapToolWithHooks } from "./wrap.js";
+export type {
+  HookEventName,
+  HookConfig,
+  HookConfigEntry,
+  HookInput,
+  HookResponse,
+  HookExecResult,
+  HookRunner,
+} from "./types.js";

--- a/packages/creative-agent/src/hooks/runner.ts
+++ b/packages/creative-agent/src/hooks/runner.ts
@@ -1,0 +1,220 @@
+/**
+ * Hook runner. Spawns TS/JS files via the bundled Bun runtime
+ * (`process.execPath` + `BUN_BE_BUN=1`, same trick as the script tool).
+ *
+ * Protocol: hook gets the event payload as JSON on stdin and responds by
+ *   - exit 0 + JSON on stdout → parsed as HookResponse
+ *   - exit 0 + anything else → no-op success
+ *   - exit 2 + reason on stderr → block
+ *   - any other exit → non-blocking error (logged)
+ */
+
+import { resolve } from "node:path";
+import * as log from "../logger.js";
+import { loadHookConfig } from "./config.js";
+import type {
+  CompiledHook,
+  CompiledHookConfig,
+  HookExecResult,
+  HookInput,
+  HookResponse,
+  HookRunner,
+} from "./types.js";
+
+interface RunnerOptions {
+  projectDir: string;
+  sessionId: string;
+}
+
+interface SingleHookOutcome {
+  blocked: boolean;
+  reason?: string;
+  response?: HookResponse;
+}
+
+const REAP_GRACE_MS = 1000;
+
+function matchesHook(hook: CompiledHook, toolName?: string): boolean {
+  if (!hook.matcher || !toolName) return true;
+  return hook.matcher.test(toolName);
+}
+
+async function readStream(stream: ReadableStream | null): Promise<string> {
+  if (!stream) return "";
+  try {
+    return await new Response(stream).text();
+  } catch {
+    return "";
+  }
+}
+
+function parseJsonResponse(stdout: string): HookResponse | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed || !trimmed.startsWith("{")) return undefined;
+  try {
+    return JSON.parse(trimmed) as HookResponse;
+  } catch (err) {
+    log.warn("hooks", `failed to parse hook stdout as JSON: ${(err as Error).message}`);
+    return undefined;
+  }
+}
+
+async function executeHook(
+  hook: CompiledHook,
+  input: HookInput,
+  projectDir: string,
+): Promise<SingleHookOutcome> {
+  const scriptPath = resolve(projectDir, hook.file);
+  const payload = new TextEncoder().encode(JSON.stringify(input));
+
+  let proc: ReturnType<typeof Bun.spawn>;
+  try {
+    proc = Bun.spawn([process.execPath, "run", scriptPath], {
+      cwd: projectDir,
+      stdin: payload,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: {
+        ...process.env,
+        BUN_BE_BUN: "1",
+        AGENTCHAN_PROJECT_DIR: projectDir,
+        AGENTCHAN_SESSION_ID: input.session_id,
+        AGENTCHAN_HOOK_EVENT: input.hook_event_name,
+      },
+    });
+  } catch (err) {
+    log.warn("hooks", `failed to spawn ${hook.file}: ${(err as Error).message}`);
+    return { blocked: false };
+  }
+
+  const stdoutPromise = readStream(proc.stdout as ReadableStream);
+  const stderrPromise = readStream(proc.stderr as ReadableStream);
+  const exitPromise = proc.exited;
+
+  let timerId: ReturnType<typeof setTimeout> | undefined;
+  let timedOut = false;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timerId = setTimeout(() => {
+      timedOut = true;
+      try {
+        proc.kill();
+      } catch {
+        // already exited
+      }
+      reject(new Error(`hook ${hook.file} timed out after ${hook.timeout}ms`));
+    }, hook.timeout);
+  });
+
+  const resultPromise = (async () => {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      stdoutPromise,
+      stderrPromise,
+      exitPromise,
+    ]);
+    return { stdout, stderr, exitCode };
+  })();
+
+  let stdout: string;
+  let stderr: string;
+  let exitCode: number;
+  try {
+    const r = await Promise.race([resultPromise, timeoutPromise]);
+    stdout = r.stdout;
+    stderr = r.stderr;
+    exitCode = r.exitCode;
+  } catch (err) {
+    log.warn("hooks", (err as Error).message);
+    if (timedOut) {
+      // Ensure the killed child is reaped and stream readers don't dangle.
+      await Promise.race([
+        Promise.all([stdoutPromise, stderrPromise, exitPromise]),
+        new Promise((r) => setTimeout(r, REAP_GRACE_MS)),
+      ]).catch(() => {});
+    }
+    return { blocked: false };
+  } finally {
+    if (timerId) clearTimeout(timerId);
+  }
+
+  if (exitCode === 2) {
+    const reason = stderr.trim() || `hook ${hook.file} blocked the action`;
+    log.info("hooks", `${input.hook_event_name} blocked by ${hook.file}: ${reason}`);
+    return { blocked: true, reason };
+  }
+
+  if (exitCode !== 0) {
+    log.warn(
+      "hooks",
+      `${hook.file} exited ${exitCode}${stderr ? `: ${stderr.trim()}` : ""}`,
+    );
+    return { blocked: false };
+  }
+
+  const response = parseJsonResponse(stdout);
+  if (response?.continue === false) {
+    const reason = response.reason ?? `hook ${hook.file} blocked the action`;
+    log.info("hooks", `${input.hook_event_name} blocked by ${hook.file}: ${reason}`);
+    return { blocked: true, reason, response };
+  }
+
+  return { blocked: false, response };
+}
+
+function buildRunner(opts: RunnerOptions, config: CompiledHookConfig): HookRunner {
+  const { projectDir, sessionId } = opts;
+  const totalHooks = Object.values(config).reduce((n, arr) => n + (arr?.length ?? 0), 0);
+
+  return {
+    isEmpty: () => totalHooks === 0,
+    has: (event) => (config[event]?.length ?? 0) > 0,
+
+    async run(event, partial): Promise<HookExecResult> {
+      const hooks = config[event];
+      const result: HookExecResult = { blocked: false };
+      if (!hooks || hooks.length === 0) return result;
+
+      const applicable = hooks.filter((h) => matchesHook(h, partial.tool_name));
+      if (applicable.length === 0) return result;
+
+      const input: HookInput = {
+        hook_event_name: event,
+        session_id: sessionId,
+        project_dir: projectDir,
+        ...partial,
+      };
+
+      // Sequential: first blocking hook wins. Parallel would race block
+      // decisions and make PreToolUse reasoning non-deterministic.
+      const additionalContextParts: string[] = [];
+      for (const hook of applicable) {
+        const outcome = await executeHook(hook, input, projectDir);
+        const resp = outcome.response;
+        if (resp?.hookSpecificOutput?.updatedInput !== undefined) {
+          result.updatedInput = resp.hookSpecificOutput.updatedInput;
+        }
+        if (resp?.hookSpecificOutput?.additionalContext) {
+          additionalContextParts.push(resp.hookSpecificOutput.additionalContext);
+        }
+        if (outcome.blocked && !result.blocked) {
+          result.blocked = true;
+          result.reason = outcome.reason;
+        }
+      }
+
+      if (additionalContextParts.length > 0) {
+        result.additionalContext = additionalContextParts.join("\n\n");
+      }
+
+      return result;
+    },
+  };
+}
+
+/**
+ * Create a HookRunner for a project. Reads `hooks.json` once; missing file
+ * yields an empty runner (every `run` call is a no-op).
+ */
+export async function createHookRunner(opts: RunnerOptions): Promise<HookRunner> {
+  const config = await loadHookConfig(opts.projectDir);
+  return buildRunner(opts, config);
+}

--- a/packages/creative-agent/src/hooks/types.ts
+++ b/packages/creative-agent/src/hooks/types.ts
@@ -1,0 +1,72 @@
+export type HookEventName = "PreToolUse" | "PostToolUse" | "UserPromptSubmit";
+
+/** Single hook entry as defined in `hooks.json`. */
+export interface HookConfigEntry {
+  /** Tool name regex. Omit or `"*"` to match all tools. Only used by tool events. */
+  matcher?: string;
+  /** Path to the script file, relative to the project directory. */
+  file: string;
+  /** Timeout in milliseconds. Defaults to 30_000. */
+  timeout?: number;
+}
+
+/** Top-level shape of `hooks.json`. */
+export type HookConfig = Partial<Record<HookEventName, HookConfigEntry[]>>;
+
+/** Compiled hook ready for execution. Matcher is pre-compiled to a regex. */
+export interface CompiledHook {
+  matcher?: RegExp;
+  file: string;
+  timeout: number;
+}
+
+export type CompiledHookConfig = Partial<Record<HookEventName, CompiledHook[]>>;
+
+/** Input passed to a hook script via stdin (JSON). */
+export interface HookInput {
+  hook_event_name: HookEventName;
+  session_id: string;
+  project_dir: string;
+  tool_name?: string;
+  tool_input?: unknown;
+  tool_output?: unknown;
+  prompt?: string;
+}
+
+/**
+ * JSON response a hook script may write to stdout. All fields are optional —
+ * the hook can also exit with code 2 + stderr to signal a block.
+ */
+export interface HookResponse {
+  /** `false` blocks the action (tool call or prompt). */
+  continue?: boolean;
+  /** Reason shown to the user / model when continue is false. */
+  reason?: string;
+  hookSpecificOutput?: {
+    /** PreToolUse: replace the tool input. */
+    updatedInput?: unknown;
+    /** UserPromptSubmit: text prepended to the user's prompt. */
+    additionalContext?: string;
+  };
+}
+
+/** Result of running all hooks for an event. Aggregated by the runner. */
+export interface HookExecResult {
+  /** True if any hook returned `continue: false` or exited with code 2. */
+  blocked: boolean;
+  /** Aggregated reason from blocking hooks. */
+  reason?: string;
+  /** Tool input replacement from the last PreToolUse hook that set it. */
+  updatedInput?: unknown;
+  /** Concatenated additionalContext from UserPromptSubmit hooks. */
+  additionalContext?: string;
+}
+
+export interface HookRunner {
+  /** Run all hooks registered for `event` against `input`. */
+  run(event: HookEventName, input: Omit<HookInput, "hook_event_name" | "session_id" | "project_dir">): Promise<HookExecResult>;
+  /** Whether any hooks are configured for the given event. */
+  has(event: HookEventName): boolean;
+  /** Whether any hooks are configured at all. Lets callers skip wrapping. */
+  isEmpty(): boolean;
+}

--- a/packages/creative-agent/src/hooks/wrap.ts
+++ b/packages/creative-agent/src/hooks/wrap.ts
@@ -1,0 +1,50 @@
+import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { textResult } from "../tools/util.js";
+import type { HookRunner } from "./types.js";
+
+/**
+ * Wrap an AgentTool so PreToolUse hooks can block or rewrite the call and
+ * PostToolUse hooks observe the result. Forwards all execute() arguments
+ * (toolCallId, params, signal, onUpdate) so abort and streaming still work.
+ */
+export function wrapToolWithHooks<TDetails = any>(
+  tool: AgentTool<any, TDetails>,
+  runner: HookRunner,
+): AgentTool<any, TDetails> {
+  const hasPre = runner.has("PreToolUse");
+  const hasPost = runner.has("PostToolUse");
+  if (!hasPre && !hasPost) return tool;
+
+  return {
+    ...tool,
+    execute: async (toolCallId, params, signal, onUpdate) => {
+      if (hasPre) {
+        const pre = await runner.run("PreToolUse", {
+          tool_name: tool.name,
+          tool_input: params,
+        });
+        if (pre.blocked) {
+          const reason = pre.reason ?? "blocked by PreToolUse hook";
+          return textResult(`[hook denied] ${reason}`) as AgentToolResult<TDetails>;
+        }
+        if (pre.updatedInput !== undefined) {
+          params = pre.updatedInput as typeof params;
+        }
+      }
+
+      const result = await tool.execute(toolCallId, params, signal, onUpdate);
+
+      if (hasPost) {
+        // Awaited (not fire-and-forget) so logs are deterministic, but the
+        // block decision is ignored — the tool already ran.
+        await runner.run("PostToolUse", {
+          tool_name: tool.name,
+          tool_input: params,
+          tool_output: result,
+        });
+      }
+
+      return result;
+    },
+  };
+}

--- a/packages/creative-agent/src/index.ts
+++ b/packages/creative-agent/src/index.ts
@@ -1,3 +1,15 @@
+// Hooks
+export {
+  createHookRunner,
+  type HookEventName,
+  type HookConfig,
+  type HookConfigEntry,
+  type HookInput,
+  type HookResponse,
+  type HookExecResult,
+  type HookRunner,
+} from "./hooks/index.js";
+
 // Tools
 export { createScriptTool } from "./tools/script.js";
 export { createReadTool } from "./tools/read.js";

--- a/packages/creative-agent/src/tools/index.ts
+++ b/packages/creative-agent/src/tools/index.ts
@@ -6,13 +6,18 @@ import { createAppendTool } from "./append.js";
 import { createEditTool } from "./edit.js";
 import { createGrepTool } from "./grep.js";
 import { createLsTool } from "./ls.js";
+import { wrapToolWithHooks, type HookRunner } from "../hooks/index.js";
 
 /**
- * Create the standard set of project-scoped tools.
- * All file operations are restricted to the given project directory.
+ * Create the standard set of project-scoped tools. All file operations are
+ * restricted to the given project directory. If a non-empty HookRunner is
+ * provided, each tool is wrapped so PreToolUse/PostToolUse hooks fire.
  */
-export function createProjectTools(projectDir: string): AgentTool<any, any>[] {
-  return [
+export function createProjectTools(
+  projectDir: string,
+  hookRunner?: HookRunner,
+): AgentTool<any, any>[] {
+  const tools: AgentTool<any, any>[] = [
     createScriptTool(projectDir),
     createReadTool(projectDir),
     createWriteTool(projectDir),
@@ -21,4 +26,6 @@ export function createProjectTools(projectDir: string): AgentTool<any, any>[] {
     createGrepTool(projectDir),
     createLsTool(projectDir),
   ];
+  if (!hookRunner || hookRunner.isEmpty()) return tools;
+  return tools.map((t) => wrapToolWithHooks(t, hookRunner));
 }


### PR DESCRIPTION
## Summary
- Adds a Claude-Code-style hook system for `PreToolUse`, `PostToolUse`, and `UserPromptSubmit` events
- Hooks are TS/JS files (no bash) executed via the bundled Bun runtime — same `process.execPath` + `BUN_BE_BUN=1` trick as the script tool, so dev and compiled-exe both work with zero extra deps
- Per-project `hooks.json` maps events → scripts; the runner reads a JSON payload from stdin and parses a JSON response (or exit code 2 for blocks)

## Design notes
- **Tool-level hooks** (`PreToolUse`/`PostToolUse`) live in `@agentchan/creative-agent` as a `wrapToolWithHooks` wrapper around each `AgentTool`. Pre can block or rewrite input; Post observes the result. When the runner is empty, wrapping is skipped entirely so the default zero-hook path has no overhead
- **`UserPromptSubmit`** lives in the webui server and runs *before* persisting the user node — a blocking hook prevents the message from entering the conversation tree at all (matches Claude Code semantics)
- `createHookRunner` is async and reads `hooks.json` itself, so callers don't see the internal `loadHookConfig`/`CompiledHook*` types
- Matchers are pre-compiled regexes (`*` or omitted → match all). Sequential execution per event so PreToolUse block decisions stay deterministic
- Timeout path reaps the killed child + drains stream readers within a 1s grace window to avoid leaks

## Example
`example_data/projects/chat/hooks.json` registers two demo hooks:
- `hooks/log-tool-use.ts` — PostToolUse stderr logging
- `hooks/timestamp.ts` — UserPromptSubmit prepends current time as additional context

## Test plan
- [x] `bunx tsc --noEmit` clean in `apps/webui` and `packages/creative-agent`
- [x] `bun run lint` clean across the workspace
- [ ] Manual: send a message in the chat project and confirm `[hook:PostToolUse]` lines appear in server stderr after tool calls
- [ ] Manual: confirm `additionalContext` from `timestamp.ts` reaches the model (e.g. ask "what time is it?") while the tree still stores the original user message

## Intentionally deferred to v2
- prompt/agent/http hook types (script-only for now)
- `if` permission-rule conditions (matcher regex only)
- Async/rewake hooks, plugin policies, managed-hook filtering
- Hook management UI (edit `hooks.json` directly)
- `SessionStart`/`Stop` events
- PostToolUse parallelization, stdout/stderr size caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)