### PR TITLE
feat: 프로젝트를 템플릿으로 저장

### DIFF
--- a/apps/webui/src/client/entities/editor/file-tree.utils.tsx
+++ b/apps/webui/src/client/entities/editor/file-tree.utils.tsx
@@ -1,0 +1,54 @@
+import { FileText, FileCode, Image } from "lucide-react";
+import { IMAGE_EXTS, type TreeEntry } from "./editor.types.js";
+
+export interface TreeNode {
+  name: string;
+  path: string;
+  type: "file" | "dir";
+  children: TreeNode[];
+}
+
+export function buildTree(entries: TreeEntry[]): TreeNode[] {
+  const root: TreeNode[] = [];
+  const dirs = new Map<string, TreeNode>();
+
+  for (const entry of entries) {
+    if (entry.type === "dir") {
+      dirs.set(entry.path, { name: entry.path.split("/").pop()!, path: entry.path, type: "dir", children: [] });
+    }
+  }
+
+  for (const entry of entries) {
+    const node: TreeNode = entry.type === "dir"
+      ? dirs.get(entry.path)!
+      : { name: entry.path.split("/").pop()!, path: entry.path, type: "file", children: [] };
+
+    const parentPath = entry.path.includes("/") ? entry.path.substring(0, entry.path.lastIndexOf("/")) : null;
+
+    if (parentPath && dirs.has(parentPath)) {
+      dirs.get(parentPath)!.children.push(node);
+    } else if (!parentPath) {
+      root.push(node);
+    }
+  }
+
+  function sortNodes(nodes: TreeNode[]) {
+    nodes.sort((a, b) => {
+      if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    for (const n of nodes) {
+      if (n.children.length > 0) sortNodes(n.children);
+    }
+  }
+
+  sortNodes(root);
+  return root;
+}
+
+export function FileIcon({ name }: { name: string }) {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  if (IMAGE_EXTS.has(ext)) return <Image size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
+  if (ext === "ts" || ext === "js" || ext === "mjs" || ext === "mts") return <FileCode size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
+  return <FileText size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
+}

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -2,3 +2,4 @@ export { EditorProvider, useEditorState, useEditorDispatch } from "./EditorConte
 export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile, revealProjectFile } from "./editor.api.js";
 export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
+export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";

--- a/apps/webui/src/client/entities/template/index.ts
+++ b/apps/webui/src/client/entities/template/index.ts
@@ -1,2 +1,2 @@
 export type { TemplateMeta } from "./template.types.js";
-export { fetchTemplates } from "./template.api.js";
+export { fetchTemplates, saveProjectAsTemplate } from "./template.api.js";

--- a/apps/webui/src/client/entities/template/template.api.ts
+++ b/apps/webui/src/client/entities/template/template.api.ts
@@ -1,6 +1,30 @@
-import { json } from "@/client/shared/api.js";
+import { json, BASE } from "@/client/shared/api.js";
 import type { TemplateMeta } from "./template.types.js";
 
 export function fetchTemplates(): Promise<TemplateMeta[]> {
   return json("/templates");
+}
+
+export async function saveProjectAsTemplate(
+  slug: string,
+  payload: {
+    name: string;
+    description?: string;
+    excludeFiles?: string[];
+    overwrite?: boolean;
+  },
+): Promise<{ ok: boolean; conflict?: boolean }> {
+  const res = await fetch(`${BASE}/projects/${encodeURIComponent(slug)}/save-as-template`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (res.status === 409) {
+    return { ok: false, conflict: true };
+  }
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`API error ${res.status}: ${body}`);
+  }
+  return { ok: true };
 }

--- a/apps/webui/src/client/entities/template/template.types.ts
+++ b/apps/webui/src/client/entities/template/template.types.ts
@@ -1,4 +1,5 @@
 export interface TemplateMeta {
+  slug: string;
   name: string;
   description?: string;
 }

--- a/apps/webui/src/client/features/editor/FileTree.tsx
+++ b/apps/webui/src/client/features/editor/FileTree.tsx
@@ -2,70 +2,13 @@ import { useState, useMemo, useCallback } from "react";
 import {
   ChevronRight,
   ChevronDown,
-  FileText,
-  FileCode,
   FolderOpen,
   FolderClosed,
-  Image,
 } from "lucide-react";
 import { ContextMenu } from "@base-ui/react/context-menu";
