### PR TITLE
feat: novel 템플릿 탭 헤더를 sticky로 고정

### DIFF
--- a/apps/webui/src/client/features/project/RenderedView.tsx
+++ b/apps/webui/src/client/features/project/RenderedView.tsx
@@ -71,8 +71,8 @@ export function RenderedView() {
   }, [actionDispatch]);
 
   return (
-    <ScrollArea ref={containerRef} className="flex-1" viewportClassName="p-6">
-      <div ref={contentRef} className="min-h-full" />
+    <ScrollArea ref={containerRef} className="flex-1">
+      <div ref={contentRef} className="min-h-full p-6" />
     </ScrollArea>
   );
 }

--- a/example_data/library/templates/novel/renderer.ts
+++ b/example_data/library/templates/novel/renderer.ts
@@ -120,6 +120,10 @@ const STYLES = `<style>
     margin-bottom: 32px;
     border-bottom: 1px solid color-mix(in srgb, var(--color-edge) 10%, transparent);
     padding: 0 8px;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background: var(--color-void);
   }
   .rb-tab-label {
     padding: 12px 4px;


### PR DESCRIPTION
## Summary
- novel 템플릿 렌더러의 탭 헤더(이야기/아웃라인/세계 설정/캐릭터)에 `position: sticky` 적용하여 스크롤 시 상단 고정
- RenderedView의 padding을 viewport에서 content div로 이동하여 sticky 헤더가 viewport 최상단에 빈 공간 없이 고정되도록 수정

## 변경 파일
- `example_data/library/templates/novel/renderer.ts` — `.rb-tabs-header`에 sticky 관련 CSS 속성 추가
- `apps/webui/src/client/features/project/RenderedView.tsx` — `p-6` padding을 viewport에서 content div로 이동

## Test plan
- [ ] novel 프로젝트에서 콘텐츠를 스크롤할 때 탭 헤더가 상단에 고정되는지 확인
- [ ] 스크롤 상태에서 탭 전환이 정상 동작하는지 확인
- [ ] 탭 헤더 배경이 불투명하여 콘텐츠가 비치지 않는지 확인
- [ ] 다른 프로젝트(chat, impersonate-chat 등)에서 레이아웃 회귀가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)