### PR TITLE
refactor: Base UI ScrollArea 도입으로 스크롤 처리 통합

### DIFF
--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { BookOpen, Settings } from "lucide-react";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
-import { IconButton } from "@/client/shared/ui/index.js";
+import { IconButton, ScrollArea } from "@/client/shared/ui/index.js";
 import { ProjectTabs } from "@/client/features/project/index.js";
 import { ModelBar } from "@/client/features/settings/index.js";
 import { SkillList } from "./SkillList.js";
@@ -50,14 +50,14 @@ export function Sidebar() {
       </div>
 
       {/* Projects */}
-      <div className="flex-1 overflow-y-auto border-t border-edge/6 pt-1 pb-2">
+      <ScrollArea className="flex-1 border-t border-edge/6" viewportClassName="pt-1 pb-2">
         <div className="px-5 pt-3 pb-1">
           <label className="text-[11px] font-semibold text-fg-3 uppercase tracking-[0.12em]">
             {t("sidebar.projects")}
           </label>
         </div>
         <ProjectTabs />
-      </div>
+      </ScrollArea>
 
       {/* Bottom panel */}
       <div>

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -5,6 +5,7 @@ import { useSessionState } from "@/client/entities/session/index.js";
 import type { TreeNode } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { formatCost, formatTokens } from "@/client/shared/pricing.utils.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 import { MessageActionsProvider } from "./MessageActionsContext.js";
 import { useConversation } from "./useConversation.js";
 import { useStreaming } from "./useStreaming.js";
@@ -140,7 +141,7 @@ export function AgentPanel() {
       )}
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto">
+      <ScrollArea className="flex-1">
         <MessageActionsProvider
           switchBranch={switchBranch}
           branchFrom={setReplyTo}
@@ -180,7 +181,7 @@ export function AgentPanel() {
         )}
 
         <div ref={messagesEndRef} />
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/apps/webui/src/client/features/chat/MessageBubble.tsx
+++ b/apps/webui/src/client/features/chat/MessageBubble.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState, type ReactNode } from "react";
 import { AlignLeft, ChevronLeft, ChevronRight } from "lucide-react";
 import type { TreeNode, TextContent, ImageContent, AssistantContentBlock } from "@/client/entities/session/index.js";
 import { useI18n } from "@/client/i18n/index.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 import { UserAvatar, AgentAvatar } from "./Avatars.js";
 import { MessageContent } from "./MessageContent.js";
 