-import { IMAGE_EXTS, type TreeEntry } from "@/client/entities/editor/index.js";
+import { buildTree, FileIcon, type TreeNode } from "@/client/entities/editor/index.js";
+import type { TreeEntry } from "@/client/entities/editor/index.js";
 import { useI18n } from "@/client/i18n/index.js";
-
-interface TreeNode {
-  name: string;
-  path: string;
-  type: "file" | "dir";
-  children: TreeNode[];
-}
-
-function buildTree(entries: TreeEntry[]): TreeNode[] {
-  const root: TreeNode[] = [];
-  const dirs = new Map<string, TreeNode>();
-
-  // Ensure parent dirs exist
-  for (const entry of entries) {
-    if (entry.type === "dir") {
-      dirs.set(entry.path, { name: entry.path.split("/").pop()!, path: entry.path, type: "dir", children: [] });
-    }
-  }
-
-  // Build hierarchy
-  for (const entry of entries) {
-    const node: TreeNode = entry.type === "dir"
-      ? dirs.get(entry.path)!
-      : { name: entry.path.split("/").pop()!, path: entry.path, type: "file", children: [] };
-
-    const parentPath = entry.path.includes("/") ? entry.path.substring(0, entry.path.lastIndexOf("/")) : null;
-
-    if (parentPath && dirs.has(parentPath)) {
-      dirs.get(parentPath)!.children.push(node);
-    } else if (!parentPath) {
-      root.push(node);
-    }
-  }
-
-  // Sort: dirs first, then alphabetical
-  function sortNodes(nodes: TreeNode[]) {
-    nodes.sort((a, b) => {
-      if (a.type !== b.type) return a.type === "dir" ? -1 : 1;
-      return a.name.localeCompare(b.name);
-    });
-    for (const n of nodes) {
-      if (n.children.length > 0) sortNodes(n.children);
-    }
-  }
-
-  sortNodes(root);
-  return root;
-}
-
-function FileIcon({ name }: { name: string }) {
-  const ext = name.split(".").pop()?.toLowerCase() ?? "";
-  if (IMAGE_EXTS.has(ext)) return <Image size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
-  if (ext === "ts" || ext === "js" || ext === "mjs" || ext === "mts") return <FileCode size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
-  return <FileText size={13} strokeWidth={2} className="flex-shrink-0 opacity-60" />;
-}
 
 const MENU_POPUP_CLASS =
   "bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50";

--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -7,6 +7,7 @@ import { Indicator } from "@/client/shared/ui/index.js";
 import { fetchTemplates, type TemplateMeta } from "@/client/entities/template/index.js";
 import { useProject } from "./useProject.js";
 import { ProjectSettingsModal } from "./ProjectSettingsModal.js";
+import { SaveAsTemplateModal } from "./SaveAsTemplateModal.js";
 
 // -- Shared menu styles ---
 
@@ -148,6 +149,7 @@ export function ProjectTabs() {
   };
 
   const [settingsSlug, setSettingsSlug] = useState<string | null>(null);
