### PR TITLE
fix: 템플릿 페이지에서 빠져나갈 수 없는 네비게이션 버그 수정

### DIFF
--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -1,9 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
-import { BookOpen, Plus } from "lucide-react";
+import { ArrowLeft, BookOpen, Plus } from "lucide-react";
 import { useI18n } from "@/client/i18n/index.js";
 import { useUIDispatch } from "@/client/entities/ui/index.js";
 import { fetchTemplates, type TemplateMeta } from "@/client/entities/template/index.js";
 import { useProject } from "@/client/features/project/index.js";
+import { IconButton } from "@/client/shared/ui/index.js";
 
 export function TemplatesPage() {
   const { t } = useI18n();
@@ -30,12 +31,24 @@ export function TemplatesPage() {
   }, [nameInput, createProject, uiDispatch]);
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex flex-col h-full bg-void">
+      {/* Header */}
+      <div className="flex items-center gap-4 px-6 py-4 border-b border-edge/6 bg-base/60">
+        <IconButton
+          onClick={() => uiDispatch({ type: "NAVIGATE", route: { page: "main" } })}
+          title={t("settings.back")}
+        >
+          <ArrowLeft size={16} strokeWidth={2} />
+        </IconButton>
+        <h2 className="font-display text-lg font-bold tracking-tight">
+          {t("templates.title")}
+        </h2>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 min-h-0 overflow-y-auto">
       <div className="max-w-2xl mx-auto px-8 py-12">
         <div className="mb-8">
-          <h1 className="font-display text-2xl font-bold tracking-tight mb-2">
-            {t("templates.title")}
-          </h1>
           <p className="text-sm text-fg-3">
             {t("templates.description")}
           </p>
@@ -101,6 +114,7 @@ export function TemplatesPage() {
             ))}
           </div>
         )}
+      </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- 템플릿 페이지(`TemplatesPage`)에 뒤로가기 버튼이 없어서 사이드바 외에 탈출 방법이 없는 버그 수정
- SettingsView와 동일한 header 패턴(`ArrowLeft` + `IconButton` + `NAVIGATE` dispatch) 적용
- 컨테이너 레이아웃을 `flex flex-col h-full`로 변경하여 header 고정 + content 스크롤 구조 적용

## Test plan
- [ ] 사이드바에서 "Templates" 클릭 → 템플릿 페이지 진입
- [ ] header의 ← 버튼 클릭 → 메인 페이지로 복귀 확인
- [ ] 템플릿 목록이 긴 경우 content 영역만 스크롤되는지 확인
- [ ] 템플릿에서 프로젝트 생성 플로우가 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)