### PR TITLE
feat: 에이전트 패널 인라인 마크다운 + 문장 애니메이션

### DIFF
--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -10,7 +10,6 @@ import { useConversation } from "./useConversation.js";
 import { useStreaming } from "./useStreaming.js";
 import { SessionTabs } from "./SessionTabs.js";
 import { MessageBubble } from "./MessageBubble.js";
-import { StreamingMessage } from "./StreamingMessage.js";
 
 // ── Model Info Popover ───────────────────────
 
@@ -88,27 +87,7 @@ export function AgentPanel() {
   const { regenerate } = useStreaming();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Tail-key matching: the streaming wrapper div and the completed MessageBubble
-  // share the same React key, so React reuses the DOM element and the entry
-  // animation (on the wrapper) doesn't re-trigger when streaming ends.
-  // Refs are mutated during render (not useEffect) to avoid a one-frame key
-  // mismatch that would re-mount the wrapper and replay the animation.
-  // StrictMode double-render is safe: the edge-detection consumes the transition
-  // on the first invocation, so the second sees no change.
-  const prevStreamingRef = useRef(false);
-  const tailCountRef = useRef(0);
-  const tailKeysRef = useRef(new Map<string, string>());
-
-  if (!prevStreamingRef.current && session.isStreaming) {
-    tailCountRef.current++;
-  }
-  if (prevStreamingRef.current && !session.isStreaming) {
-    const lastId = session.activePath.at(-1);
-    if (lastId) tailKeysRef.current.set(lastId, `tail-${tailCountRef.current}`);
-  }
-  prevStreamingRef.current = session.isStreaming;
-
-  useEffect(() => {
+useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [session.activePath, session.streamingText, session.streamingToolCalls]);
 
@@ -168,30 +147,31 @@ export function AgentPanel() {
           regenerate={regenerate}
           isStreaming={session.isStreaming}
         >
-          {session.activePath.map((nodeId) => {
+          {session.activePath.map((nodeId, i) => {
             const node = session.nodes.get(nodeId);
             if (!node) return null;
             return (
-              <div key={tailKeysRef.current.get(nodeId) ?? nodeId} className="animate-fade-slide">
-                <MessageBubble
-                  node={node}
-                  siblings={getSiblings(node)}
-                  actions={actions}
-                  isStreaming={session.isStreaming}
-                  variant="compact"
-                  footer={
-                    node.message.role === "assistant" && node.message.model
-                      ? <ModelInfoPopover node={node} />
-                      : undefined
-                  }
-                />
-              </div>
+              <MessageBubble
+                key={i}
+                node={node}
+                siblings={getSiblings(node)}
+                actions={actions}
+                isStreaming={session.isStreaming}
+                variant="compact"
+                footer={
+                  node.message.role === "assistant" && node.message.model
+                    ? <ModelInfoPopover node={node} />
+                    : undefined
+                }
+              />
             );
           })}
           {(session.isStreaming || session.streamingText || session.streamingToolCalls.length > 0) && (
-            <div key={`tail-${tailCountRef.current}`} className="animate-fade-slide">
-              <StreamingMessage variant="compact" />
-            </div>
+            <MessageBubble
+              key={session.activePath.length}
+              streaming
+              variant="compact"
+            />
           )}
         </MessageActionsProvider>
 

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -87,7 +87,7 @@ export function AgentPanel() {
   const { regenerate } = useStreaming();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-useEffect(() => {
+  useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [session.activePath, session.streamingText, session.streamingToolCalls]);
 

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -10,6 +10,7 @@ import { useConversation } from "./useConversation.js";
 import { useStreaming } from "./useStreaming.js";
 import { SessionTabs } from "./SessionTabs.js";
 import { MessageBubble } from "./MessageBubble.js";
+import { StreamingMessage } from "./StreamingMessage.js";
 
 // ── Model Info Popover ───────────────────────
 
@@ -147,12 +148,12 @@ export function AgentPanel() {
           regenerate={regenerate}
           isStreaming={session.isStreaming}
         >
-          {session.activePath.map((nodeId, i) => {
+          {session.activePath.map((nodeId) => {
             const node = session.nodes.get(nodeId);
             if (!node) return null;
             return (
               <MessageBubble
-                key={i}
+                key={nodeId}
                 node={node}
                 siblings={getSiblings(node)}
                 actions={actions}
@@ -166,14 +167,9 @@ export function AgentPanel() {
               />
             );
           })}
-          {(session.isStreaming || session.streamingText || session.streamingToolCalls.length > 0) && (
-            <MessageBubble
-              key={session.activePath.length}
-              streaming
-              variant="compact"
-            />
-          )}
         </MessageActionsProvider>
+
+        <StreamingMessage variant="compact" />
 
         {session.activePath.length === 0 && !session.isStreaming && (
           <div className="flex items-center justify-center h-full">

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -88,6 +88,28 @@ export function AgentPanel() {
   const { regenerate } = useStreaming();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  // Refs mutated during render (not in an effect) so the animation skip is
+  // ready in the same render cycle that first mounts the new MessageBubble.
+  const prevIsStreamingRef = useRef(false);
+  const prevPathRef = useRef(new Set<string>());
+  const streamedNodesRef = useRef(new Set<string>());
+  const prevConvoRef = useRef(session.activeConversationId);
+
+  if (prevConvoRef.current !== session.activeConversationId) {
+    streamedNodesRef.current = new Set();
+    prevConvoRef.current = session.activeConversationId;
+  }
+
+  if (prevIsStreamingRef.current && !session.isStreaming) {
+    for (const id of session.activePath) {
+      if (!prevPathRef.current.has(id)) {
+        streamedNodesRef.current.add(id);
+      }
+    }
+  }
+  prevIsStreamingRef.current = session.isStreaming;
+  prevPathRef.current = new Set(session.activePath);
+
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [session.activePath, session.streamingText, session.streamingToolCalls]);
@@ -159,6 +181,7 @@ export function AgentPanel() {
                 actions={actions}
                 isStreaming={session.isStreaming}
                 variant="compact"
+                skipEntryAnimation={streamedNodesRef.current.has(nodeId)}
                 footer={
                   node.message.role === "assistant" && node.message.model
                     ? <ModelInfoPopover node={node} />

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -91,6 +91,10 @@ export function AgentPanel() {
   // Tail-key matching: the streaming wrapper div and the completed MessageBubble
   // share the same React key, so React reuses the DOM element and the entry
   // animation (on the wrapper) doesn't re-trigger when streaming ends.
+  // Refs are mutated during render (not useEffect) to avoid a one-frame key
+  // mismatch that would re-mount the wrapper and replay the animation.
+  // StrictMode double-render is safe: the edge-detection consumes the transition
+  // on the first invocation, so the second sees no change.
   const prevStreamingRef = useRef(false);
   const tailCountRef = useRef(0);
   const tailKeysRef = useRef(new Map<string, string>());

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -88,27 +88,21 @@ export function AgentPanel() {
   const { regenerate } = useStreaming();
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Refs mutated during render (not in an effect) so the animation skip is
-  // ready in the same render cycle that first mounts the new MessageBubble.
-  const prevIsStreamingRef = useRef(false);
-  const prevPathRef = useRef(new Set<string>());
-  const streamedNodesRef = useRef(new Set<string>());
-  const prevConvoRef = useRef(session.activeConversationId);
+  // Tail-key matching: the streaming wrapper div and the completed MessageBubble
+  // share the same React key, so React reuses the DOM element and the entry
+  // animation (on the wrapper) doesn't re-trigger when streaming ends.
+  const prevStreamingRef = useRef(false);
+  const tailCountRef = useRef(0);
+  const tailKeysRef = useRef(new Map<string, string>());
 
-  if (prevConvoRef.current !== session.activeConversationId) {
-    streamedNodesRef.current = new Set();
-    prevConvoRef.current = session.activeConversationId;
+  if (!prevStreamingRef.current && session.isStreaming) {
+    tailCountRef.current++;
   }
-
-  if (prevIsStreamingRef.current && !session.isStreaming) {
-    for (const id of session.activePath) {
-      if (!prevPathRef.current.has(id)) {
-        streamedNodesRef.current.add(id);
-      }
-    }
+  if (prevStreamingRef.current && !session.isStreaming) {
+    const lastId = session.activePath.at(-1);
+    if (lastId) tailKeysRef.current.set(lastId, `tail-${tailCountRef.current}`);
   }
-  prevIsStreamingRef.current = session.isStreaming;
-  prevPathRef.current = new Set(session.activePath);
+  prevStreamingRef.current = session.isStreaming;
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -174,25 +168,28 @@ export function AgentPanel() {
             const node = session.nodes.get(nodeId);
             if (!node) return null;
             return (
-              <MessageBubble
-                key={nodeId}
-                node={node}
-                siblings={getSiblings(node)}
-                actions={actions}
-                isStreaming={session.isStreaming}
-                variant="compact"
-                skipEntryAnimation={streamedNodesRef.current.has(nodeId)}
-                footer={
-                  node.message.role === "assistant" && node.message.model
-                    ? <ModelInfoPopover node={node} />
-                    : undefined
-                }
-              />
+              <div key={tailKeysRef.current.get(nodeId) ?? nodeId} className="animate-fade-slide">
+                <MessageBubble
+                  node={node}
+                  siblings={getSiblings(node)}
+                  actions={actions}
+                  isStreaming={session.isStreaming}
+                  variant="compact"
+                  footer={
+                    node.message.role === "assistant" && node.message.model
+                      ? <ModelInfoPopover node={node} />
+                      : undefined
+                  }
+                />
+              </div>
             );
           })}
+          {(session.isStreaming || session.streamingText || session.streamingToolCalls.length > 0) && (
+            <div key={`tail-${tailCountRef.current}`} className="animate-fade-slide">
+              <StreamingMessage variant="compact" />
+            </div>
+          )}
         </MessageActionsProvider>
-
-        <StreamingMessage variant="compact" />
 
         {session.activePath.length === 0 && !session.isStreaming && (
           <div className="flex items-center justify-center h-full">

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -228,6 +228,8 @@ export interface MessageBubbleProps {
   isStreaming?: boolean;
   variant?: "compact" | "wide";
   footer?: ReactNode;
+  /** Skip the entry animation (e.g. for nodes that were already visible during streaming). */
+  skipEntryAnimation?: boolean;
 }
 
 export function MessageBubble({
@@ -237,6 +239,7 @@ export function MessageBubble({
   isStreaming,
   variant = "compact",
   footer,
+  skipEntryAnimation,
 }: MessageBubbleProps) {
   const { t } = useI18n();
   const isWide = variant === "wide";
@@ -327,7 +330,7 @@ export function MessageBubble({
     <BubbleWrap
       variant={variant}
       padding="loose"
-      className={`group animate-fade-slide ${isUser ? "" : "bg-surface/40"}`}
+      className={`group ${skipEntryAnimation ? "" : "animate-fade-slide"} ${isUser ? "" : "bg-surface/40"}`}
     >
       {content}
     </BubbleWrap>

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -228,8 +228,6 @@ export interface MessageBubbleProps {
   isStreaming?: boolean;
   variant?: "compact" | "wide";
   footer?: ReactNode;
-  /** Skip the entry animation (e.g. for nodes that were already visible during streaming). */
-  skipEntryAnimation?: boolean;
 }
 
 export function MessageBubble({
@@ -239,7 +237,6 @@ export function MessageBubble({
   isStreaming,
   variant = "compact",
   footer,
-  skipEntryAnimation,
 }: MessageBubbleProps) {
   const { t } = useI18n();
   const isWide = variant === "wide";
@@ -330,7 +327,7 @@ export function MessageBubble({
     <BubbleWrap
       variant={variant}
       padding="loose"
-      className={`group ${skipEntryAnimation ? "" : "animate-fade-slide"} ${isUser ? "" : "bg-surface/40"}`}
+      className={`group ${isUser ? "" : "bg-surface/40"}`}
     >
       {content}
     </BubbleWrap>

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -4,6 +4,7 @@ import type { TreeNode, TextContent, ImageContent, AssistantContentBlock } from 
 import { useI18n } from "@/client/i18n/index.js";
 import { UserAvatar, AgentAvatar } from "./Avatars.js";
 import { MessageContent } from "./MessageContent.js";
+import { StreamingBubbleContent } from "./StreamingMessage.js";
 
 // ── Helpers ─────────────────────────────────────
 
@@ -222,8 +223,9 @@ export interface MessageBubbleActions {
 }
 
 export interface MessageBubbleProps {
-  node: TreeNode;
-  siblings: string[];
+  node?: TreeNode;
+  streaming?: boolean;
+  siblings?: string[];
   actions?: MessageBubbleActions;
   isStreaming?: boolean;
   variant?: "compact" | "wide";
@@ -232,6 +234,7 @@ export interface MessageBubbleProps {
 
 export function MessageBubble({
   node,
+  streaming,
   siblings,
   actions,
   isStreaming,
@@ -240,9 +243,24 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const { t } = useI18n();
   const isWide = variant === "wide";
+
+  // Streaming mode — same BubbleWrap root so React reuses the DOM element
+  // when transitioning from streaming to completed (index-key matching).
+  if (streaming) {
+    return (
+      <BubbleWrap
+        variant={variant}
+        padding="loose"
+        className="group animate-fade-slide bg-surface/40"
+      >
+        <StreamingBubbleContent variant={variant} />
+      </BubbleWrap>
+    );
+  }
+
+  if (!node) return null;
   const role = node.message.role;
 
-  // toolResult nodes are not rendered in the UI
   if (role === "toolResult") return null;
 
   if (role === "user" && node.meta === "skill-load") {
@@ -275,7 +293,7 @@ export function MessageBubble({
             {isUser ? t("chat.you") : t("chat.agent")}
           </span>
           {footer}
-          {actions?.onSwitchBranch && (
+          {actions?.onSwitchBranch && siblings && (
             <BranchNavigator
               nodeId={node.id}
               siblings={siblings}
@@ -327,7 +345,7 @@ export function MessageBubble({
     <BubbleWrap
       variant={variant}
       padding="loose"
-      className={`group ${isUser ? "" : "bg-surface/40"}`}
+      className={`group animate-fade-slide ${isUser ? "" : "bg-surface/40"}`}
     >
       {content}
     </BubbleWrap>

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -4,7 +4,6 @@ import type { TreeNode, TextContent, ImageContent, AssistantContentBlock } from 
 import { useI18n } from "@/client/i18n/index.js";
 import { UserAvatar, AgentAvatar } from "./Avatars.js";
 import { MessageContent } from "./MessageContent.js";
-import { StreamingBubbleContent } from "./StreamingMessage.js";
 
 // ── Helpers ─────────────────────────────────────
 
@@ -32,7 +31,7 @@ function getUserContentBlocks(node: TreeNode): (TextContent | ImageContent)[] {
 // max-w-3xl content column; padding is "tight" (py-1) for chips/summaries
 // or "loose" (py-3/py-4) for full message rows.
 
-function BubbleWrap({
+export function BubbleWrap({
   variant,
   padding = "tight",
   className = "",
@@ -223,9 +222,8 @@ export interface MessageBubbleActions {
 }
 
 export interface MessageBubbleProps {
-  node?: TreeNode;
-  streaming?: boolean;
-  siblings?: string[];
+  node: TreeNode;
+  siblings: string[];
   actions?: MessageBubbleActions;
   isStreaming?: boolean;
   variant?: "compact" | "wide";
@@ -234,7 +232,6 @@ export interface MessageBubbleProps {
 
 export function MessageBubble({
   node,
-  streaming,
   siblings,
   actions,
   isStreaming,
@@ -243,22 +240,6 @@ export function MessageBubble({
 }: MessageBubbleProps) {
   const { t } = useI18n();
   const isWide = variant === "wide";
-
-  // Streaming mode — same BubbleWrap root so React reuses the DOM element
-  // when transitioning from streaming to completed (index-key matching).
-  if (streaming) {
-    return (
-      <BubbleWrap
-        variant={variant}
-        padding="loose"
-        className="group animate-fade-slide bg-surface/40"
-      >
-        <StreamingBubbleContent variant={variant} />
-      </BubbleWrap>
-    );
-  }
-
-  if (!node) return null;
   const role = node.message.role;
 
   if (role === "toolResult") return null;
@@ -293,7 +274,7 @@ export function MessageBubble({
             {isUser ? t("chat.you") : t("chat.agent")}
           </span>
           {footer}
-          {actions?.onSwitchBranch && siblings && (
+          {actions?.onSwitchBranch && (
             <BranchNavigator
               nodeId={node.id}
               siblings={siblings}
@@ -345,7 +326,7 @@ export function MessageBubble({
     <BubbleWrap
       variant={variant}
       padding="loose"
-      className={`group animate-fade-slide ${isUser ? "" : "bg-surface/40"}`}
+      className={`group ${isUser ? "animate-fade-slide" : "bg-surface/40"}`}
     >
       {content}
     </BubbleWrap>

--- a/apps/webui/src/client/features/chat/MessageContent.tsx
+++ b/apps/webui/src/client/features/chat/MessageContent.tsx
@@ -1,4 +1,5 @@
 import type { AssistantContentBlock } from "@/client/entities/session/index.js";
+import { parseInlineMarkdown } from "@/client/shared/inlineMarkdown.js";
 import { ToolCallDisplay } from "./ToolCallDisplay.js";
 
 export function MessageContent({ content }: { content: AssistantContentBlock[] }) {
@@ -9,7 +10,7 @@ export function MessageContent({ content }: { content: AssistantContentBlock[] }
           case "text":
             return (
               <div key={i} className="whitespace-pre-wrap break-words leading-relaxed">
-                {block.text}
+                {parseInlineMarkdown(block.text)}
               </div>
             );
           case "toolCall":

--- a/apps/webui/src/client/features/chat/StreamingMessage.tsx
+++ b/apps/webui/src/client/features/chat/StreamingMessage.tsx
@@ -1,6 +1,7 @@
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { parseInlineMarkdown } from "@/client/shared/inlineMarkdown.js";
+import { BubbleWrap } from "./MessageBubble.js";
 import { AgentAvatar } from "./Avatars.js";
 import { StreamingToolCall } from "./ToolCallDisplay.js";
 import { useSentenceAnimation } from "./useSentenceAnimation.js";
@@ -13,11 +14,7 @@ function Sentence({ text, animating }: { text: string; animating: boolean }) {
   );
 }
 
-/**
- * Renders streaming content (text, tool calls, error state).
- * Does NOT render the outer BubbleWrap — the caller (MessageBubble) provides that.
- */
-export function StreamingBubbleContent({ variant = "compact" }: { variant?: "compact" | "wide" }) {
+export function StreamingMessage({ variant = "compact" }: { variant?: "compact" | "wide" }) {
   const session = useSessionState();
   const { t } = useI18n();
   const { confirmedSentences, animatingIndices } =
@@ -27,59 +24,62 @@ export function StreamingBubbleContent({ variant = "compact" }: { variant?: "com
 
   if (session.streamError) {
     return (
+      <BubbleWrap variant={variant} padding="loose" className="bg-danger/5 border-l-2 border-danger/30 animate-fade">
+        <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
+          <AgentAvatar />
+          <div className="flex-1 min-w-0">
+            <div className={`flex items-center gap-2 ${isWide ? "mb-1.5" : "mb-1"}`}>
+              <span className="text-[11px] font-semibold text-danger uppercase tracking-[0.1em]">
+                {t("chat.streamError")}
+              </span>
+            </div>
+            <div className="text-sm text-danger/80">
+              <p className="leading-relaxed">{session.streamError}</p>
+              <p className="text-xs text-fg-3 mt-1">{t("chat.streamErrorRetry")}</p>
+            </div>
+          </div>
+        </div>
+      </BubbleWrap>
+    );
+  }
+
+  if (!session.isStreaming) return null;
+
+  const hasText = confirmedSentences.length > 0;
+  const showCursor = session.streamingToolCalls.length === 0;
+
+  return (
+    <BubbleWrap variant={variant} padding="loose" className="bg-surface/40 animate-fade">
       <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
         <AgentAvatar />
         <div className="flex-1 min-w-0">
           <div className={`flex items-center gap-2 ${isWide ? "mb-1.5" : "mb-1"}`}>
-            <span className="text-[11px] font-semibold text-danger uppercase tracking-[0.1em]">
-              {t("chat.streamError")}
+            <span className="text-[11px] font-semibold text-accent uppercase tracking-[0.1em]">
+              {t("chat.agent")}
             </span>
-          </div>
-          <div className="text-sm text-danger/80">
-            <p className="leading-relaxed">{session.streamError}</p>
-            <p className="text-xs text-fg-3 mt-1">{t("chat.streamErrorRetry")}</p>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  const hasText = confirmedSentences.length > 0;
-  const showCursor =
-    session.isStreaming && session.streamingToolCalls.length === 0;
-
-  return (
-    <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
-      <AgentAvatar />
-      <div className="flex-1 min-w-0">
-        <div className={`flex items-center gap-2 ${isWide ? "mb-1.5" : "mb-1"}`}>
-          <span className="text-[11px] font-semibold text-accent uppercase tracking-[0.1em]">
-            {t("chat.agent")}
-          </span>
-          {session.isStreaming && (
             <span className="inline-block w-1.5 h-1.5 rounded-full bg-accent animate-glow" />
-          )}
-        </div>
-        <div className="text-sm text-fg">
-          {hasText && (
-            <div className="whitespace-pre-wrap break-words leading-relaxed">
-              {confirmedSentences.map((sentence, i) => (
-                <Sentence
-                  key={i}
-                  text={sentence}
-                  animating={animatingIndices.has(i)}
-                />
-              ))}
-              {showCursor && (
-                <span className="inline-block w-0.5 h-4 bg-accent ml-0.5 rounded-full animate-blink" />
-              )}
-            </div>
-          )}
-          {session.streamingToolCalls.map((tc) => (
-            <StreamingToolCall key={tc.id} tc={tc} />
-          ))}
+          </div>
+          <div className="text-sm text-fg">
+            {hasText && (
+              <div className="whitespace-pre-wrap break-words leading-relaxed">
+                {confirmedSentences.map((sentence, i) => (
+                  <Sentence
+                    key={i}
+                    text={sentence}
+                    animating={animatingIndices.has(i)}
+                  />
+                ))}
+                {showCursor && (
+                  <span className="inline-block w-0.5 h-4 bg-accent ml-0.5 rounded-full animate-blink" />
+                )}
+              </div>
+            )}
+            {session.streamingToolCalls.map((tc) => (
+              <StreamingToolCall key={tc.id} tc={tc} />
+            ))}
+          </div>
         </div>
       </div>
-    </div>
+    </BubbleWrap>
   );
 }

--- a/apps/webui/src/client/features/chat/StreamingMessage.tsx
+++ b/apps/webui/src/client/features/chat/StreamingMessage.tsx
@@ -15,7 +15,7 @@ const Sentence = memo(function Sentence({
   animating: boolean;
 }) {
   return (
-    <span className={animating ? "animate-sentence-settle" : undefined}>
+    <span className={animating ? "animate-sentence-fade" : undefined}>
       {parseInlineMarkdown(text)}
     </span>
   );

--- a/apps/webui/src/client/features/chat/StreamingMessage.tsx
+++ b/apps/webui/src/client/features/chat/StreamingMessage.tsx
@@ -1,7 +1,25 @@
+import { memo } from "react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
+import { parseInlineMarkdown } from "@/client/shared/inlineMarkdown.js";
 import { AgentAvatar } from "./Avatars.js";
 import { StreamingToolCall } from "./ToolCallDisplay.js";
+import { useSentenceAnimation } from "./useSentenceAnimation.js";
+
+/** Memoised so parseInlineMarkdown only runs when `text` actually changes. */
+const Sentence = memo(function Sentence({
+  text,
+  animating,
+}: {
+  text: string;
+  animating: boolean;
+}) {
+  return (
+    <span className={animating ? "animate-sentence-settle" : undefined}>
+      {parseInlineMarkdown(text)}
+    </span>
+  );
+});
 
 interface StreamingMessageProps {
   variant?: "compact" | "wide";
@@ -10,6 +28,8 @@ interface StreamingMessageProps {
 export function StreamingMessage({ variant = "compact" }: StreamingMessageProps) {
   const session = useSessionState();
   const { t } = useI18n();
+  const { confirmedSentences, animatingIndices } =
+    useSentenceAnimation(session.streamingText, session.isStreaming);
 
   const isWide = variant === "wide";
 
@@ -49,6 +69,10 @@ export function StreamingMessage({ variant = "compact" }: StreamingMessageProps)
     return null;
   }
 
+  const hasText = confirmedSentences.length > 0;
+  const showCursor =
+    session.isStreaming && session.streamingToolCalls.length === 0;
+
   return wrap("bg-surface/40",
     <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
       <AgentAvatar />
@@ -62,13 +86,18 @@ export function StreamingMessage({ variant = "compact" }: StreamingMessageProps)
           )}
         </div>
         <div className="text-sm text-fg">
-          {session.streamingText && (
+          {hasText && (
             <div className="whitespace-pre-wrap break-words leading-relaxed">
-              {session.streamingText}
-              {session.isStreaming &&
-                session.streamingToolCalls.length === 0 && (
-                  <span className="inline-block w-0.5 h-4 bg-accent ml-0.5 rounded-full animate-blink" />
-                )}
+              {confirmedSentences.map((sentence, i) => (
+                <Sentence
+                  key={i}
+                  text={sentence}
+                  animating={animatingIndices.has(i)}
+                />
+              ))}
+              {showCursor && (
+                <span className="inline-block w-0.5 h-4 bg-accent ml-0.5 rounded-full animate-blink" />
+              )}
             </div>
           )}
           {session.streamingToolCalls.map((tc) => (

--- a/apps/webui/src/client/features/chat/StreamingMessage.tsx
+++ b/apps/webui/src/client/features/chat/StreamingMessage.tsx
@@ -1,4 +1,3 @@
-import { memo } from "react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { parseInlineMarkdown } from "@/client/shared/inlineMarkdown.js";
@@ -6,26 +5,19 @@ import { AgentAvatar } from "./Avatars.js";
 import { StreamingToolCall } from "./ToolCallDisplay.js";
 import { useSentenceAnimation } from "./useSentenceAnimation.js";
 
-/** Memoised so parseInlineMarkdown only runs when `text` actually changes. */
-const Sentence = memo(function Sentence({
-  text,
-  animating,
-}: {
-  text: string;
-  animating: boolean;
-}) {
+function Sentence({ text, animating }: { text: string; animating: boolean }) {
   return (
     <span className={animating ? "animate-sentence-fade" : undefined}>
       {parseInlineMarkdown(text)}
     </span>
   );
-});
-
-interface StreamingMessageProps {
-  variant?: "compact" | "wide";
 }
 
-export function StreamingMessage({ variant = "compact" }: StreamingMessageProps) {
+/**
+ * Renders streaming content (text, tool calls, error state).
+ * Does NOT render the outer BubbleWrap — the caller (MessageBubble) provides that.
+ */
+export function StreamingBubbleContent({ variant = "compact" }: { variant?: "compact" | "wide" }) {
   const session = useSessionState();
   const { t } = useI18n();
   const { confirmedSentences, animatingIndices } =
@@ -33,17 +25,8 @@ export function StreamingMessage({ variant = "compact" }: StreamingMessageProps)
 
   const isWide = variant === "wide";
 
-  const wrap = (bg: string, children: React.ReactNode) => {
-    const cls = `${isWide ? "px-4 py-4" : "px-3 py-3"} ${bg} animate-fade`;
-    return isWide ? (
-      <div className={cls}><div className="max-w-3xl mx-auto">{children}</div></div>
-    ) : (
-      <div className={cls}>{children}</div>
-    );
-  };
-
   if (session.streamError) {
-    return wrap("bg-danger/5 border-l-2 border-danger/30",
+    return (
       <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
         <AgentAvatar />
         <div className="flex-1 min-w-0">
@@ -57,23 +40,15 @@ export function StreamingMessage({ variant = "compact" }: StreamingMessageProps)
             <p className="text-xs text-fg-3 mt-1">{t("chat.streamErrorRetry")}</p>
           </div>
         </div>
-      </div>,
+      </div>
     );
-  }
-
-  if (
-    !session.isStreaming &&
-    !session.streamingText &&
-    session.streamingToolCalls.length === 0
-  ) {
-    return null;
   }
 
   const hasText = confirmedSentences.length > 0;
   const showCursor =
     session.isStreaming && session.streamingToolCalls.length === 0;
 
-  return wrap("bg-surface/40",
+  return (
     <div className={`flex items-start ${isWide ? "gap-3" : "gap-2.5"}`}>
       <AgentAvatar />
       <div className="flex-1 min-w-0">
@@ -105,6 +80,6 @@ export function StreamingMessage({ variant = "compact" }: StreamingMessageProps)
           ))}
         </div>
       </div>
-    </div>,
+    </div>
   );
 }

--- a/apps/webui/src/client/features/chat/useSentenceAnimation.ts
+++ b/apps/webui/src/client/features/chat/useSentenceAnimation.ts
@@ -1,0 +1,61 @@
+import { useMemo, useRef, useState, useEffect } from "react";
+import { segmentSentences } from "@/client/shared/sentenceSegmenter.js";
+
+export interface SentenceAnimationState {
+  confirmedSentences: string[];
+  animatingIndices: Set<number>;
+}
+
+/**
+ * Splits streaming text at sentence boundaries and tracks which sentences
+ * are newly confirmed so the caller can apply a one-shot entrance animation.
+ */
+export function useSentenceAnimation(
+  streamingText: string,
+  isStreaming: boolean,
+): SentenceAnimationState {
+  const animatedCountRef = useRef(0);
+  const [animatingIndices, setAnimatingIndices] = useState<Set<number>>(
+    new Set(),
+  );
+
+  const { confirmed, pending } = useMemo(
+    () => segmentSentences(streamingText),
+    [streamingText],
+  );
+
+  const confirmedSentences = useMemo(() => {
+    if (!isStreaming && pending) {
+      return [...confirmed, pending];
+    }
+    return confirmed;
+  }, [confirmed, pending, isStreaming]);
+
+  useEffect(() => {
+    const prevCount = animatedCountRef.current;
+    const currentCount = confirmedSentences.length;
+
+    if (currentCount > prevCount) {
+      const newIndices = new Set<number>();
+      for (let i = prevCount; i < currentCount; i++) {
+        newIndices.add(i);
+      }
+      setAnimatingIndices(newIndices);
+      animatedCountRef.current = currentCount;
+
+      const timer = setTimeout(() => {
+        setAnimatingIndices(new Set());
+      }, 150);
+      return () => clearTimeout(timer);
+    }
+  }, [confirmedSentences.length]);
+
+  useEffect(() => {
+    if (!streamingText) {
+      animatedCountRef.current = 0;
+      setAnimatingIndices(new Set());
+    }
+  }, [streamingText]);
+
+  return { confirmedSentences, animatingIndices };
+}

--- a/apps/webui/src/client/features/chat/useSentenceAnimation.ts
+++ b/apps/webui/src/client/features/chat/useSentenceAnimation.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useEffect } from "react";
+import { useMemo, useRef, useState, useEffect, useLayoutEffect } from "react";
 import { segmentSentences } from "@/client/shared/sentenceSegmenter.js";
 
 export interface SentenceAnimationState {
@@ -31,7 +31,7 @@ export function useSentenceAnimation(
     return confirmed;
   }, [confirmed, pending, isStreaming]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const prevCount = animatedCountRef.current;
     const currentCount = confirmedSentences.length;
 

--- a/apps/webui/src/client/main.css
+++ b/apps/webui/src/client/main.css
@@ -33,7 +33,7 @@
   --animate-blink: blink 1s step-end infinite;
   --animate-glow: glow-pulse 2s ease-in-out infinite;
   --animate-shake: shake 0.3s ease-in-out;
-  --animate-sentence-settle: fade 0.15s ease-out both;
+  --animate-sentence-fade: fade 0.15s ease-out both;
 }
 
 /* ── Keyframes ─────────────────────────────── */

--- a/apps/webui/src/client/main.css
+++ b/apps/webui/src/client/main.css
@@ -33,6 +33,7 @@
   --animate-blink: blink 1s step-end infinite;
   --animate-glow: glow-pulse 2s ease-in-out infinite;
   --animate-shake: shake 0.3s ease-in-out;
+  --animate-sentence-settle: fade 0.15s ease-out both;
 }
 
 /* ── Keyframes ─────────────────────────────── */

--- a/apps/webui/src/client/shared/inlineMarkdown.tsx
+++ b/apps/webui/src/client/shared/inlineMarkdown.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+
+/**
+ * Parse inline markdown (bold, italic, code, strikethrough) into React elements.
+ * Handles nested formatting and gracefully ignores unclosed markers.
+ *
+ * Processing order matters — code first (protects inner content), then bold
+ * before italic (longest match first), then strikethrough.
+ */
+
+// Matches inline code, bold, italic, strikethrough in one pass.
+// Code backticks are matched first via alternation order so their inner
+// content is never re-parsed for bold/italic.
+const INLINE_RE =
+  /(`[^`]+`)|(\*\*(?:[^*]|\*(?!\*))+\*\*)|(\*(?:[^*])+?\*)|(~~(?:[^~]|~(?!~))+~~)/g;
+
+export function parseInlineMarkdown(text: string): ReactNode {
+  const parts: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of text.matchAll(INLINE_RE)) {
+    const idx = match.index!;
+
+    // Push plain text before this match
+    if (idx > lastIndex) {
+      parts.push(text.slice(lastIndex, idx));
+    }
+
+    const raw = match[0];
+
+    if (match[1]) {
+      // `code`
+      parts.push(
+        <code
+          key={key++}
+          className="font-mono bg-elevated/50 px-1 rounded text-[0.9em]"
+        >
+          {raw.slice(1, -1)}
+        </code>,
+      );
+    } else if (match[2]) {
+      // **bold** — recurse for nested italic/strike inside bold
+      parts.push(
+        <strong key={key++} className="font-semibold">
+          {parseInlineMarkdown(raw.slice(2, -2))}
+        </strong>,
+      );
+    } else if (match[3]) {
+      // *italic* — recurse for nested strike inside italic
+      parts.push(
+        <em key={key++} className="italic">
+          {parseInlineMarkdown(raw.slice(1, -1))}
+        </em>,
+      );
+    } else if (match[4]) {
+      // ~~strikethrough~~
+      parts.push(
+        <del key={key++} className="line-through opacity-60">
+          {parseInlineMarkdown(raw.slice(2, -2))}
+        </del>,
+      );
+    }
+
+    lastIndex = idx + raw.length;
+  }
+
+  // Trailing plain text
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex));
+  }
+
+  // If nothing matched, return the original string (avoids wrapping in array)
+  return parts.length === 0 ? text : parts.length === 1 ? parts[0] : parts;
+}

--- a/apps/webui/src/client/shared/sentenceSegmenter.ts
+++ b/apps/webui/src/client/shared/sentenceSegmenter.ts
@@ -1,0 +1,55 @@
+/**
+ * Sentence segmenter using Intl.Segmenter + newline boundaries.
+ *
+ * Splits on `\n` first (guaranteed boundary regardless of browser), then
+ * applies Intl.Segmenter to each chunk for punctuation-aware splitting.
+ */
+
+const segmenter = new Intl.Segmenter("ko", { granularity: "sentence" });
+
+export interface SentenceSegments {
+  confirmed: string[];
+  pending: string;
+}
+
+/**
+ * Segment text into confirmed sentences and a pending tail.
+ * All segments except the last are "confirmed" (boundary observed);
+ * the last is "pending" since more text may still arrive.
+ */
+export function segmentSentences(text: string): SentenceSegments {
+  if (!text) return { confirmed: [], pending: "" };
+
+  const lines = text.split("\n");
+  const allSegments: string[] = [];
+
+  for (let li = 0; li < lines.length; li++) {
+    const line = lines[li];
+    if (!line) {
+      if (li < lines.length - 1) {
+        allSegments.push("\n");
+      }
+      continue;
+    }
+
+    const segs = [...segmenter.segment(line)].map((s) => s.segment);
+    for (const seg of segs) {
+      allSegments.push(seg);
+    }
+
+    if (li < lines.length - 1) {
+      if (allSegments.length > 0) {
+        allSegments[allSegments.length - 1] += "\n";
+      } else {
+        allSegments.push("\n");
+      }
+    }
+  }
+
+  if (allSegments.length === 0) return { confirmed: [], pending: "" };
+
+  const confirmed = allSegments.slice(0, -1);
+  const pending = allSegments[allSegments.length - 1];
+
+  return { confirmed, pending };
+}


### PR DESCRIPTION
## Summary
- 에이전트 패널(스트리밍/완료)에 인라인 마크다운 렌더링 추가 (`**bold**`, `*italic*`, `` `code` ``, `~~strike~~`)
- `Intl.Segmenter` 기반 문장 경계 감지로 확정된 문장만 파싱 후 표시하여 마크다운 파싱으로 인한 layout shift 원천 차단

## Test plan
- [ ] 에이전트에게 마크다운 포맷팅이 포함된 응답 유도 → 인라인 스타일 렌더링 확인
- [ ] 스트리밍 중 미확정 텍스트가 숨겨지고, 문장 확정 시 fade-in 표시되는지 확인
- [ ] 완료된 메시지에서도 인라인 마크다운 렌더링 확인
- [ ] 스트리밍 완료 후 메시지 버블이 다시 애니메이션되지 않는지 확인
- [ ] 도구 호출 포함 응답에서 텍스트/도구 독립 처리 확인
- [ ] `bunx tsc --noEmit` 타입 체크 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)