@@ -120,9 +121,9 @@ function CompactSummaryBubble({
       </div>
       {expanded && (
         <div className="mt-1.5 pl-[22px] text-xs text-fg-3/70 border-l-2 border-edge/10 ml-[6px]">
-          <div className="max-h-[300px] overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed p-2">
+          <ScrollArea className="max-h-[300px]" viewportClassName="whitespace-pre-wrap font-mono text-[11px] leading-relaxed p-2">
             {summaryText}
-          </div>
+          </ScrollArea>
         </div>
       )}
     </BubbleWrap>
@@ -203,9 +204,9 @@ function SkillChipBubble({
       ) : chipRow}
       {expanded && (
         <div className="mt-1.5 pl-[22px] text-xs text-fg-3/70 border-l-2 border-edge/10 ml-[6px]">
-          <div className="max-h-[300px] overflow-y-auto whitespace-pre-wrap font-mono text-[11px] leading-relaxed p-2">
+          <ScrollArea className="max-h-[300px]" viewportClassName="whitespace-pre-wrap font-mono text-[11px] leading-relaxed p-2">
             {firstText}
-          </div>
+          </ScrollArea>
         </div>
       )}
     </BubbleWrap>

--- a/apps/webui/src/client/features/chat/SessionTabs.tsx
+++ b/apps/webui/src/client/features/chat/SessionTabs.tsx
@@ -2,6 +2,7 @@ import { ChevronsRight, Plus, X } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useUIDispatch } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 import { useConversation } from "./useConversation.js";
 
 export function SessionTabs() {
@@ -13,9 +14,11 @@ export function SessionTabs() {
   return (
     <div className="flex items-center border-b border-edge/6">
       {/* Scrollable tab area */}
-      <div
-        className="flex-1 flex items-center gap-0.5 px-1.5 py-1.5 overflow-x-auto min-w-0"
-        style={{ scrollbarWidth: "none" }}
+      <ScrollArea
+        orientation="horizontal"
+        hideScrollbar
+        className="flex-1 min-w-0"
+        viewportClassName="flex items-center gap-0.5 px-1.5 py-1.5"
       >
         {session.conversations.map((conv) => {
           const isActive = session.activeConversationId === conv.id;
@@ -55,7 +58,7 @@ export function SessionTabs() {
         >
           <Plus size={12} strokeWidth={2.5} />
         </button>
-      </div>
+      </ScrollArea>
 
       {/* Close panel */}
       <button

--- a/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
+++ b/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { SlashEntry } from "./commands.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 
 interface SlashCommandPopupProps {
   commands: SlashEntry[];
@@ -22,9 +23,9 @@ export function SlashCommandPopup({ commands, selectedIndex, onSelect, onHover }
   if (commands.length === 0) return null;
 
   return (
-    <div
+    <ScrollArea
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated/95 backdrop-blur-md border border-edge/12 rounded-xl shadow-xl shadow-void/60 overflow-y-auto max-h-[240px] animate-fade z-50"
+      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated/95 backdrop-blur-md border border-edge/12 rounded-xl shadow-xl shadow-void/60 max-h-[240px] animate-fade z-50"
     >
       {commands.map((cmd, i) => (
         <button
@@ -49,6 +50,6 @@ export function SlashCommandPopup({ commands, selectedIndex, onSelect, onHover }
           )}
         </button>
       ))}
-    </div>
+    </ScrollArea>
   );
 }

--- a/apps/webui/src/client/features/chat/ToolCallDisplay.tsx
+++ b/apps/webui/src/client/features/chat/ToolCallDisplay.tsx
@@ -1,5 +1,5 @@
 import type { ToolCallContent, ToolCallState } from "@/client/entities/session/index.js";
-import { Indicator } from "@/client/shared/ui/index.js";
+import { Indicator, ScrollArea } from "@/client/shared/ui/index.js";
 
 export function ToolCallDisplay({ block }: { block: ToolCallContent }) {
   return (
@@ -8,9 +8,11 @@ export function ToolCallDisplay({ block }: { block: ToolCallContent }) {
         <Indicator />
         <span className="font-mono text-xs text-accent font-medium">{block.name}</span>
       </div>
-      <pre className="px-3 py-2.5 text-xs text-fg-3 overflow-x-auto max-h-40 font-mono leading-relaxed">
-        {JSON.stringify(block.arguments, null, 2)}
-      </pre>
+      <ScrollArea orientation="horizontal" className="max-h-40">
+        <pre className="px-3 py-2.5 text-xs text-fg-3 font-mono leading-relaxed">
+          {JSON.stringify(block.arguments, null, 2)}
+        </pre>
+      </ScrollArea>
     </div>
   );
 }
@@ -26,9 +28,11 @@ export function StreamingToolCall({ tc }: { tc: ToolCallState }) {
         )}
       </div>
       {tc.inputJson && (
-        <pre className="px-3 py-2.5 text-xs text-fg-3 overflow-x-auto max-h-40 font-mono leading-relaxed">
-          {tc.inputJson}
-        </pre>
+        <ScrollArea orientation="horizontal" className="max-h-40">
+          <pre className="px-3 py-2.5 text-xs text-fg-3 font-mono leading-relaxed">
+            {tc.inputJson}
+          </pre>
+        </ScrollArea>
       )}
     </div>
   );

--- a/apps/webui/src/client/features/editor/FileTree.tsx
+++ b/apps/webui/src/client/features/editor/FileTree.tsx
@@ -9,6 +9,7 @@ import { ContextMenu } from "@base-ui/react/context-menu";
 import { buildTree, FileIcon, type TreeNode } from "@/client/entities/editor/index.js";
 import type { TreeEntry } from "@/client/entities/editor/index.js";
 import { useI18n } from "@/client/i18n/index.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 
 const MENU_POPUP_CLASS =
   "bg-elevated border border-edge/8 rounded-lg shadow-lg shadow-void/50 py-1 z-50";
@@ -40,7 +41,7 @@ export function FileTree({ entries, selectedPath, dirty, onSelect, onDelete, onR
   }, []);
 
   return (
-    <div className="h-full overflow-y-auto overflow-x-hidden py-2 text-[12px] select-none">
+    <ScrollArea className="h-full" viewportClassName="py-2 text-[12px] select-none">
       {tree.map((node) => (
         <TreeItem
           key={node.path}
@@ -55,7 +56,7 @@ export function FileTree({ entries, selectedPath, dirty, onSelect, onDelete, onR
           onReveal={onReveal}
         />
       ))}
-    </div>
+    </ScrollArea>
   );
 }
 

--- a/apps/webui/src/client/features/project/RenderedView.tsx
+++ b/apps/webui/src/client/features/project/RenderedView.tsx
@@ -4,6 +4,7 @@ import { useOutput } from "./useOutput.js";
 import { useProjectState } from "@/client/entities/project/index.js";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useRendererActionDispatch } from "@/client/entities/renderer-action/index.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 
 export function RenderedView() {
   const project = useProjectState();
@@ -70,8 +71,8 @@ export function RenderedView() {
   }, [actionDispatch]);
 
   return (
-    <div ref={containerRef} className="flex-1 overflow-y-auto p-6">
+    <ScrollArea ref={containerRef} className="flex-1" viewportClassName="p-6">
       <div ref={contentRef} className="min-h-full" />
-    </div>
+    </ScrollArea>
   );
 }

--- a/apps/webui/src/client/features/settings/SettingsView.tsx
+++ b/apps/webui/src/client/features/settings/SettingsView.tsx
@@ -4,7 +4,7 @@ import { useUIState, useUIDispatch, type PageRoute } from "@/client/entities/ui/
 import { useConfigState, useConfigDispatch, updateConfig, fetchApiKeys, updateApiKey, deleteApiKey, saveCustomProvider, deleteCustomProvider, fetchProviders, FORMAT_OPTIONS } from "@/client/entities/config/index.js";
 import type { ApiKeyStatus, CustomApiFormat } from "@/client/entities/config/index.js";
 import { useI18n, type LanguagePreference, type TranslationKey } from "@/client/i18n/index.js";
-import { Badge, Button, IconButton, Indicator, SectionHeader, TabBar, Select, FormField, OptionCardGrid, TextInput } from "@/client/shared/ui/index.js";
+import { Badge, Button, IconButton, Indicator, SectionHeader, TabBar, Select, FormField, OptionCardGrid, TextInput, ScrollArea } from "@/client/shared/ui/index.js";
 import { useTheme, useThemeOptions } from "./useTheme.js";
 
 type SettingsTab = "appearance" | "api-keys";
@@ -44,10 +44,10 @@ export function SettingsView() {
       </div>
 
       {/* Content */}
-      <div className="flex-1 min-h-0 overflow-y-auto">
+      <ScrollArea className="flex-1 min-h-0">
         {tab === "appearance" && <AppearanceTab />}
         {tab === "api-keys" && <ApiKeysTab />}
-      </div>
+      </ScrollArea>
     </div>
   );
 }

--- a/apps/webui/src/client/main.css
+++ b/apps/webui/src/client/main.css
@@ -108,7 +108,7 @@ html, body, #root {
 
 /* ── Scrollbar ─────────────────────────────── */
 
-::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar { width: 5px; height: 5px; }
 ::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
   background: var(--color-fg-4);

--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@/client/i18n/index.js";
 import { useUIDispatch } from "@/client/entities/ui/index.js";
 import { fetchTemplates, type TemplateMeta } from "@/client/entities/template/index.js";
 import { useProject } from "@/client/features/project/index.js";
+import { ScrollArea } from "@/client/shared/ui/index.js";
 
 export function TemplatesPage() {
   const { t } = useI18n();
@@ -30,7 +31,7 @@ export function TemplatesPage() {
   }, [nameInput, createProject, uiDispatch]);
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <ScrollArea className="flex-1">
       <div className="max-w-2xl mx-auto px-8 py-12">
         <div className="mb-8">
           <h1 className="font-display text-2xl font-bold tracking-tight mb-2">
@@ -102,6 +103,6 @@ export function TemplatesPage() {
           </div>
         )}
       </div>
-    </div>
+    </ScrollArea>
   );
 }

--- a/apps/webui/src/client/shared/ui/ScrollArea.tsx
+++ b/apps/webui/src/client/shared/ui/ScrollArea.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode, Ref } from "react";
+import { ScrollArea as BaseScrollArea } from "@base-ui/react/scroll-area";
+
+interface ScrollAreaProps {
+  children: ReactNode;
+  /** Which axes to scroll. @default "vertical" */
+  orientation?: "vertical" | "horizontal" | "both";
+  /** Hide scrollbar entirely (invisible scroll like tab strips). @default false */
+  hideScrollbar?: boolean;
+  /** Classes on the Root (sizing/layout: flex-1, max-h-40, etc.) */
+  className?: string;
+  /** Classes on the Viewport (padding, text, interior styles) */
+  viewportClassName?: string;
+  ref?: Ref<HTMLDivElement>;
+}
+
+const scrollbarClass = [
+  "flex touch-none select-none",
+  "data-[orientation=vertical]:w-1.5 data-[orientation=vertical]:py-1",
+  "data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:flex-col data-[orientation=horizontal]:px-1",
+  "opacity-0 transition-opacity duration-200",
+  "data-[hovering]:opacity-100 data-[scrolling]:opacity-100",
+].join(" ");
+
+const thumbClass = [
+  "flex-1 rounded-full",
+  "bg-fg-4 hover:bg-fg-3 transition-colors duration-150",
+].join(" ");
+
+export function ScrollArea({
+  children,
+  orientation = "vertical",
+  hideScrollbar = false,
+  className,
+  viewportClassName,
+  ref,
+}: ScrollAreaProps) {
+  const showVertical = !hideScrollbar && (orientation === "vertical" || orientation === "both");
+  const showHorizontal = !hideScrollbar && (orientation === "horizontal" || orientation === "both");
+
+  return (
+    <BaseScrollArea.Root className={`overflow-hidden ${className ?? ""}`}>
+      <BaseScrollArea.Viewport
+        ref={ref}
+        className={viewportClassName}
+        style={hideScrollbar ? { scrollbarWidth: "none" } : undefined}
+      >
+        {orientation === "both"
+          ? <BaseScrollArea.Content>{children}</BaseScrollArea.Content>
+          : children}
+      </BaseScrollArea.Viewport>
+
+      {showVertical && (
+        <BaseScrollArea.Scrollbar orientation="vertical" className={scrollbarClass}>
+          <BaseScrollArea.Thumb className={thumbClass} />
+        </BaseScrollArea.Scrollbar>
+      )}
+      {showHorizontal && (
+        <BaseScrollArea.Scrollbar orientation="horizontal" className={scrollbarClass}>
+          <BaseScrollArea.Thumb className={thumbClass} />
+        </BaseScrollArea.Scrollbar>
+      )}
+      {showVertical && showHorizontal && <BaseScrollArea.Corner />}
+    </BaseScrollArea.Root>
+  );
+}

--- a/apps/webui/src/client/shared/ui/index.ts
+++ b/apps/webui/src/client/shared/ui/index.ts
@@ -12,3 +12,4 @@ export { IconButton } from "./IconButton.js";
 export { Indicator } from "./Indicator.js";
 export { TextInput } from "./TextInput.js";
 export { OptionCardGrid } from "./OptionCardGrid.js";
+export { ScrollArea } from "./ScrollArea.js";


### PR DESCRIPTION
## Summary

- `@base-ui/react/scroll-area` 기반 공유 `ScrollArea` 컴포넌트를 `shared/ui/`에 도입하여, 클라이언트 전반에 제각각이던 스크롤 처리를 통합
- ToolCallDisplay의 **두꺼운 가로 스크롤바 버그 수정** — 네이티브 스크롤바 대신 6px 커스텀 스크롤바로 교체
- SessionTabs의 inline `scrollbarWidth: "none"` 해킹 제거
- 11개 스크롤 영역 마이그레이션 (AgentPanel, Sidebar, FileTree, SettingsView, TemplatesPage, RenderedView, SlashCommandPopup, MessageBubble x2, ToolCallDisplay x2)

### ScrollArea 컴포넌트 API
- `orientation`: vertical (기본) / horizontal / both
- `hideScrollbar`: 스크롤바 숨김 (SessionTabs 용도)
- `className`: Root 요소 (레이아웃/사이징)
- `viewportClassName`: Viewport 요소 (패딩/내부 스타일)
- `ref`: Viewport에 전달 (auto-scroll, querySelector 등)

### 스크롤바 동작
- macOS overlay 스크롤바 방식: hover/scroll 시 나타나고, idle 시 사라짐
- `data-[hovering]`/`data-[scrolling]` 기반 opacity 전환 (CSS only)
- 크로스 브라우저 일관성 (Firefox에서도 동일 동작)

## Test plan
- [ ] ToolCallDisplay: 긴 JSON argument에서 가로 스크롤바가 얇게 (6px) 표시되는지
- [ ] AgentPanel: 긴 대화에서 세로 스크롤이 body로 넘치지 않고 패널 내부에서 동작하는지
- [ ] SessionTabs: 탭이 많을 때 가로 스크롤이 되되 스크롤바가 보이지 않는지
- [ ] Sidebar: 프로젝트 목록이 많을 때 세로 스크롤 정상 동작
- [ ] 스크롤바 auto-hide: hover/scroll 시 나타나고 idle 시 사라지는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)