### PR TITLE
refactor: remove license field from skill frontmatter

### DIFF
--- a/example_data/library/skills/chapter-writing/SKILL.md
+++ b/example_data/library/skills/chapter-writing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: chapter-writing
 description: 아웃라인에 따라 소설 챕터를 집필한다. 문체 가이드와 챕터 템플릿을 사용한다. 챕터 작성, 소설 집필에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/library/skills/characters/SKILL.md
+++ b/example_data/library/skills/characters/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: characters
 description: 아키타입과 동기 프레임워크를 사용하여 소설의 주요 캐릭터를 설계한다. 캐릭터 개발, 인물 설계, 캐릭터 시트 작성에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/library/skills/outline/SKILL.md
+++ b/example_data/library/skills/outline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: outline
 description: 소설의 전제를 확인하고 3막 비트 시트 기반의 플롯 아웃라인을 작성한다. 장르, 로그라인, 주제 정의 및 아웃라인 구성에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/library/skills/revision/SKILL.md
+++ b/example_data/library/skills/revision/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: revision
 description: 완성된 원고의 일관성을 점검하고, 문체를 교정하며, 최종 원고를 편집한다. 퇴고, 교정, 원고 편집에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/library/skills/world-building/SKILL.md
+++ b/example_data/library/skills/world-building/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: world-building
 description: 소설의 세계관을 구축한다. 시대, 지리, 사회 구조, 규칙, 감각 팔레트를 정의한다. 세계관 설정, 배경 구축에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/chapter-writing/SKILL.md
+++ b/example_data/projects/novel/skills/chapter-writing/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: chapter-writing
 description: 아웃라인에 따라 소설 챕터를 집필한다. 문체 가이드와 챕터 템플릿을 사용한다. 챕터 작성, 소설 집필에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/characters/SKILL.md
+++ b/example_data/projects/novel/skills/characters/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: characters
 description: 아키타입과 동기 프레임워크를 사용하여 소설의 주요 캐릭터를 설계한다. 캐릭터 개발, 인물 설계, 캐릭터 시트 작성에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/outline/SKILL.md
+++ b/example_data/projects/novel/skills/outline/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: outline
 description: 소설의 전제를 확인하고 3막 비트 시트 기반의 플롯 아웃라인을 작성한다. 장르, 로그라인, 주제 정의 및 아웃라인 구성에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/revision/SKILL.md
+++ b/example_data/projects/novel/skills/revision/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: revision
 description: 완성된 원고의 일관성을 점검하고, 문체를 교정하며, 최종 원고를 편집한다. 퇴고, 교정, 원고 편집에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/example_data/projects/novel/skills/world-building/SKILL.md
+++ b/example_data/projects/novel/skills/world-building/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: world-building
 description: 소설의 세계관을 구축한다. 시대, 지리, 사회 구조, 규칙, 감각 팔레트를 정의한다. 세계관 설정, 배경 구축에서 활성화한다.
-license: MIT
 metadata:
   author: agentchan
   version: "1.0"

--- a/packages/creative-agent/src/skills/discovery.ts
+++ b/packages/creative-agent/src/skills/discovery.ts
@@ -96,7 +96,6 @@ function buildSkillRecord(
     meta: {
       name: skillName,
       description,
-      ...(raw.license ? { license: raw.license as string } : {}),
       ...(raw.metadata ? { metadata: raw.metadata as Record<string, string> } : {}),
       ...(isTruthy(disableInvokeRaw) ? { disableModelInvocation: true } : {}),
     },

--- a/packages/creative-agent/src/skills/types.ts
+++ b/packages/creative-agent/src/skills/types.ts
@@ -1,7 +1,6 @@
 export interface SkillMetadata {
   name: string;
   description: string;
-  license?: string;
   metadata?: Record<string, string>;
   /** Hide from the model-facing catalog so the model never self-activates. */
   disableModelInvocation?: boolean;


### PR DESCRIPTION
## Summary
- Drop `license?: string` from `SkillMetadata` and stop parsing it in `discovery.ts`
- Remove `license: MIT` from 10 example SKILL.md files (library + novel project)

The field had no consumer — it was declared on the type and conditionally copied by the parser, but no reader ever used it. It also isn't part of agentchan's skill spec.

## Test plan
- [x] `bunx tsc --noEmit` in `packages/creative-agent` passes
- [x] `bunx tsc --noEmit` in `apps/webui` passes
- [x] No remaining `license` references in `example_data/` or `packages/creative-agent/src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)