### PR TITLE
fix: keep chat input enabled during streaming

### DIFF
--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -104,8 +104,7 @@ export function BottomInput() {
                 : t("input.placeholder")
             }
             rows={1}
-            disabled={isStreaming}
-            className="flex-1 bg-transparent px-5 py-3.5 text-sm resize-none focus:outline-none text-fg placeholder-fg-4 disabled:opacity-40 max-h-[200px] font-body"
+            className="flex-1 bg-transparent px-5 py-3.5 text-sm resize-none focus:outline-none text-fg placeholder-fg-4 max-h-[200px] font-body"
           />
           <button
             onClick={handleSubmit}


### PR DESCRIPTION
## Summary
- Remove `disabled={isStreaming}` from the chat textarea so users can pre-type the next message while awaiting a response
- Send button still disables during streaming (`disabled={!text.trim() || isStreaming}`) — double-send protection unchanged
- Fixes focus loss: browsers strip focus from disabled elements, which previously forced a manual click after every response

## Test plan
- [ ] Send a message and start typing during streaming — textarea accepts input
- [ ] Send button shows disabled styling while streaming
- [ ] Enter during streaming is a no-op (guarded in `handleSubmit` and `useStreaming.send`)
- [ ] After streaming ends, focus is preserved and Enter sends the pre-typed message

🤖 Generated with [Claude Code](https://claude.com/claude-code)