### PR TITLE
fix: ScrollArea Viewport 높이 제약 추가로 스크롤 회귀 수정

### DIFF
--- a/apps/webui/src/client/shared/ui/ScrollArea.tsx
+++ b/apps/webui/src/client/shared/ui/ScrollArea.tsx
@@ -42,7 +42,7 @@ export function ScrollArea({
     <BaseScrollArea.Root className={`overflow-hidden ${className ?? ""}`}>
       <BaseScrollArea.Viewport
         ref={ref}
-        className={viewportClassName}
+        className={`h-full max-h-[inherit] ${viewportClassName ?? ""}`}
         style={hideScrollbar ? { scrollbarWidth: "none" } : undefined}
       >
         {orientation === "both"


### PR DESCRIPTION
## Summary

- 커밋 `6a155ce`(ScrollArea 컴포넌트 도입)에서 `@base-ui/react` Viewport에 높이 제약이 누락되어 모든 수직 스크롤 영역이 동작하지 않던 회귀 버그 수정
- Viewport에 `h-full max-h-[inherit]`를 추가하여 flex-1/h-full 부모(RenderedView, AgentPanel, Sidebar 등)와 max-height 부모(SlashCommandPopup, MessageBubble 등) 모두에서 스크롤 정상 동작
- 변경 파일: `ScrollArea.tsx` 1줄

## 근본 원인

Base UI `ScrollArea.Viewport`는 `overflow: scroll`만 inline style로 적용하고 **높이를 지정하지 않음**. Viewport가 콘텐츠에 맞춰 확장되어 `scrollHeight === clientHeight` → 스크롤 불발. Root의 `overflow: hidden`이 초과분을 잘라내어 콘텐츠가 보이지 않고 스크롤도 불가.

## 수정 방식

| CSS | 역할 | 적용 케이스 |
|-----|------|-----------|
| `h-full` | 부모에 definite height가 있으면 100%로 해석 | flex-1, h-full 부모 (RenderedView, AgentPanel, Sidebar, SettingsView, TemplatesPage, FileTree) |
| `max-h-[inherit]` | 부모의 max-height를 상속 | max-h-* 부모 (SlashCommandPopup, MessageBubble, ToolCallDisplay) |

두 속성 모두 해당 조건이 아닌 경우 `auto`/`none`으로 해석되어 무해.

## Test plan

- [x] RenderedView: 긴 렌더러 출력에서 수직 스크롤 동작 확인 (scrollHeight: 8562 vs clientHeight: 468)
- [x] Sidebar: 프로젝트 목록 스크롤 동작 확인 (scrollHeight: 228 vs clientHeight: 93)
- [x] SlashCommandPopup: `/` 입력 시 팝업 스크롤 동작 확인 (scrollHeight: 400, max-height: 240px)
- [x] `bunx tsc --noEmit` 통과
- [x] `bun run lint` (기존 에러만, 신규 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)