### PR TITLE
feat: Vercel AI Gateway provider 지원 추가

### DIFF
--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -2,7 +2,7 @@ import { getProviders, getModels } from "@agentchan/creative-agent";
 import type { ServerConfig, ProviderInfo, CustomProviderDef } from "../types.js";
 import type { SettingsRepo } from "../repositories/settings.repo.js";
 
-const BUILTIN_PROVIDERS = new Set(["google", "google-vertex", "openai", "anthropic"]);
+const BUILTIN_PROVIDERS = new Set(["google", "google-vertex", "openai", "anthropic", "vercel-ai-gateway"]);
 
 const ALLOWED_MODELS = new Set([
   // Anthropic
@@ -20,6 +20,19 @@ const ALLOWED_MODELS = new Set([
   "gpt-5.1",
   "o4-mini",
   "o3-mini",
+  // Vercel AI Gateway
+  "anthropic/claude-opus-4-6",
+  "anthropic/claude-sonnet-4-6",
+  "anthropic/claude-haiku-4-5",
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-mini",
+  "openai/o4-mini",
+  "openai/o3-mini",
+  "google/gemini-3.1-pro-preview",
+  "google/gemini-3-flash",
+  "google/gemini-3.1-flash-lite-preview",
+  "deepseek/deepseek-v3.2",
+  "xai/grok-4.1-fast-non-reasoning",
 ]);
 
 const DEFAULT_PROVIDER = "google";
@@ -92,7 +105,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     let model: string;
     if (providerInfo?.custom) {
       // Custom providers: accept any saved model, fallback to default
-      model = savedModel ?? (providerInfo.defaultModel ?? "");
+      model = savedModel ?? (providerInfo?.defaultModel ?? "");
     } else {
       model = savedModel && ALLOWED_MODELS.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
     }


### PR DESCRIPTION
## Summary
- `BUILTIN_PROVIDERS`에 `vercel-ai-gateway` 추가
- `ALLOWED_MODELS`에 gateway 모델 12개 화이트리스트 (Anthropic 3, OpenAI 4, Google 3, DeepSeek 1, xAI 1)
- pi-ai가 이미 gateway provider의 모델 registry, base URL, API format, reasoning 정보를 제공하므로 추가 인프라 변경 불필요

## Test plan
- [ ] Settings > API Keys에서 `vercel-ai-gateway` provider가 표시되는지 확인
- [ ] gateway 모델 목록이 화이트리스트된 12개만 노출되는지 확인
- [ ] gateway API 키 설정 후 모델 선택하여 채팅 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)