+  const [saveAsTemplateSlug, setSaveAsTemplateSlug] = useState<string | null>(null);
 
   const handleOpenSettings = useCallback(
     (slug: string) => {
@@ -260,6 +262,12 @@ export function ProjectTabs() {
                   >
                     {t("project.duplicate")}
                   </ContextMenu.Item>
+                  <ContextMenu.Item
+                    onClick={() => setSaveAsTemplateSlug(project.slug)}
+                    className={MENU_ITEM_CLASS}
+                  >
+                    {t("project.saveAsTemplate")}
+                  </ContextMenu.Item>
                 </ContextMenu.Popup>
               </ContextMenu.Positioner>
             </ContextMenu.Portal>
@@ -332,8 +340,8 @@ export function ProjectTabs() {
                       </Menu.GroupLabel>
                       {templates.map((s) => (
                         <Menu.Item
-                          key={s.name}
-                          onClick={() => modeDispatch({ type: "START_CREATE", templateName: s.name })}
+                          key={s.slug}
+                          onClick={() => modeDispatch({ type: "START_CREATE", templateName: s.slug })}
                           className={`${MENU_ITEM_CLASS} truncate`}
                         >
                           {s.name}
@@ -348,6 +356,7 @@ export function ProjectTabs() {
         </Menu.Root>
       )}
       <ProjectSettingsModal slug={settingsSlug} onClose={() => setSettingsSlug(null)} />
+      <SaveAsTemplateModal slug={saveAsTemplateSlug} onClose={() => setSaveAsTemplateSlug(null)} />
     </div>
   );
 }

--- a/apps/webui/src/client/features/project/SaveAsTemplateModal.tsx
+++ b/apps/webui/src/client/features/project/SaveAsTemplateModal.tsx
@@ -1,0 +1,394 @@
+import { useState, useEffect, useMemo, useCallback } from "react";
+import {
+  ChevronRight,
+  ChevronDown,
+  FolderOpen,
+  FolderClosed,
+  Check,
+  Minus,
+} from "lucide-react";
+import { Dialog, Button, TextInput, FormField } from "@/client/shared/ui/index.js";
+import { useI18n } from "@/client/i18n/index.js";
+import { fetchProjectTree, readProjectFile, isImagePath, buildTree, FileIcon, type TreeEntry, type TreeNode } from "@/client/entities/editor/index.js";
+import { saveProjectAsTemplate } from "@/client/entities/template/index.js";
+import { BASE } from "@/client/shared/api.js";
+
+function collectFilePaths(node: TreeNode): string[] {
+  if (node.type === "file") return [node.path];
+  return node.children.flatMap(collectFilePaths);
+}
+
+/** Pre-compute file paths for each directory node to avoid re-traversal on every render. */
+function buildFilePathsMap(roots: TreeNode[]): Map<string, string[]> {
+  const map = new Map<string, string[]>();
+  function walk(node: TreeNode) {
+    if (node.type === "dir") {
+      map.set(node.path, collectFilePaths(node));
+      node.children.forEach(walk);
+    }
+  }
+  roots.forEach(walk);
+  return map;
+}
+
+// -- Checkbox tree item --
+
+interface CheckboxTreeItemProps {
+  node: TreeNode;
+  depth: number;
+  excluded: Set<string>;
+  collapsed: Set<string>;
+  selectedPreview: string | null;
+  filePathsMap: Map<string, string[]>;
+  onToggleExclude: (node: TreeNode) => void;
+  onToggleCollapse: (path: string) => void;
+  onSelectPreview: (path: string) => void;
+}
+
+function CheckboxTreeItem({
+  node, depth, excluded, collapsed, selectedPreview, filePathsMap,
+  onToggleExclude, onToggleCollapse, onSelectPreview,
+}: CheckboxTreeItemProps) {
+  const isDir = node.type === "dir";
+  const isCollapsed = collapsed.has(node.path);
+
+  if (isDir) {
+    const allFiles = filePathsMap.get(node.path) ?? [];
+    const excludedCount = allFiles.filter((p) => excluded.has(p)).length;
+    const checkState: "all" | "some" | "none" =
+      excludedCount === 0 ? "all" : excludedCount === allFiles.length ? "none" : "some";
+
+    const FolderIcon = isCollapsed ? FolderClosed : FolderOpen;
+    const ChevronIcon = isCollapsed ? ChevronRight : ChevronDown;
+
+    return (
+      <>
+        <div
+          className="flex items-center gap-1 px-2 py-1 hover:bg-accent/8 text-fg-2 hover:text-fg transition-colors rounded-md cursor-pointer"
+          style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        >
+          <button
+            onClick={() => onToggleExclude(node)}
+            className={`flex-shrink-0 w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${
+              checkState === "all"
+                ? "bg-accent border-accent text-void"
+                : checkState === "some"
+                  ? "bg-accent/40 border-accent/60 text-void"
+                  : "border-fg-4 hover:border-fg-3"
+            }`}
+          >
+            {checkState === "all" && <Check size={10} strokeWidth={3} />}
+            {checkState === "some" && <Minus size={10} strokeWidth={3} />}
+          </button>
+          <button
+            onClick={() => onToggleCollapse(node.path)}
+            className="flex items-center gap-1 flex-1 min-w-0"
+          >
+            <ChevronIcon size={12} strokeWidth={2} className="text-fg-4 flex-shrink-0" />
+            <FolderIcon size={13} strokeWidth={2} className="text-accent/60 flex-shrink-0" />
+            <span className="truncate ml-0.5 text-[12px]">{node.name}</span>
+          </button>
+        </div>
+        {!isCollapsed && node.children.map((child) => (
+          <CheckboxTreeItem
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            excluded={excluded}
+            collapsed={collapsed}
+            selectedPreview={selectedPreview}
+            filePathsMap={filePathsMap}
+            onToggleExclude={onToggleExclude}
+            onToggleCollapse={onToggleCollapse}
+            onSelectPreview={onSelectPreview}
+          />
+        ))}
+      </>
+    );
+  }
+
+  const isExcluded = excluded.has(node.path);
+  const isSelected = node.path === selectedPreview;
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 px-2 py-1 rounded-md transition-colors cursor-pointer ${
+        isSelected ? "bg-accent/12 text-accent" : "text-fg-2 hover:bg-accent/6 hover:text-fg"
+      }`}
+      style={{ paddingLeft: `${depth * 12 + 20}px` }}
+      onClick={() => onSelectPreview(node.path)}
+    >
+      <button
+        onClick={(e) => { e.stopPropagation(); onToggleExclude(node); }}
+        className={`flex-shrink-0 w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${
+          !isExcluded
+            ? "bg-accent border-accent text-void"
+            : "border-fg-4 hover:border-fg-3"
+        }`}
+      >
+        {!isExcluded && <Check size={10} strokeWidth={3} />}
+      </button>
+      <FileIcon name={node.name} />
+      <span className={`truncate text-[12px] ${isExcluded ? "line-through opacity-50" : ""}`}>{node.name}</span>
+    </div>
+  );
+}
+
+// -- Preview panel --
+
+interface PreviewPanelProps {
+  slug: string;
+  selectedPath: string | null;
+}
+
+function PreviewPanel({ slug, selectedPath }: PreviewPanelProps) {
+  const { t } = useI18n();
+  const [content, setContent] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!selectedPath) { setContent(null); return; }
+    if (isImagePath(selectedPath)) { setContent(null); return; }
+
+    let cancelled = false;
+    setLoading(true);
+    readProjectFile(slug, `files/${selectedPath}`)
+      .then((res) => { if (!cancelled) setContent(res.content); })
+      .catch(() => { if (!cancelled) setContent(null); })
+      .finally(() => { if (!cancelled) setLoading(false); });
+    return () => { cancelled = true; };
+  }, [slug, selectedPath]);
+
+  if (!selectedPath) {
+    return (
+      <div className="flex items-center justify-center h-full text-fg-4 text-sm">
+        {t("template.noPreview")}
+      </div>
+    );
+  }
+
+  if (isImagePath(selectedPath)) {
+    return (
+      <div className="flex items-center justify-center h-full p-4 overflow-auto">
+        <img
+          src={`${BASE}/projects/${encodeURIComponent(slug)}/files/${selectedPath}`}
+          alt={selectedPath}
+          className="max-w-full max-h-full object-contain rounded-lg"
+        />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full text-fg-4 text-sm">
+        {t("settings.loading")}
+      </div>
+    );
+  }
+
+  if (content === null) {
+    return (
+      <div className="flex items-center justify-center h-full text-fg-4 text-sm">
+        {t("template.binaryFile")}
+      </div>
+    );
+  }
+
+  return (
+    <pre className="h-full overflow-auto p-3 text-[11px] text-fg-3 font-mono whitespace-pre-wrap break-words leading-relaxed">
+      {content}
+    </pre>
+  );
+}
+
+// -- Main modal --
+
+interface SaveAsTemplateModalProps {
+  slug: string | null;
+  onClose: () => void;
+}
+
+export function SaveAsTemplateModal({ slug, onClose }: SaveAsTemplateModalProps) {
+  const { t } = useI18n();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [fileEntries, setFileEntries] = useState<TreeEntry[]>([]);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [selectedPreview, setSelectedPreview] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [nameError, setNameError] = useState(false);
+  const [overwritePrompt, setOverwritePrompt] = useState(false);
+
+  // Load file tree when slug changes
+  useEffect(() => {
+    if (!slug) return;
+    setName("");
+    setDescription("");
+    setFileEntries([]);
+    setExcluded(new Set());
+    setCollapsed(new Set());
+    setSelectedPreview(null);
+    setSaving(false);
+    setNameError(false);
+    setOverwritePrompt(false);
+
+    void fetchProjectTree(slug).then(({ entries }) => {
+      // Filter to files/ prefix only, then strip the prefix
+      const filesEntries = entries
+        .filter((e) => e.path.startsWith("files/"))
+        .map((e) => ({ ...e, path: e.path.slice("files/".length) }));
+      setFileEntries(filesEntries);
+    });
+  }, [slug]);
+
+  const tree = useMemo(() => buildTree(fileEntries), [fileEntries]);
+  const filePathsMap = useMemo(() => buildFilePathsMap(tree), [tree]);
+  const hasFiles = fileEntries.length > 0;
+
+  const toggleExclude = useCallback((node: TreeNode) => {
+    setExcluded((prev) => {
+      const next = new Set(prev);
+      const paths = collectFilePaths(node);
+      const allExcluded = paths.every((p) => next.has(p));
+      if (allExcluded) {
+        for (const p of paths) next.delete(p);
+      } else {
+        for (const p of paths) next.add(p);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleCollapse = useCallback((path: string) => {
+    setCollapsed((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const doSave = useCallback(async (overwrite: boolean) => {
+    if (!slug) return;
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setNameError(true);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      const result = await saveProjectAsTemplate(slug, {
+        name: trimmedName,
+        description: description.trim() || undefined,
+        excludeFiles: [...excluded],
+        overwrite,
+      });
+
+      if (result.conflict) {
+        setOverwritePrompt(true);
+        setSaving(false);
+        return;
+      }
+
+      onClose();
+    } catch {
+      setSaving(false);
+    }
+  }, [slug, name, description, excluded, onClose]);
+
+  return (
+    <Dialog open={slug !== null} onOpenChange={(open) => { if (!open) onClose(); }} size={hasFiles ? "xl" : "md"}>
+      <div className="p-6 space-y-5">
+        {/* Title */}
+        <h2 className="font-display text-lg font-bold tracking-tight text-fg">
+          {t("template.saveTitle")}
+        </h2>
+
+        {/* Name + Description */}
+        <div className="space-y-3">
+          <FormField label={t("template.name")}>
+            <TextInput
+              value={name}
+              onChange={(e) => { setName(e.target.value); setNameError(false); setOverwritePrompt(false); }}
+              placeholder={t("template.namePlaceholder")}
+              className={nameError ? "!border-danger/60" : ""}
+              autoFocus
+            />
+          </FormField>
+          <FormField label={t("template.templateDescription")}>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("template.descriptionPlaceholder")}
+              rows={2}
+              className="w-full rounded-lg border border-edge/8 bg-elevated px-3 py-2 text-sm text-fg placeholder:text-fg-4 outline-none focus:border-accent/30 resize-none"
+            />
+          </FormField>
+        </div>
+
+        {/* File tree + preview */}
+        {hasFiles && (
+          <div className="border border-edge/8 rounded-xl overflow-hidden">
+            <div className="px-3 py-2 bg-elevated/50 border-b border-edge/8">
+              <span className="text-[11px] font-semibold text-fg-3 uppercase tracking-[0.12em]">
+                {t("template.files")}
+              </span>
+            </div>
+            <div className="flex" style={{ height: "280px" }}>
+              {/* Left: tree with checkboxes */}
+              <div className="w-1/2 border-r border-edge/8 overflow-y-auto overflow-x-hidden py-1 select-none">
+                {tree.map((node) => (
+                  <CheckboxTreeItem
+                    key={node.path}
+                    node={node}
+                    depth={0}
+                    excluded={excluded}
+                    collapsed={collapsed}
+                    selectedPreview={selectedPreview}
+                    filePathsMap={filePathsMap}
+                    onToggleExclude={toggleExclude}
+                    onToggleCollapse={toggleCollapse}
+                    onSelectPreview={setSelectedPreview}
+                  />
+                ))}
+              </div>
+              {/* Right: preview */}
+              <div className="w-1/2 overflow-hidden">
+                <PreviewPanel slug={slug!} selectedPath={selectedPreview} />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Action buttons */}
+        <div className="flex items-center justify-end gap-2">
+          {overwritePrompt ? (
+            <>
+              <span className="text-sm text-fg-3 mr-auto">
+                {t("template.overwriteConfirm", { name: name.trim() })}
+              </span>
+              <Button variant="ghost" onClick={() => setOverwritePrompt(false)}>
+                {t("editMode.cancel")}
+              </Button>
+              <Button variant="danger" onClick={() => doSave(true)} disabled={saving}>
+                {t("template.overwrite")}
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={onClose}>
+                {t("editMode.cancel")}
+              </Button>
+              <Button variant="accent" onClick={() => doSave(false)} disabled={saving}>
+                {saving ? t("template.saving") : t("template.save")}
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -99,6 +99,21 @@ export const translations = {
   "templates.createProject": "Create project",
   "templates.empty": "No templates available",
 
+  // Save as template
+  "project.saveAsTemplate": "Save as template",
+  "template.saveTitle": "Save as Template",
+  "template.name": "Template Name",
+  "template.templateDescription": "Description",
+  "template.namePlaceholder": "Template name...",
+  "template.descriptionPlaceholder": "Optional description...",
+  "template.files": "Files",
+  "template.save": "Save Template",
+  "template.saving": "Saving...",
+  "template.overwriteConfirm": "\"{{name}}\" already exists. Overwrite?",
+  "template.overwrite": "Overwrite",
+  "template.noPreview": "Select a file to preview",
+  "template.binaryFile": "Binary file",
+
   // Skill/Renderer editor
   "editor.unsaved": "unsaved changes",
   "editor.saved": "saved",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -101,6 +101,21 @@ export const translations: Record<TranslationKey, string> = {
   "templates.createProject": "프로젝트 생성",
   "templates.empty": "사용 가능한 템플릿이 없습니다",
 
+  // Save as template
+  "project.saveAsTemplate": "템플릿으로 저장",
+  "template.saveTitle": "템플릿으로 저장",
+  "template.name": "템플릿 이름",
+  "template.templateDescription": "설명",
+  "template.namePlaceholder": "템플릿 이름...",
+  "template.descriptionPlaceholder": "선택적 설명...",
+  "template.files": "파일",
+  "template.save": "템플릿 저장",
+  "template.saving": "저장 중...",
+  "template.overwriteConfirm": "\"{{name}}\" 템플릿이 이미 존재합니다. 덮어쓰시겠습니까?",
+  "template.overwrite": "덮어쓰기",
+  "template.noPreview": "미리보기할 파일을 선택하세요",
+  "template.binaryFile": "바이너리 파일",
+
   // Skill/Renderer editor
   "editor.unsaved": "저장되지 않은 변경",
   "editor.saved": "저장됨",

--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -17,11 +17,11 @@ export function TemplatesPage() {
     void fetchTemplates().then(setTemplates);
   }, []);
 
-  const handleCreate = useCallback(async (templateName: string) => {
+  const handleCreate = useCallback(async (templateSlug: string) => {
     if (!nameInput.trim()) return;
-    setCreating(templateName);
+    setCreating(templateSlug);
     try {
-      await createProject(nameInput.trim(), templateName);
+      await createProject(nameInput.trim(), templateSlug);
       uiDispatch({ type: "NAVIGATE", route: { page: "main" } });
     } finally {
       setCreating(null);
@@ -50,7 +50,7 @@ export function TemplatesPage() {
           <div className="grid gap-3">
             {templates.map((tpl) => (
               <div
-                key={tpl.name}
+                key={tpl.slug}
                 className="group border border-edge/8 rounded-xl bg-elevated/50 hover:bg-elevated hover:border-edge/16 transition-all duration-150"
               >
                 <div className="px-5 py-4 flex items-start justify-between gap-4">
@@ -65,14 +65,14 @@ export function TemplatesPage() {
                     )}
                   </div>
 
-                  {creating === tpl.name ? (
+                  {creating === tpl.slug ? (
                     <div className="flex items-center gap-2 shrink-0">
                       <input
                         type="text"
                         value={nameInput}
                         onChange={(e) => setNameInput(e.target.value)}
                         onKeyDown={(e) => {
-                          if (e.key === "Enter") void handleCreate(tpl.name);
+                          if (e.key === "Enter") void handleCreate(tpl.slug);
                           if (e.key === "Escape") { setCreating(null); setNameInput(""); }
                         }}
                         placeholder={t("project.namePlaceholder")}
@@ -80,7 +80,7 @@ export function TemplatesPage() {
                         autoFocus
                       />
                       <button
-                        onClick={() => void handleCreate(tpl.name)}
+                        onClick={() => void handleCreate(tpl.slug)}
                         disabled={!nameInput.trim()}
                         className="px-3 py-1.5 text-xs font-medium bg-accent text-void rounded-lg hover:bg-accent/90 disabled:opacity-40 transition-all duration-150"
                       >
@@ -89,7 +89,7 @@ export function TemplatesPage() {
                     </div>
                   ) : (
                     <button
-                      onClick={() => { setCreating(tpl.name); setNameInput(""); }}
+                      onClick={() => { setCreating(tpl.slug); setNameInput(""); }}
                       className="shrink-0 p-1.5 rounded-lg text-fg-3 opacity-0 group-hover:opacity-100 hover:text-accent hover:bg-accent/8 transition-all duration-150"
                       title={t("templates.createProject")}
                     >

--- a/apps/webui/src/client/shared/ui/Dialog.tsx
+++ b/apps/webui/src/client/shared/ui/Dialog.tsx
@@ -1,20 +1,27 @@
 import type { ReactNode } from "react";
 import { Dialog as BaseDialog } from "@base-ui/react/dialog";
 
+const SIZE_MAP = {
+  md: "max-w-lg",
+  lg: "max-w-2xl",
+  xl: "max-w-4xl",
+} as const;
+
 interface DialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   modal?: boolean;
+  size?: keyof typeof SIZE_MAP;
   children: ReactNode;
 }
 
-export function Dialog({ open, onOpenChange, modal = true, children }: DialogProps) {
+export function Dialog({ open, onOpenChange, modal = true, size = "md", children }: DialogProps) {
   return (
     <BaseDialog.Root open={open} onOpenChange={onOpenChange} modal={modal}>
       <BaseDialog.Portal>
         <BaseDialog.Backdrop className="fixed inset-0 z-50 bg-void/80 backdrop-blur-sm transition-opacity" />
         <BaseDialog.Popup className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div className="w-full max-w-lg bg-surface border border-edge/8 rounded-2xl shadow-lg shadow-void/50 animate-fade-slide">
+          <div className={`w-full ${SIZE_MAP[size]} bg-surface border border-edge/8 rounded-2xl shadow-lg shadow-void/50 animate-fade-slide`}>
             {children}
           </div>
         </BaseDialog.Popup>

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -34,7 +34,7 @@ const projectSkillRepo = createProjectSkillRepo(PROJECTS_DIR);
 
 // ===== 2. Services =====
 const configService = createConfigService(settingsRepo);
-const templateService = createTemplateService(templateRepo);
+const templateService = createTemplateService(templateRepo, PROJECTS_DIR);
 const projectService = createProjectService(projectRepo, templateRepo, PROJECTS_DIR);
 const skillService = createSkillService(projectSkillRepo, PROJECTS_DIR);
 

--- a/apps/webui/src/server/repositories/template.repo.ts
+++ b/apps/webui/src/server/repositories/template.repo.ts
@@ -1,9 +1,10 @@
-import { readFile, readdir, mkdir } from "node:fs/promises";
+import { readFile, readdir, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { assertSafePathSegment } from "../paths.js";
 
 export interface TemplateMeta {
+  slug: string;
   name: string;
   description?: string;
 }
@@ -23,7 +24,8 @@ export function createTemplateRepo(templatesDir: string) {
           const metaPath = join(templatesDir, entry.name, "_template.json");
           if (!existsSync(metaPath)) return null;
           const raw = await readFile(metaPath, "utf-8");
-          return JSON.parse(raw) as TemplateMeta;
+          const meta = JSON.parse(raw) as { name: string; description?: string };
+          return { slug: entry.name, ...meta } as TemplateMeta;
         }),
       );
       return results.filter((m): m is TemplateMeta => m !== null);
@@ -33,6 +35,24 @@ export function createTemplateRepo(templatesDir: string) {
       assertSafePathSegment(name);
       const dir = join(templatesDir, name);
       if (!existsSync(dir)) throw new Error(`Template not found: ${name}`);
+      return dir;
+    },
+
+    async exists(name: string): Promise<boolean> {
+      assertSafePathSegment(name);
+      return existsSync(join(templatesDir, name, "_template.json"));
+    },
+
+    async remove(name: string): Promise<void> {
+      assertSafePathSegment(name);
+      await rm(join(templatesDir, name), { recursive: true, force: true });
+    },
+
+    async ensureTemplateDir(name: string, meta: { name: string; description?: string }): Promise<string> {
+      assertSafePathSegment(name);
+      const dir = join(templatesDir, name);
+      await mkdir(dir, { recursive: true });
+      await Bun.write(join(dir, "_template.json"), JSON.stringify(meta, null, 2));
       return dir;
     },
   };

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -72,6 +72,38 @@ export function createProjectRoutes() {
     }
   });
 
+  app.post("/:slug/save-as-template", async (c) => {
+    const slug = c.req.param("slug");
+    const { name, description, excludeFiles = [], overwrite = false } =
+      await c.req.json<{
+        name: string;
+        description?: string;
+        excludeFiles?: string[];
+        overwrite?: boolean;
+      }>();
+
+    if (!name?.trim()) return c.json({ error: "Name is required" }, 400);
+
+    const existing = await c.get("projectService").get(slug);
+    if (!existing) return c.json({ error: "Project not found" }, 404);
+
+    try {
+      const result = await c.get("templateService").saveProjectAsTemplate(slug, {
+        name: name.trim(),
+        description: description?.trim(),
+        excludeFiles,
+        overwrite,
+      });
+      if (result.conflict) {
+        return c.json({ error: "exists" }, 409);
+      }
+      return c.json({ ok: true }, 201);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to save as template";
+      return c.json({ error: message }, 400);
+    }
+  });
+
   app.get("/:slug/workspace/files", async (c) => {
     const slug = c.req.param("slug");
     const existing = await c.get("projectService").get(slug);

--- a/apps/webui/src/server/services/template.service.ts
+++ b/apps/webui/src/server/services/template.service.ts
@@ -1,9 +1,81 @@
+import { existsSync } from "node:fs";
+import { cp, mkdir, readdir } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { assertSafePathSegment } from "../paths.js";
 import type { TemplateRepo } from "../repositories/template.repo.js";
 
-export function createTemplateService(templateRepo: TemplateRepo) {
+interface SaveAsTemplateOptions {
+  name: string;
+  description?: string;
+  excludeFiles: string[];
+  overwrite: boolean;
+}
+
+export function createTemplateService(templateRepo: TemplateRepo, projectsDir: string) {
+  async function copyFilesSelectively(
+    srcDir: string,
+    destDir: string,
+    excludeSet: Set<string>,
+  ): Promise<void> {
+    async function walk(dir: string, prefix: string) {
+      const items = await readdir(dir, { withFileTypes: true });
+      for (const item of items) {
+        const relPath = prefix ? `${prefix}/${item.name}` : item.name;
+        if (item.isDirectory()) {
+          await walk(join(dir, item.name), relPath);
+        } else {
+          if (excludeSet.has(relPath)) continue;
+          const destPath = join(destDir, relPath);
+          await mkdir(dirname(destPath), { recursive: true });
+          await cp(join(dir, item.name), destPath);
+        }
+      }
+    }
+    await walk(srcDir, "");
+  }
+
   return {
     async list() { return templateRepo.list(); },
     getSourceDir(name: string) { return templateRepo.getSourceDir(name); },
+
+    async saveProjectAsTemplate(
+      projectSlug: string,
+      opts: SaveAsTemplateOptions,
+    ): Promise<{ saved: boolean; conflict?: boolean }> {
+      assertSafePathSegment(projectSlug);
+      const { name, description, excludeFiles, overwrite } = opts;
+      const srcDir = join(projectsDir, projectSlug);
+
+      if (!overwrite && await templateRepo.exists(name)) {
+        return { saved: false, conflict: true };
+      }
+      if (overwrite) {
+        await templateRepo.remove(name);
+      }
+
+      const destDir = await templateRepo.ensureTemplateDir(name, { name, description });
+
+      const copies: Promise<void>[] = [];
+      for (const file of ["SYSTEM.md", "renderer.ts"] as const) {
+        const src = join(srcDir, file);
+        if (existsSync(src)) {
+          copies.push(cp(src, join(destDir, file)));
+        }
+      }
+      const skillsSrc = join(srcDir, "skills");
+      if (existsSync(skillsSrc)) {
+        copies.push(cp(skillsSrc, join(destDir, "skills"), { recursive: true }));
+      }
+      await Promise.all(copies);
+
+      const filesSrc = join(srcDir, "files");
+      if (existsSync(filesSrc)) {
+        const excludeSet = new Set(excludeFiles);
+        await copyFilesSelectively(filesSrc, join(destDir, "files"), excludeSet);
+      }
+
+      return { saved: true };
+    },
   };
 }
 


### PR DESCRIPTION
## Summary
- 사이드바 프로젝트 우클릭 컨텍스트 메뉴에 "템플릿으로 저장" 기능 추가
- 모달 다이얼로그: 이름/설명 입력 + 체크박스 파일 트리(미리보기 포함)로 files/ 내 파일 선택적 제외
- 동일 이름 템플릿 존재 시 409 → 덮어쓰기 확인 UX
- `buildTree`/`FileIcon` 공유 모듈 추출 (`entities/editor/file-tree.utils`)
- `TemplateMeta`에 `slug` 추가하여 표시명/디렉토리명 불일치 버그 수정

## 테스트 계획
- [x] 사이드바 프로젝트 우클릭 → "템플릿으로 저장" 메뉴 표시
- [x] 빈 프로젝트(files/ 없음) → 파일 선택 영역 숨김, 이름만으로 저장
- [x] 파일 있는 프로젝트 → 트리뷰 체크박스 + 이미지/텍스트 미리보기
- [x] 파일 언체크 후 저장 → 제외 파일 없이 `data/library/templates/`에 생성
- [x] 동일 이름 재저장 → 덮어쓰기 확인 UI → 성공
- [x] `bunx tsc --noEmit` 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)