### PR TITLE
fix: slash command popup hidden behind project content

### DIFF
--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -70,7 +70,7 @@ export function BottomInput() {
   };
 
   return (
-    <div className="border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4">
+    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4">
       <div className="max-w-4xl mx-auto">
         <div className="relative">
           {slash.isOpen && (

--- a/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
+++ b/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
@@ -24,7 +24,7 @@ export function SlashCommandPopup({ commands, selectedIndex, onSelect, onHover }
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated border border-white/8 rounded-xl shadow-lg shadow-void/50 overflow-y-auto max-h-[240px] animate-fade z-50"
+      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated/95 backdrop-blur-md border border-edge/12 rounded-xl shadow-xl shadow-void/60 overflow-y-auto max-h-[240px] animate-fade z-50"
     >
       {commands.map((cmd, i) => (
         <button


### PR DESCRIPTION
## Summary
- `BottomInput`에 `relative z-20`을 추가해 stacking context를 `ProjectPage`(`z-10`) 위로 올림 — 그동안 `SlashCommandPopup`이 내부 `z-50`을 가져도 부모 stacking이 더 낮아 `RenderedView`에 가려지고 있었음
- `SlashCommandPopup` 자체의 배경/blur/border 강화 (`bg-elevated/95 backdrop-blur-md`, `border-edge/12`, `shadow-xl shadow-void/60`)로 큰 면적의 popup이 뒤 콘텐츠와 명확히 대비되도록 함

## Root cause
`backdrop-filter`는 stacking context를 만들지만 z-index를 자동으로 올려주지 않음. `BottomInput`은 `backdrop-blur-sm`만 있고 `z-auto`였고, 형제인 `ProjectPage` 컨테이너는 명시적 `relative z-10`이라 `BottomInput`이 그 아래에 깔림. 그 안의 `z-50` popup은 부모 stacking에 갇혀 `bottom-full`로 위로 튀어나가는 영역에서 `RenderedView`에 가려짐. backdrop-blur 추가가 효과 없던 것도 popup이 뒤 콘텐츠 *아래*에 있어서 blur할 대상이 없었기 때문.

## Test plan
- [ ] 채팅 메시지가 쌓인 상태에서 입력창에 `/` 타이핑 → popup이 `RenderedView`/`AgentPanel` 위에 표시되며 뒤 콘텐츠가 backdrop-blur로 부드럽게 처리되는지
- [ ] slash item hover/keyboard 선택이 정상 동작하는지
- [ ] light 테마 토글 후에도 popup이 깨지지 않는지 (`border-edge/12` 자동 반전)
- [ ] 다른 popup(Model 선택, ContextMenu)에 회귀 없는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)