### PR TITLE
feat: 에이전트 파일 수정 롤백을 위한 checkpoint 기능 추가

### DIFF
--- a/apps/webui/src/client/entities/session/SessionContext.tsx
+++ b/apps/webui/src/client/entities/session/SessionContext.tsx
@@ -17,6 +17,9 @@ export interface SessionState {
   activePath: string[];
   replyToNodeId: string | null;
 
+  // Checkpoints (node IDs that have file snapshots)
+  checkpointNodeIds: Set<string>;
+
   // Token usage
   sessionUsage: {
     inputTokens: number;
@@ -39,7 +42,7 @@ export interface SessionState {
 export type SessionAction =
   // Conversation actions
   | { type: "SET_CONVERSATIONS"; conversations: Conversation[] }
-  | { type: "SET_ACTIVE_CONVERSATION"; conversation: Conversation; nodes: TreeNode[]; activePath: string[] }
+  | { type: "SET_ACTIVE_CONVERSATION"; conversation: Conversation; nodes: TreeNode[]; activePath: string[]; checkpointNodeIds?: string[] }
   | { type: "ADD_NODE"; node: TreeNode }
   | { type: "ADD_NODES"; nodes: TreeNode[] }
   | { type: "APPEND_USER_NODE"; node: TreeNode }
@@ -121,6 +124,9 @@ function sessionReducer(state: SessionState, action: SessionAction): SessionStat
         nodes: nodeMap,
         activePath: action.activePath,
         replyToNodeId: null,
+        checkpointNodeIds: action.checkpointNodeIds
+          ? new Set(action.checkpointNodeIds)
+          : state.checkpointNodeIds,
         sessionUsage: {
           inputTokens: totalInput, outputTokens: totalOutput,
           cachedInputTokens: totalCachedInput, cacheCreationTokens: totalCacheCreation,
@@ -168,6 +174,7 @@ function sessionReducer(state: SessionState, action: SessionAction): SessionStat
         nodes: nodeMap,
         activePath: seeded.map((n) => n.id),
         replyToNodeId: null,
+        checkpointNodeIds: new Set(),
         sessionUsage: { ...emptyUsage },
       };
     }
@@ -289,6 +296,7 @@ function sessionReducer(state: SessionState, action: SessionAction): SessionStat
         nodes: new Map(),
         activePath: [],
         replyToNodeId: null,
+        checkpointNodeIds: new Set(),
         sessionUsage: { ...emptyUsage },
         isStreaming: false,
         streamingText: "",
@@ -309,6 +317,7 @@ const initialState: SessionState = {
   nodes: new Map(),
   activePath: [],
   replyToNodeId: null,
+  checkpointNodeIds: new Set(),
   sessionUsage: { ...emptyUsage },
   isStreaming: false,
   streamingText: "",

--- a/apps/webui/src/client/entities/session/session.api.ts
+++ b/apps/webui/src/client/entities/session/session.api.ts
@@ -29,6 +29,7 @@ export function fetchConversation(projectSlug: string, id: string): Promise<{
   conversation: Conversation;
   nodes: TreeNode[];
   activePath: string[];
+  checkpointNodeIds?: string[];
 }> {
   return json(`${projectBase(projectSlug)}/${id}`);
 }
@@ -41,10 +42,10 @@ export function deleteNode(
   projectSlug: string,
   conversationId: string,
   nodeId: string,
+  restoreFiles?: boolean,
 ): Promise<{ activePath: string[]; activeLeafId: string; rootNodeId: string }> {
-  return json(`${projectBase(projectSlug)}/${conversationId}/nodes/${nodeId}`, {
-    method: "DELETE",
-  });
+  const url = `${projectBase(projectSlug)}/${conversationId}/nodes/${nodeId}${restoreFiles ? "?restoreFiles=true" : ""}`;
+  return json(url, { method: "DELETE" });
 }
 
 export function switchBranch(
@@ -174,10 +175,11 @@ export function regenerateResponse(
   conversationId: string,
   userNodeId: string,
   callbacks: SSECallbacks,
+  restoreFiles?: boolean,
 ): Promise<void> {
   return postSSE(
     `${BASE}${projectBase(projectSlug)}/${conversationId}/regenerate`,
-    { userNodeId },
+    { userNodeId, ...(restoreFiles && { restoreFiles: true }) },
     callbacks,
   );
 }

--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState, useCallback } from "react";
 import { CornerUpLeft } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { useSessionState } from "@/client/entities/session/index.js";
@@ -12,6 +12,7 @@ import { useStreaming } from "./useStreaming.js";
 import { SessionTabs } from "./SessionTabs.js";
 import { MessageBubble } from "./MessageBubble.js";
 import { StreamingMessage } from "./StreamingMessage.js";
+import { CheckpointDialog } from "./CheckpointDialog.js";
 
 // ── Model Info Popover ───────────────────────
 
@@ -82,12 +83,60 @@ function ModelInfoPopover({ node }: { node: TreeNode }) {
 
 // ── Agent Panel ───────────────────────────────
 
+// --- Checkpoint key helpers ---
+
+/**
+ * Find the checkpoint key for a regenerate operation.
+ * onRegenerate passes node.parentId which may not be a user node
+ * (e.g., it could be a toolResult in a multi-step turn).
+ * Walk up to find the user node, then return its first assistant child.
+ */
+function getCheckpointKeyForRegenerate(
+  parentNodeId: string,
+  nodes: Map<string, TreeNode>,
+): string | null {
+  // Walk up to find the user node that started this turn
+  let userNodeId = parentNodeId;
+  let node = nodes.get(userNodeId);
+  while (node && node.message.role !== "user") {
+    if (!node.parentId) return null;
+    userNodeId = node.parentId;
+    node = nodes.get(userNodeId);
+  }
+  if (!node) return null;
+
+  // Return the first assistant child of the user node
+  if (!node.children?.length) return null;
+  return node.activeChildId ?? node.children[node.children.length - 1];
+}
+
+function getCheckpointKeyForDelete(
+  nodeId: string,
+  nodes: Map<string, TreeNode>,
+): string | null {
+  let current = nodeId;
+  while (current) {
+    const node = nodes.get(current);
+    if (!node?.parentId) return null;
+    const parent = nodes.get(node.parentId);
+    if (parent && parent.message.role === "user") return current;
+    current = node.parentId;
+  }
+  return null;
+}
+
 export function AgentPanel() {
   const session = useSessionState();
   const { t } = useI18n();
   const { switchBranch, setReplyTo, deleteNode } = useConversation();
   const { regenerate } = useStreaming();
   const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  // Checkpoint dialog state
+  const [cpDialog, setCpDialog] = useState<{
+    type: "regenerate" | "delete";
+    nodeId: string;
+  } | null>(null);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
@@ -98,6 +147,31 @@ export function AgentPanel() {
     const parent = session.nodes.get(node.parentId);
     return parent?.children ?? [node.id];
   };
+
+  // Checkpoint-aware action wrappers
+  const handleRegenerate = useCallback(
+    (userNodeId: string) => {
+      const key = getCheckpointKeyForRegenerate(userNodeId, session.nodes);
+      if (key && session.checkpointNodeIds.has(key)) {
+        setCpDialog({ type: "regenerate", nodeId: userNodeId });
+      } else {
+        void regenerate(userNodeId);
+      }
+    },
+    [session.nodes, session.checkpointNodeIds, regenerate],
+  );
+
+  const handleDelete = useCallback(
+    (nodeId: string) => {
+      const key = getCheckpointKeyForDelete(nodeId, session.nodes);
+      if (key && session.checkpointNodeIds.has(key)) {
+        setCpDialog({ type: "delete", nodeId });
+      } else {
+        void deleteNode(nodeId);
+      }
+    },
+    [session.nodes, session.checkpointNodeIds, deleteNode],
+  );
 
   if (!session.activeConversationId) {
     return (
@@ -115,8 +189,8 @@ export function AgentPanel() {
   const actions = {
     onSwitchBranch: switchBranch,
     onBranchFrom: setReplyTo,
-    onDelete: deleteNode,
-    onRegenerate: regenerate,
+    onDelete: handleDelete,
+    onRegenerate: handleRegenerate,
   };
 
   return (
@@ -145,8 +219,8 @@ export function AgentPanel() {
         <MessageActionsProvider
           switchBranch={switchBranch}
           branchFrom={setReplyTo}
-          deleteNode={deleteNode}
-          regenerate={regenerate}
+          deleteNode={handleDelete}
+          regenerate={handleRegenerate}
           isStreaming={session.isStreaming}
         >
           {session.activePath.map((nodeId) => {
@@ -182,6 +256,21 @@ export function AgentPanel() {
 
         <div ref={messagesEndRef} />
       </ScrollArea>
+
+      <CheckpointDialog
+        open={cpDialog !== null}
+        onConversationOnly={() => {
+          if (cpDialog?.type === "regenerate") void regenerate(cpDialog.nodeId);
+          else if (cpDialog?.type === "delete") void deleteNode(cpDialog.nodeId);
+          setCpDialog(null);
+        }}
+        onWithFiles={() => {
+          if (cpDialog?.type === "regenerate") void regenerate(cpDialog.nodeId, true);
+          else if (cpDialog?.type === "delete") void deleteNode(cpDialog.nodeId, true);
+          setCpDialog(null);
+        }}
+        onCancel={() => setCpDialog(null)}
+      />
     </div>
   );
 }

--- a/apps/webui/src/client/features/chat/CheckpointDialog.tsx
+++ b/apps/webui/src/client/features/chat/CheckpointDialog.tsx
@@ -1,0 +1,43 @@
+import { Dialog } from "@/client/shared/ui/Dialog.js";
+import { Button } from "@/client/shared/ui/index.js";
+import { useI18n } from "@/client/i18n/index.js";
+
+interface CheckpointDialogProps {
+  open: boolean;
+  onConversationOnly: () => void;
+  onWithFiles: () => void;
+  onCancel: () => void;
+}
+
+export function CheckpointDialog({
+  open,
+  onConversationOnly,
+  onWithFiles,
+  onCancel,
+}: CheckpointDialogProps) {
+  const { t } = useI18n();
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onCancel(); }}>
+      <div className="p-6 space-y-4">
+        <h3 className="font-display text-lg font-bold text-fg">
+          {t("checkpoint.title")}
+        </h3>
+        <p className="text-sm text-fg-2">
+          {t("checkpoint.message")}
+        </p>
+        <div className="flex justify-end gap-3">
+          <Button variant="ghost" onClick={onCancel}>
+            {t("common.cancel")}
+          </Button>
+          <Button variant="ghost" onClick={onConversationOnly}>
+            {t("checkpoint.conversationOnly")}
+          </Button>
+          <Button variant="accent" onClick={onWithFiles}>
+            {t("checkpoint.withFiles")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}

--- a/apps/webui/src/client/features/chat/useConversation.ts
+++ b/apps/webui/src/client/features/chat/useConversation.ts
@@ -33,6 +33,7 @@ export function useConversation() {
         conversation: data.conversation,
         nodes: data.nodes,
         activePath: data.activePath,
+        checkpointNodeIds: data.checkpointNodeIds,
       });
     },
     [projectState.activeProjectSlug, sessionDispatch],
@@ -63,15 +64,16 @@ export function useConversation() {
   );
 
   const deleteNode = useCallback(
-    async (nodeId: string) => {
+    async (nodeId: string, restoreFiles?: boolean) => {
       if (!sessionState.activeConversationId || !projectState.activeProjectSlug) return;
-      await apiDeleteNode(projectState.activeProjectSlug, sessionState.activeConversationId, nodeId);
+      await apiDeleteNode(projectState.activeProjectSlug, sessionState.activeConversationId, nodeId, restoreFiles);
       const data = await fetchConversation(projectState.activeProjectSlug, sessionState.activeConversationId);
       sessionDispatch({
         type: "SET_ACTIVE_CONVERSATION",
         conversation: data.conversation,
         nodes: data.nodes,
         activePath: data.activePath,
+        checkpointNodeIds: data.checkpointNodeIds,
       });
     },
     [sessionState.activeConversationId, projectState.activeProjectSlug, sessionDispatch],

--- a/apps/webui/src/client/features/chat/useStreaming.ts
+++ b/apps/webui/src/client/features/chat/useStreaming.ts
@@ -37,7 +37,7 @@ export function useStreaming() {
       },
       onDone: () => {
         void fetchConversation(projectSlug, conversationId).then((data) => {
-          sessionDispatch({ type: "SET_ACTIVE_CONVERSATION", conversation: data.conversation, nodes: data.nodes, activePath: data.activePath });
+          sessionDispatch({ type: "SET_ACTIVE_CONVERSATION", conversation: data.conversation, nodes: data.nodes, activePath: data.activePath, checkpointNodeIds: data.checkpointNodeIds });
         }).catch(() => { /* keep current state */ });
       },
       onError: (message) => {
@@ -78,7 +78,7 @@ export function useStreaming() {
   );
 
   const regenerate = useCallback(
-    async (userNodeId: string) => {
+    async (userNodeId: string, restoreFiles?: boolean) => {
       const p = projectStateRef.current;
       const s = sessionStateRef.current;
       if (!s.activeConversationId || !p.activeProjectSlug || s.isStreaming) return;
@@ -87,6 +87,7 @@ export function useStreaming() {
       await regenerateResponse(
         p.activeProjectSlug, s.activeConversationId, userNodeId,
         makeCallbacks(p.activeProjectSlug, s.activeConversationId),
+        restoreFiles,
       );
     },
     [sessionDispatch, makeCallbacks],

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -190,6 +190,12 @@ export const translations = {
   // Project settings modal
   "projectModal.title": "Project Settings",
 
+  // Checkpoint
+  "checkpoint.title": "Restore files?",
+  "checkpoint.message": "The agent modified files during this turn. Would you also like to restore them?",
+  "checkpoint.conversationOnly": "Conversation only",
+  "checkpoint.withFiles": "Restore files too",
+
   // Edit mode
   "editMode.switchToEdit": "Edit mode",
   "editMode.switchToChat": "Chat mode",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -192,7 +192,12 @@ export const translations: Record<TranslationKey, string> = {
   // Project settings modal
   "projectModal.title": "프로젝트 설정",
 
-  // Edit mode
+  // Checkpoint
+  "checkpoint.title": "파일 복원",
+  "checkpoint.message": "이 턴에서 에이전트가 파일을 수정했습니다. 파일도 복원하시겠습니까?",
+  "checkpoint.conversationOnly": "대화만",
+  "checkpoint.withFiles": "파일도 복원",
+
   "editMode.switchToEdit": "편집 모드",
   "editMode.switchToChat": "채팅 모드",
   "editMode.selectFile": "편집할 파일을 선택하세요",

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
-import { createAgentContext, type ResolvedAgentConfig } from "@agentchan/creative-agent";
+import { createAgentContext, createCheckpointStore, type ResolvedAgentConfig } from "@agentchan/creative-agent";
 import { CLIENT_DIR, DATA_DIR, PROJECTS_DIR, LIBRARY_DIR, isDev } from "./paths.js";
 import type { AppEnv } from "./types.js";
 
@@ -39,8 +39,10 @@ const projectService = createProjectService(projectRepo, templateRepo, PROJECTS_
 const skillService = createSkillService(projectSkillRepo, PROJECTS_DIR);
 
 // ===== 2b. Agent context (stateless handle) =====
+const checkpointStore = createCheckpointStore();
 const agentContext = createAgentContext({
   projectsDir: PROJECTS_DIR,
+  checkpointStore,
   resolveAgentConfig: (): ResolvedAgentConfig => {
     const cfg = configService.getConfig();
     const providerInfo = configService.findProvider(cfg.provider);

--- a/apps/webui/src/server/routes/conversations.routes.ts
+++ b/apps/webui/src/server/routes/conversations.routes.ts
@@ -19,13 +19,14 @@ export function createConversationRoutes() {
     return c.json(await c.get("conversationService").create(slug, body.mode), 201);
   });
 
-  // Load conversation tree
+  // Load conversation tree + checkpoint info
   app.get("/:id", async (c) => {
     const slug = c.req.param("slug")!;
     const id = c.req.param("id");
     const result = await c.get("conversationService").get(slug, id);
     if (!result) return c.json({ error: "Conversation not found" }, 404);
-    return c.json(result);
+    const checkpointNodeIds = c.get("conversationService").getCheckpointNodeIds(id);
+    return c.json({ ...result, checkpointNodeIds });
   });
 
   // Delete conversation
@@ -36,13 +37,17 @@ export function createConversationRoutes() {
     return c.json({ ok: true });
   });
 
-  // Delete node (and all descendants)
+  // Delete node (and all descendants), optionally restoring files from checkpoint
   app.delete("/:id/nodes/:nodeId", async (c) => {
     const slug = c.req.param("slug")!;
     const conversationId = c.req.param("id");
     const nodeId = c.req.param("nodeId");
+    const restoreFiles = c.req.query("restoreFiles") === "true";
 
     try {
+      if (restoreFiles) {
+        await c.get("conversationService").restoreCheckpointForNode(slug, conversationId, nodeId);
+      }
       const result = await c.get("conversationService").deleteSubtree(slug, conversationId, nodeId);
       return c.json(result);
     } catch (e) {
@@ -64,11 +69,15 @@ export function createConversationRoutes() {
     });
   });
 
-  // Regenerate response (SSE stream)
+  // Regenerate response (SSE stream), optionally restoring files from checkpoint
   app.post("/:id/regenerate", async (c) => {
     const slug = c.req.param("slug")!;
     const conversationId = c.req.param("id");
-    const { userNodeId } = await c.req.json<{ userNodeId: string }>();
+    const { userNodeId, restoreFiles } = await c.req.json<{ userNodeId: string; restoreFiles?: boolean }>();
+
+    if (restoreFiles) {
+      await c.get("conversationService").restoreCheckpointForRegenerate(slug, conversationId, userNodeId);
+    }
 
     return streamSSE(c, async (stream) => {
       await c.get("agentService").regenerate(stream, slug, conversationId, userNodeId);

--- a/apps/webui/src/server/services/conversation.service.ts
+++ b/apps/webui/src/server/services/conversation.service.ts
@@ -1,12 +1,51 @@
+import { join } from "node:path";
 import {
   type AgentContext,
   type SessionMode,
+  type TreeNodeWithChildren,
   createConversation,
   deleteConversation,
   compactConversation,
+  restoreCheckpoint,
 } from "@agentchan/creative-agent";
 
+/**
+ * Walk up the tree from nodeId to find the checkpoint key:
+ * the first node whose parent is a user node (i.e., the first assistant
+ * child of the user node that started the turn).
+ */
+function findCheckpointKey(
+  tree: Map<string, TreeNodeWithChildren>,
+  nodeId: string,
+): string | null {
+  let current = nodeId;
+  while (current) {
+    const node = tree.get(current);
+    if (!node?.parentId) return null;
+    const parent = tree.get(node.parentId);
+    if (parent && parent.message.role === "user") return current;
+    current = node.parentId;
+  }
+  return null;
+}
+
 export function createConversationService(ctx: AgentContext) {
+  /**
+   * Restore files from a checkpoint, given any node in the turn.
+   * Walks up to find the checkpoint key, then restores files.
+   */
+  async function tryRestoreCheckpoint(slug: string, conversationId: string, nodeId: string): Promise<void> {
+    if (!ctx.checkpointStore) return;
+    const loaded = await ctx.storage.loadConversationWithTree(slug, conversationId);
+    if (!loaded) return;
+
+    const checkpointKey = findCheckpointKey(loaded.tree, nodeId);
+    if (checkpointKey) {
+      const projectDir = join(ctx.projectsDir, slug);
+      await restoreCheckpoint(projectDir, ctx.checkpointStore, checkpointKey);
+    }
+  }
+
   return {
     list: (slug: string) => ctx.storage.listConversations(slug),
 
@@ -26,6 +65,15 @@ export function createConversationService(ctx: AgentContext) {
 
     switchBranch: (slug: string, conversationId: string, nodeId: string) =>
       ctx.storage.switchBranch(slug, conversationId, nodeId),
+
+    // --- Checkpoint ---
+
+    getCheckpointNodeIds: (conversationId: string): string[] =>
+      ctx.checkpointStore?.listForConversation(conversationId) ?? [],
+
+    restoreCheckpointForNode: tryRestoreCheckpoint,
+
+    restoreCheckpointForRegenerate: tryRestoreCheckpoint,
   };
 }
 

--- a/packages/creative-agent/src/agent/context.ts
+++ b/packages/creative-agent/src/agent/context.ts
@@ -7,6 +7,7 @@
 
 import { join } from "node:path";
 import { createConversationStorage, type ConversationStorage } from "../conversation/storage.js";
+import type { CheckpointStore } from "../checkpoint/index.js";
 import type { ResolvedAgentConfig } from "./config.js";
 
 export interface AgentContext {
@@ -14,11 +15,14 @@ export interface AgentContext {
   /** Absolute path to the projects root — agent functions resolve per-project skill paths from here. */
   projectsDir: string;
   resolveAgentConfig: () => ResolvedAgentConfig;
+  /** In-memory checkpoint store for file snapshot tracking. Optional — when absent, no checkpointing. */
+  checkpointStore?: CheckpointStore;
 }
 
 export interface AgentContextOptions {
   projectsDir: string;
   resolveAgentConfig: () => ResolvedAgentConfig;
+  checkpointStore?: CheckpointStore;
 }
 
 export function createAgentContext(opts: AgentContextOptions): AgentContext {
@@ -26,6 +30,7 @@ export function createAgentContext(opts: AgentContextOptions): AgentContext {
     storage: createConversationStorage(opts.projectsDir),
     projectsDir: opts.projectsDir,
     resolveAgentConfig: opts.resolveAgentConfig,
+    checkpointStore: opts.checkpointStore,
   };
 }
 

--- a/packages/creative-agent/src/agent/lifecycle.ts
+++ b/packages/creative-agent/src/agent/lifecycle.ts
@@ -46,6 +46,7 @@ export async function deleteConversation(
   id: string,
 ): Promise<void> {
   clearConversationAgentState(id);
+  ctx.checkpointStore?.clearConversation(id);
   await ctx.storage.deleteConversation(slug, id);
 }
 

--- a/packages/creative-agent/src/agent/orchestrator.ts
+++ b/packages/creative-agent/src/agent/orchestrator.ts
@@ -7,7 +7,7 @@
 
 import { Agent, type AgentMessage, type AgentEvent } from "@mariozechner/pi-agent-core";
 import { getModel, getEnvApiKey, streamSimple, type AssistantMessage, type Message, type ThinkingLevel } from "@mariozechner/pi-ai";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { readFile } from "node:fs/promises";
 
 import { createProjectTools } from "../tools/index.js";
@@ -17,6 +17,7 @@ import { generateCatalog } from "../skills/catalog.js";
 import { createActivateSkillTool } from "../skills/manager.js";
 import type { SkillMetadata, SkillEnvironment, SkillRecord } from "../skills/types.js";
 import type { SessionMode } from "../conversation/format.js";
+import type { FileChangeTracker } from "../checkpoint/index.js";
 import { microCompact, clearCompactState } from "./compact.js";
 import type { ResolvedAgentConfig } from "./config.js";
 import { analyzeContext } from "./context-analysis.js";
@@ -165,6 +166,7 @@ export async function setupCreativeAgent(
   history: AgentMessage[],
   conversationId: string,
   sessionMode?: SessionMode,
+  tracker?: FileChangeTracker,
 ): Promise<CreativeAgentSetup> {
   const allSkills = await discoverProjectSkills(join(projectDir, "skills"));
   const env: SkillEnvironment = sessionMode === "meta" ? "meta" : "creative";
@@ -179,6 +181,26 @@ export async function setupCreativeAgent(
 
   // Build tools
   const tools: any[] = createProjectTools(projectDir);
+
+  // Wrap file-modifying tools for checkpoint tracking
+  if (tracker) {
+    const TRACKED_TOOLS = new Set(["write", "edit", "append"]);
+    for (const tool of tools) {
+      if (TRACKED_TOOLS.has(tool.name)) {
+        const original = tool.execute.bind(tool);
+        tool.execute = async (
+          toolCallId: string,
+          params: { file_path: string; [k: string]: unknown },
+          signal?: AbortSignal,
+          onUpdate?: unknown,
+        ) => {
+          await tracker.recordBeforeWrite(resolve(projectDir, params.file_path));
+          return original(toolCallId, params, signal, onUpdate);
+        };
+      }
+    }
+  }
+
   if (envSkills.size > 0) tools.push(createActivateSkillTool(envSkills, projectDir));
   if (sessionMode === "meta") tools.push(createValidateRendererTool(projectDir));
 

--- a/packages/creative-agent/src/agent/prompt.ts
+++ b/packages/creative-agent/src/agent/prompt.ts
@@ -11,6 +11,7 @@ import type {
   TreeNode,
   TreeNodeWithChildren,
 } from "../types.js";
+import { createFileChangeTracker } from "../checkpoint/tracker.js";
 import type { SessionMode } from "../conversation/format.js";
 import {
   pathToNode,
@@ -24,6 +25,7 @@ import {
   joinUserNodeText,
 } from "./build.js";
 import { summarizeTurnUsage } from "./usage.js";
+import * as log from "../logger.js";
 
 // --- Public types ---
 
@@ -224,12 +226,18 @@ async function runAgentTurn(args: AgentTurnArgs): Promise<void> {
     : [];
   const history = flattenPathToMessages(tree, historyPath);
 
+  // Create file change tracker for checkpoint if store is available
+  const tracker = ctx.checkpointStore
+    ? createFileChangeTracker(projectDir)
+    : undefined;
+
   const { agent, historyLength } = await setupCreativeAgent(
     cfg,
     projectDir,
     history,
     conversationId,
     args.sessionMode,
+    tracker,
   );
 
   let lastNodeId = args.promptParentId;
@@ -288,6 +296,13 @@ async function runAgentTurn(args: AgentTurnArgs): Promise<void> {
 
   for (const node of newNodes) {
     await persistAndInsertNode(ctx, slug, conversationId, tree, node);
+  }
+
+  // Save checkpoint if any files were modified during this turn
+  if (tracker?.hasChanges() && ctx.checkpointStore && newNodes.length > 0) {
+    const snapshots = tracker.getSnapshots();
+    ctx.checkpointStore.save(conversationId, newNodes[0].id, snapshots);
+    log.info("checkpoint", `saved ${snapshots.length} file snapshot(s) for node ${newNodes[0].id}`);
   }
 
   if (turnUsage) emit({ type: "usage_summary", usage: turnUsage });

--- a/packages/creative-agent/src/checkpoint/index.ts
+++ b/packages/creative-agent/src/checkpoint/index.ts
@@ -1,0 +1,6 @@
+export type { FileSnapshot } from "./types.js";
+export type { CheckpointStore } from "./store.js";
+export { createCheckpointStore } from "./store.js";
+export type { FileChangeTracker } from "./tracker.js";
+export { createFileChangeTracker } from "./tracker.js";
+export { restoreCheckpoint } from "./restore.js";

--- a/packages/creative-agent/src/checkpoint/restore.ts
+++ b/packages/creative-agent/src/checkpoint/restore.ts
@@ -1,0 +1,41 @@
+/**
+ * Restore files to their pre-modification state using checkpoint snapshots.
+ * Failures are logged and skipped — conversation rollback proceeds regardless.
+ */
+
+import { join } from "node:path";
+import { writeFile, unlink } from "node:fs/promises";
+import type { CheckpointStore } from "./store.js";
+import * as log from "../logger.js";
+
+export async function restoreCheckpoint(
+  projectDir: string,
+  store: CheckpointStore,
+  nodeId: string,
+): Promise<string[]> {
+  const snapshots = store.get(nodeId);
+  if (!snapshots || snapshots.length === 0) return [];
+
+  const results = await Promise.allSettled(
+    snapshots.map(async (snap) => {
+      const absPath = join(projectDir, snap.path);
+      if (snap.action === "created") {
+        await unlink(absPath);
+      } else if (snap.originalContent !== null) {
+        await writeFile(absPath, snap.originalContent, "utf-8");
+      }
+      return snap.path;
+    }),
+  );
+
+  const restored: string[] = [];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    if (r.status === "fulfilled") {
+      restored.push(r.value);
+    } else {
+      log.warn("checkpoint", `restore failed for ${snapshots[i].path}: ${r.reason instanceof Error ? r.reason.message : String(r.reason)}`);
+    }
+  }
+  return restored;
+}

--- a/packages/creative-agent/src/checkpoint/store.ts
+++ b/packages/creative-agent/src/checkpoint/store.ts
@@ -1,0 +1,56 @@
+/**
+ * In-memory checkpoint store — holds file snapshots keyed by assistant node ID.
+ *
+ * Two maps for O(1) lookup:
+ * - files: nodeId → FileSnapshot[] (per-turn snapshots)
+ * - byConversation: conversationId → Set<nodeId> (reverse index for listing)
+ *
+ * Memory-only: cleared on server restart. No disk I/O.
+ */
+
+import type { FileSnapshot } from "./types.js";
+
+export interface CheckpointStore {
+  /** Save file snapshots for a turn, keyed by the first assistant node ID. */
+  save(conversationId: string, nodeId: string, files: FileSnapshot[]): void;
+  /** Get file snapshots for a specific node. */
+  get(nodeId: string): FileSnapshot[] | undefined;
+  /** List all checkpoint node IDs for a conversation. */
+  listForConversation(conversationId: string): string[];
+  /** Clear all checkpoints for a conversation (e.g., on conversation delete). */
+  clearConversation(conversationId: string): void;
+}
+
+export function createCheckpointStore(): CheckpointStore {
+  const files = new Map<string, FileSnapshot[]>();
+  const byConversation = new Map<string, Set<string>>();
+
+  return {
+    save(conversationId, nodeId, snapshots) {
+      files.set(nodeId, snapshots);
+      let set = byConversation.get(conversationId);
+      if (!set) {
+        set = new Set();
+        byConversation.set(conversationId, set);
+      }
+      set.add(nodeId);
+    },
+
+    get(nodeId) {
+      return files.get(nodeId);
+    },
+
+    listForConversation(conversationId) {
+      const set = byConversation.get(conversationId);
+      return set ? [...set] : [];
+    },
+
+    clearConversation(conversationId) {
+      const set = byConversation.get(conversationId);
+      if (set) {
+        for (const nodeId of set) files.delete(nodeId);
+        byConversation.delete(conversationId);
+      }
+    },
+  };
+}

--- a/packages/creative-agent/src/checkpoint/tracker.ts
+++ b/packages/creative-agent/src/checkpoint/tracker.ts
@@ -1,0 +1,51 @@
+/**
+ * FileChangeTracker — captures original file content before tool modifications.
+ *
+ * Used within a single agent turn. The Map key is the relative path, so
+ * multiple writes to the same file in one turn only capture the first
+ * (original) content — the undo-log pattern.
+ */
+
+import { readFile } from "node:fs/promises";
+import { relative, resolve } from "node:path";
+import type { FileSnapshot } from "./types.js";
+
+export interface FileChangeTracker {
+  /**
+   * Record the current state of a file before it is modified.
+   * Call this with the absolute path; the tracker resolves the relative path internally.
+   * Skips if the file is already tracked (idempotent per path).
+   */
+  recordBeforeWrite(absolutePath: string): Promise<void>;
+  /** Return all captured snapshots. */
+  getSnapshots(): FileSnapshot[];
+  /** Whether any file changes were recorded. */
+  hasChanges(): boolean;
+}
+
+export function createFileChangeTracker(projectDir: string): FileChangeTracker {
+  const tracked = new Map<string, FileSnapshot>();
+
+  return {
+    async recordBeforeWrite(absolutePath: string) {
+      const rel = relative(projectDir, resolve(absolutePath));
+      if (tracked.has(rel)) return; // already tracked — keep first snapshot
+
+      try {
+        const content = await readFile(absolutePath, "utf-8");
+        tracked.set(rel, { path: rel, action: "modified", originalContent: content });
+      } catch {
+        // File does not exist yet — will be created by the tool
+        tracked.set(rel, { path: rel, action: "created", originalContent: null });
+      }
+    },
+
+    getSnapshots() {
+      return [...tracked.values()];
+    },
+
+    hasChanges() {
+      return tracked.size > 0;
+    },
+  };
+}

--- a/packages/creative-agent/src/checkpoint/types.ts
+++ b/packages/creative-agent/src/checkpoint/types.ts
@@ -1,0 +1,12 @@
+/**
+ * Checkpoint types — file snapshot data captured before agent tool modifications.
+ */
+
+export interface FileSnapshot {
+  /** Relative path from project directory (e.g., "files/characters/elara.md") */
+  path: string;
+  /** "modified" = existing file was changed, "created" = new file was created */
+  action: "modified" | "created";
+  /** Original content before modification. null for newly created files. */
+  originalContent: string | null;
+}

--- a/packages/creative-agent/src/index.ts
+++ b/packages/creative-agent/src/index.ts
@@ -1,3 +1,7 @@
+// Checkpoint
+export type { FileSnapshot, CheckpointStore } from "./checkpoint/index.js";
+export { createCheckpointStore, restoreCheckpoint } from "./checkpoint/index.js";
+
 // Skills
 export { discoverProjectSkills } from "./skills/discovery.js";
 export type { SkillMetadata, SkillEnvironment } from "./skills/types.js";


### PR DESCRIPTION
## Summary
- 매 에이전트 턴마다 write/edit/append 도구의 파일 변경을 자동 추적하여 메모리에 원본 스냅샷 저장
- 재생성(retry)/삭제 시 dialog로 "대화만 롤백" vs "파일도 복원" 선택 가능
- 파일 변경이 없는 턴에서는 기존 동작 유지 (dialog 미표시)

## 구현 상세

### creative-agent 패키지
- `checkpoint/tracker.ts` — 도구 래핑으로 write 전 원본 파일 내용 캡처 (undo-log 패턴)
- `checkpoint/store.ts` — 메모리 전용 CheckpointStore (nodeId → FileSnapshot[] + conversationId 역인덱스)
- `checkpoint/restore.ts` — 병렬 파일 복원 (Promise.allSettled), 실패 시 경고 로그 후 계속 진행
- `agent/orchestrator.ts` — write/edit/append 도구의 execute를 래핑하여 변경 추적
- `agent/prompt.ts` — 턴 완료 후 checkpoint 자동 저장

### webui 서버
- `GET /conversations/:id` 응답에 `checkpointNodeIds` 추가
- `DELETE /nodes/:nodeId?restoreFiles=true` — 파일 복원 후 삭제
- `POST /regenerate` body에 `restoreFiles` 파라미터 추가

### webui 클라이언트
- `CheckpointDialog` — "파일 복원" / "대화만" / "파일도 복원" 선택 dialog
- `AgentPanel` — checkpoint 존재 여부 감지 후 retry/delete에서 dialog 표시
- `SessionContext` — `checkpointNodeIds` 상태 관리

## 제약사항
- 메모리 전용 저장: 서버 재시작 시 checkpoint 유실 (graceful degradation — dialog 미표시)
- `script` 도구의 파일 변경은 추적 불가 (write/edit/append만 추적)
- 바이너리 파일 제외 (현재 도구가 utf-8 텍스트만 처리)

## Test plan
- [x] 빌드 검증 (`bunx tsc --noEmit` + `bun run lint` 통과)
- [x] 파일 변경 없는 턴: dialog 없이 기존 동작 수행
- [x] 파일 변경 있는 턴: retry/delete 시 dialog 표시
- [x] "파일도 복원" 선택 시 파일 복원 + 노드 삭제 확인
- [x] 서버 재시작 후 graceful degradation 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)