### PR TITLE
fix: edit 모드 토글을 AgentPanel 헤더로 이동

### DIFF
--- a/apps/webui/src/client/entities/ui/EditModeToggle.tsx
+++ b/apps/webui/src/client/entities/ui/EditModeToggle.tsx
@@ -1,5 +1,5 @@
 import { PenLine, Eye } from "lucide-react";
-import { useUIState, useUIDispatch, type ViewMode } from "@/client/entities/ui/index.js";
+import { useUIState, useUIDispatch, type ViewMode } from "./UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 
 export function EditModeToggle() {
@@ -15,7 +15,7 @@ export function EditModeToggle() {
   return (
     <button
       onClick={() => uiDispatch({ type: "SET_VIEW_MODE", mode: nextMode })}
-      className="p-2 rounded-lg text-fg-3 hover:text-accent hover:bg-accent/8 transition-all hidden lg:flex"
+      className="p-2 rounded-lg text-fg-3 hover:text-accent hover:bg-accent/8 transition-all"
       title={label}
     >
       <Icon size={16} strokeWidth={2} />

--- a/apps/webui/src/client/entities/ui/index.ts
+++ b/apps/webui/src/client/entities/ui/index.ts
@@ -1,2 +1,3 @@
 export { UIProvider, useUIState, useUIDispatch } from "./UIContext.js";
 export type { UIState, UIAction, PageRoute, ViewMode } from "./UIContext.js";
+export { EditModeToggle } from "./EditModeToggle.js";

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -13,7 +13,6 @@ import { useConversation } from "./useConversation.js";
 import { useSlashCommands } from "./useSlashCommands.js";
 import { SlashCommandPopup } from "./SlashCommandPopup.js";
 import { formatCost, formatTokens } from "@/client/shared/pricing.utils.js";
-import { EditModeToggle } from "@/client/features/editor/EditModeToggle.js";
 
 interface BottomInputProps {
   variant?: "standalone" | "embedded";
@@ -136,16 +135,13 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
             rows={1}
             className="flex-1 bg-transparent px-5 py-3.5 text-sm resize-none focus:outline-none text-fg placeholder-fg-4 max-h-[200px] font-body"
           />
-          <div className="m-1.5 flex items-center gap-1">
-            <EditModeToggle />
-            <button
-              onClick={handleSubmit}
-              disabled={!text.trim() || isStreaming}
-              className="p-2.5 rounded-xl bg-accent text-void disabled:opacity-20 disabled:cursor-not-allowed hover:brightness-110 active:scale-95 transition-all duration-150"
-            >
-              <ArrowUp size={16} strokeWidth={2.5} />
-            </button>
-          </div>
+          <button
+            onClick={handleSubmit}
+            disabled={!text.trim() || isStreaming}
+            className="m-1.5 p-2.5 rounded-xl bg-accent text-void disabled:opacity-20 disabled:cursor-not-allowed hover:brightness-110 active:scale-95 transition-all duration-150"
+          >
+            <ArrowUp size={16} strokeWidth={2.5} />
+          </button>
         </div>
       </div>
       <p className="mt-1.5 text-center text-[11px] text-fg-3 tracking-wide">

--- a/apps/webui/src/client/features/chat/SessionTabs.tsx
+++ b/apps/webui/src/client/features/chat/SessionTabs.tsx
@@ -1,6 +1,6 @@
 import { ChevronsRight, Plus, X } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
-import { useUIDispatch } from "@/client/entities/ui/index.js";
+import { useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { useConversation } from "./useConversation.js";
 
@@ -57,7 +57,7 @@ export function SessionTabs() {
         </button>
       </div>
 
-      {/* Close panel */}
+      <EditModeToggle />
       <button
         onClick={() => uiDispatch({ type: "TOGGLE_AGENT_PANEL" })}
         className="flex-shrink-0 px-2 py-1.5 text-fg-3 hover:text-fg-2 transition-colors"

--- a/apps/webui/src/client/features/editor/index.ts
+++ b/apps/webui/src/client/features/editor/index.ts
@@ -1,6 +1,5 @@
 export { FileTree } from "./FileTree.js";
 export { FileEditor } from "./FileEditor.js";
-export { EditModeToggle } from "./EditModeToggle.js";
 export { EditModePanel } from "./EditModePanel.js";
 export { UnsavedDialog } from "./UnsavedDialog.js";
 export { useEditMode } from "./useEditMode.js";

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useCallback, Suspense, lazy } from "react";
 import { ChevronsLeft } from "lucide-react";
 import { useProjectState } from "@/client/entities/project/index.js";
-import { useUIState } from "@/client/entities/ui/index.js";
+import { useUIState, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { RenderedView } from "@/client/features/project/index.js";
 import { AgentPanel, BottomInput, useConversation } from "@/client/features/chat/index.js";
@@ -90,13 +90,17 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
             {isEdit && <BottomInput variant="embedded" />}
           </div>
         ) : (
-          <button
-            onClick={onToggleAgentPanel}
-            className="hidden lg:flex flex-shrink-0 w-7 items-center justify-center border-l border-edge/6 bg-base/20 hover:bg-accent/8 text-fg-3 hover:text-accent transition-all duration-200 cursor-pointer group"
-            title={t("empty.openAgentPanel")}
-          >
-            <ChevronsLeft size={14} strokeWidth={2} className="group-hover:scale-110 transition-transform" />
-          </button>
+          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20">
+            <EditModeToggle />
+            <div className="flex-1" />
+            <button
+              onClick={onToggleAgentPanel}
+              className="p-2 text-fg-3 hover:text-accent hover:bg-accent/8 transition-all duration-200 cursor-pointer group"
+              title={t("empty.openAgentPanel")}
+            >
+              <ChevronsLeft size={14} strokeWidth={2} className="group-hover:scale-110 transition-transform" />
+            </button>
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- EditModeToggle을 BottomInput 내부에서 SessionTabs 헤더 및 collapsed panel strip으로 이동
- FSD 레이어 규칙 준수를 위해 `features/editor/` → `entities/ui/`로 재배치
- 반응형 클래스(`hidden lg:flex`)를 컴포넌트에서 제거하고 소비자 측에서 제어하도록 변경
- BottomInput의 불필요한 wrapper div 제거

## Test plan
- [ ] Chat 모드: SessionTabs 헤더에 edit 토글 아이콘(PenLine) 표시 확인
- [ ] Edit 토글 클릭 → Edit 모드 전환 확인, 아이콘이 Eye로 변경
- [ ] Edit 모드: SessionTabs 헤더에서 chat 토글(Eye) 클릭 → Chat 모드 복귀
- [ ] AgentPanel 닫기 → collapsed strip 상단에 edit 토글 표시 확인
- [ ] collapsed strip에서 edit 토글 클릭 → 모드 전환 정상 동작
- [ ] BottomInput에 edit 토글이 더 이상 없는지 확인
- [ ] Ctrl+E 키보드 단축키 여전히 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)