### PR TITLE
test: add unit tests for core pure-logic modules

### DIFF
--- a/packages/creative-agent/tests/conversation/format.test.ts
+++ b/packages/creative-agent/tests/conversation/format.test.ts
@@ -1,0 +1,343 @@
+import { describe, test, expect } from "bun:test";
+import {
+  parseConversationFile,
+  buildTreeMap,
+  deriveConversation,
+  serializeConversation,
+} from "../../src/conversation/format.js";
+import type { TreeNode } from "../../src/types.js";
+
+// --- Helpers ---
+
+function makeTreeNode(
+  id: string,
+  parentId: string | null,
+  role: "user" | "assistant" = "user",
+  text = `msg-${id}`,
+  overrides: Partial<TreeNode> = {},
+): TreeNode {
+  return {
+    id,
+    parentId,
+    message: role === "assistant"
+      ? { role: "assistant", content: [{ type: "text", text }], provider: "google", model: "gemini-test" } as any
+      : { role: "user", content: [{ type: "text", text }] } as any,
+    createdAt: 1000 + parseInt(id.replace(/\D/g, "") || "0") * 100,
+    ...overrides,
+  };
+}
+
+const HEADER_LINE = JSON.stringify({
+  _header: true,
+  createdAt: 1000,
+  provider: "google",
+  model: "gemini-test",
+});
+
+function buildJSONL(...lines: string[]): string {
+  return lines.join("\n") + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// parseConversationFile
+// ---------------------------------------------------------------------------
+
+describe("parseConversationFile", () => {
+  test("parses header + nodes", () => {
+    const node1 = makeTreeNode("n1", null);
+    const node2 = makeTreeNode("n2", "n1");
+    const content = buildJSONL(HEADER_LINE, JSON.stringify(node1), JSON.stringify(node2));
+
+    const result = parseConversationFile(content);
+
+    expect(result.header).not.toBeNull();
+    expect(result.header!._header).toBe(true);
+    expect(result.header!.provider).toBe("google");
+    expect(result.headerLine).toBe(HEADER_LINE);
+    expect(result.nodes).toHaveLength(2);
+    expect(result.nodes[0].id).toBe("n1");
+    expect(result.nodes[1].id).toBe("n2");
+  });
+
+  test("parses nodes without header", () => {
+    const node = makeTreeNode("n1", null);
+    const content = buildJSONL(JSON.stringify(node));
+
+    const result = parseConversationFile(content);
+
+    expect(result.header).toBeNull();
+    expect(result.headerLine).toBeNull();
+    expect(result.nodes).toHaveLength(1);
+  });
+
+  test("handles empty content", () => {
+    const result = parseConversationFile("");
+    expect(result.header).toBeNull();
+    expect(result.nodes).toEqual([]);
+  });
+
+  test("handles whitespace-only content", () => {
+    const result = parseConversationFile("  \n  \n  ");
+    expect(result.header).toBeNull();
+    expect(result.nodes).toEqual([]);
+  });
+
+  test("applies branch markers to node activeChildId", () => {
+    const node1 = makeTreeNode("n1", null);
+    const node2 = makeTreeNode("n2", "n1");
+    const node3 = makeTreeNode("n3", "n1");
+    const marker = JSON.stringify({ _marker: "branch", nodeId: "n1", activeChildId: "n2" });
+    const content = buildJSONL(
+      HEADER_LINE,
+      JSON.stringify(node1),
+      JSON.stringify(node2),
+      JSON.stringify(node3),
+      marker,
+    );
+
+    const result = parseConversationFile(content);
+
+    expect(result.nodes).toHaveLength(3);
+    const n1 = result.nodes.find((n) => n.id === "n1")!;
+    expect(n1.activeChildId).toBe("n2");
+  });
+
+  test("last branch marker wins for same nodeId", () => {
+    const node1 = makeTreeNode("n1", null);
+    const node2 = makeTreeNode("n2", "n1");
+    const node3 = makeTreeNode("n3", "n1");
+    const marker1 = JSON.stringify({ _marker: "branch", nodeId: "n1", activeChildId: "n2" });
+    const marker2 = JSON.stringify({ _marker: "branch", nodeId: "n1", activeChildId: "n3" });
+    const content = buildJSONL(
+      HEADER_LINE,
+      JSON.stringify(node1),
+      JSON.stringify(node2),
+      JSON.stringify(node3),
+      marker1,
+      marker2,
+    );
+
+    const result = parseConversationFile(content);
+    const n1 = result.nodes.find((n) => n.id === "n1")!;
+    expect(n1.activeChildId).toBe("n3");
+  });
+
+  test("branch marker referencing unknown nodeId is silently ignored", () => {
+    const node1 = makeTreeNode("n1", null);
+    const marker = JSON.stringify({ _marker: "branch", nodeId: "UNKNOWN", activeChildId: "n1" });
+    const content = buildJSONL(HEADER_LINE, JSON.stringify(node1), marker);
+
+    const result = parseConversationFile(content);
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0].activeChildId).toBeUndefined();
+  });
+
+  test("header with compactedFrom and mode", () => {
+    const header = JSON.stringify({
+      _header: true,
+      createdAt: 1000,
+      provider: "google",
+      model: "gemini-test",
+      compactedFrom: "old-session",
+      mode: "meta",
+    });
+    const content = buildJSONL(header);
+    const result = parseConversationFile(content);
+
+    expect(result.header!.compactedFrom).toBe("old-session");
+    expect(result.header!.mode).toBe("meta");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTreeMap
+// ---------------------------------------------------------------------------
+
+describe("buildTreeMap", () => {
+  test("builds parent-child relationships", () => {
+    const nodes: TreeNode[] = [
+      makeTreeNode("n1", null),
+      makeTreeNode("n2", "n1"),
+      makeTreeNode("n3", "n1"),
+    ];
+    const map = buildTreeMap(nodes);
+
+    expect(map.size).toBe(3);
+    expect(map.get("n1")!.children).toEqual(["n2", "n3"]);
+    expect(map.get("n2")!.children).toEqual([]);
+    expect(map.get("n3")!.children).toEqual([]);
+  });
+
+  test("handles single root node", () => {
+    const map = buildTreeMap([makeTreeNode("root", null)]);
+    expect(map.size).toBe(1);
+    expect(map.get("root")!.children).toEqual([]);
+  });
+
+  test("handles empty input", () => {
+    const map = buildTreeMap([]);
+    expect(map.size).toBe(0);
+  });
+
+  test("orphan node with missing parent has no children link", () => {
+    const nodes: TreeNode[] = [
+      makeTreeNode("n1", null),
+      makeTreeNode("n2", "MISSING"),
+    ];
+    const map = buildTreeMap(nodes);
+    expect(map.get("n1")!.children).toEqual([]);
+    // n2 exists but its parent is not in the map
+    expect(map.get("n2")!.parentId).toBe("MISSING");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// deriveConversation
+// ---------------------------------------------------------------------------
+
+describe("deriveConversation", () => {
+  test("derives metadata from header and nodes", () => {
+    const nodes: TreeNode[] = [
+      makeTreeNode("n1", null, "user", "Hello there!"),
+      makeTreeNode("n2", "n1", "assistant", "Hi!"),
+    ];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("sess-1", {
+      _header: true,
+      createdAt: 1000,
+      provider: "google",
+      model: "gemini-test",
+    }, nodes, tree);
+
+    expect(conv.id).toBe("sess-1");
+    expect(conv.title).toBe("Hello there!");
+    expect(conv.createdAt).toBe(1000);
+    expect(conv.rootNodeId).toBe("n1");
+    expect(conv.activeLeafId).toBe("n2");
+  });
+
+  test("title truncated at 50 chars", () => {
+    const longText = "x".repeat(60);
+    const nodes: TreeNode[] = [makeTreeNode("n1", null, "user", longText)];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("s", null, nodes, tree);
+
+    expect(conv.title.length).toBe(53);
+    expect(conv.title.endsWith("...")).toBe(true);
+  });
+
+  test("falls back to 'New conversation' when no user messages", () => {
+    const nodes: TreeNode[] = [makeTreeNode("n1", null, "assistant", "Hi!")];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("s", null, nodes, tree);
+    expect(conv.title).toBe("New conversation");
+  });
+
+  test("uses last assistant provider/model over header", () => {
+    const nodes: TreeNode[] = [
+      makeTreeNode("n1", null, "user", "hello"),
+      makeTreeNode("n2", "n1", "assistant", "hi"),
+    ];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("s", {
+      _header: true, createdAt: 1000, provider: "old-provider", model: "old-model",
+    }, nodes, tree);
+
+    expect(conv.provider).toBe("google");
+    expect(conv.model).toBe("gemini-test");
+  });
+
+  test("uses header provider/model when no assistant messages", () => {
+    const nodes: TreeNode[] = [makeTreeNode("n1", null, "user", "hello")];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("s", {
+      _header: true, createdAt: 1000, provider: "google", model: "gemini-test",
+    }, nodes, tree);
+
+    expect(conv.provider).toBe("google");
+    expect(conv.model).toBe("gemini-test");
+  });
+
+  test("empty nodes with no header", () => {
+    const conv = deriveConversation("s", null, []);
+    expect(conv.title).toBe("New conversation");
+    expect(conv.rootNodeId).toBe("");
+    expect(conv.activeLeafId).toBe("");
+    expect(conv.provider).toBe("");
+    expect(conv.model).toBe("");
+  });
+
+  test("compactedFrom and mode propagated from header", () => {
+    const conv = deriveConversation("s", {
+      _header: true, createdAt: 1000, provider: "g", model: "m",
+      compactedFrom: "old-id", mode: "meta",
+    }, []);
+    expect(conv.compactedFrom).toBe("old-id");
+    expect(conv.mode).toBe("meta");
+  });
+
+  test("updatedAt uses last node's createdAt", () => {
+    const nodes: TreeNode[] = [
+      { ...makeTreeNode("n1", null), createdAt: 1000 },
+      { ...makeTreeNode("n2", "n1"), createdAt: 2000 },
+      { ...makeTreeNode("n3", "n2"), createdAt: 3000 },
+    ];
+    const tree = buildTreeMap(nodes);
+    const conv = deriveConversation("s", null, nodes, tree);
+    expect(conv.updatedAt).toBe(3000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeConversation
+// ---------------------------------------------------------------------------
+
+describe("serializeConversation", () => {
+  test("round-trips through parse → build → serialize → parse", () => {
+    const node1 = makeTreeNode("n1", null);
+    const node2 = makeTreeNode("n2", "n1");
+    const original = buildJSONL(HEADER_LINE, JSON.stringify(node1), JSON.stringify(node2));
+
+    const parsed = parseConversationFile(original);
+    const tree = buildTreeMap(parsed.nodes);
+    const serialized = serializeConversation(parsed.headerLine, tree);
+    const reparsed = parseConversationFile(serialized);
+
+    expect(reparsed.header).not.toBeNull();
+    expect(reparsed.header!.provider).toBe("google");
+    expect(reparsed.nodes).toHaveLength(2);
+    expect(reparsed.nodes[0].id).toBe("n1");
+    expect(reparsed.nodes[1].id).toBe("n2");
+  });
+
+  test("serializes without header", () => {
+    const nodes: TreeNode[] = [makeTreeNode("n1", null)];
+    const tree = buildTreeMap(nodes);
+    const serialized = serializeConversation(null, tree);
+
+    expect(serialized).not.toContain("_header");
+    const reparsed = parseConversationFile(serialized);
+    expect(reparsed.header).toBeNull();
+    expect(reparsed.nodes).toHaveLength(1);
+  });
+
+  test("strips children field from output", () => {
+    const nodes: TreeNode[] = [
+      makeTreeNode("n1", null),
+      makeTreeNode("n2", "n1"),
+    ];
+    const tree = buildTreeMap(nodes);
+    const serialized = serializeConversation(null, tree);
+
+    // The serialized JSON should not contain the "children" key
+    expect(serialized).not.toContain('"children"');
+  });
+
+  test("empty tree serializes to header + empty node content", () => {
+    const tree = buildTreeMap([]);
+    const serialized = serializeConversation(HEADER_LINE, tree);
+    // allNodes is [], join produces "", + "\n" = "\n"
+    // so result is HEADER_LINE + "\n" + "\n"
+    expect(serialized).toBe(HEADER_LINE + "\n\n");
+  });
+});

--- a/packages/creative-agent/tests/conversation/tree.test.ts
+++ b/packages/creative-agent/tests/conversation/tree.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect } from "bun:test";
+import {
+  computeActivePath,
+  flattenPathToMessages,
+  pathToNode,
+  switchBranch,
+  generateTitle,
+} from "../../src/conversation/tree.js";
+import type { TreeNodeWithChildren } from "../../src/types.js";
+
+// --- Helpers ---
+
+function makeNode(
+  id: string,
+  parentId: string | null,
+  children: string[] = [],
+  activeChildId?: string,
+): TreeNodeWithChildren {
+  return {
+    id,
+    parentId,
+    message: { role: "user", content: [{ type: "text", text: `msg-${id}` }] } as any,
+    createdAt: Date.now(),
+    children,
+    ...(activeChildId ? { activeChildId } : {}),
+  };
+}
+
+/**
+ * Build a simple linear chain: A → B → C → D
+ */
+function linearChain(): Map<string, TreeNodeWithChildren> {
+  const map = new Map<string, TreeNodeWithChildren>();
+  map.set("A", makeNode("A", null, ["B"]));
+  map.set("B", makeNode("B", "A", ["C"]));
+  map.set("C", makeNode("C", "B", ["D"]));
+  map.set("D", makeNode("D", "C"));
+  return map;
+}
+
+/**
+ * Build a branching tree:
+ *
+ *       A
+ *      / \
+ *     B   E
+ *    / \
+ *   C   D
+ */
+function branchingTree(): Map<string, TreeNodeWithChildren> {
+  const map = new Map<string, TreeNodeWithChildren>();
+  map.set("A", makeNode("A", null, ["B", "E"]));
+  map.set("B", makeNode("B", "A", ["C", "D"]));
+  map.set("C", makeNode("C", "B"));
+  map.set("D", makeNode("D", "B"));
+  map.set("E", makeNode("E", "A"));
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// computeActivePath
+// ---------------------------------------------------------------------------
+
+describe("computeActivePath", () => {
+  test("follows linear chain to the leaf", () => {
+    const path = computeActivePath(linearChain(), "A");
+    expect(path).toEqual(["A", "B", "C", "D"]);
+  });
+
+  test("follows activeChildId when set", () => {
+    const tree = branchingTree();
+    tree.get("A")!.activeChildId = "E";
+    const path = computeActivePath(tree, "A");
+    expect(path).toEqual(["A", "E"]);
+  });
+
+  test("falls back to last child when no activeChildId", () => {
+    const tree = branchingTree();
+    // No activeChildId on A → picks last child "E"
+    const path = computeActivePath(tree, "A");
+    expect(path).toEqual(["A", "E"]);
+  });
+
+  test("follows activeChildId then falls back to last child deeper", () => {
+    const tree = branchingTree();
+    tree.get("A")!.activeChildId = "B";
+    // B has no activeChildId → picks last child "D"
+    const path = computeActivePath(tree, "A");
+    expect(path).toEqual(["A", "B", "D"]);
+  });
+
+  test("single node tree", () => {
+    const map = new Map<string, TreeNodeWithChildren>();
+    map.set("X", makeNode("X", null));
+    expect(computeActivePath(map, "X")).toEqual(["X"]);
+  });
+
+  test("returns empty on unknown rootNodeId", () => {
+    const path = computeActivePath(linearChain(), "UNKNOWN");
+    expect(path).toEqual([]);
+  });
+
+  test("skips invalid activeChildId that is not in the map", () => {
+    const tree = linearChain();
+    tree.get("A")!.activeChildId = "GONE";
+    // "GONE" not in map → falls back to last child "B"
+    const path = computeActivePath(tree, "A");
+    expect(path).toEqual(["A", "B", "C", "D"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// flattenPathToMessages
+// ---------------------------------------------------------------------------
+
+describe("flattenPathToMessages", () => {
+  test("returns messages in path order", () => {
+    const tree = linearChain();
+    const messages = flattenPathToMessages(tree, ["A", "B", "C"]);
+    expect(messages).toHaveLength(3);
+    expect((messages[0] as any).content[0].text).toBe("msg-A");
+    expect((messages[2] as any).content[0].text).toBe("msg-C");
+  });
+
+  test("returns empty for empty path", () => {
+    expect(flattenPathToMessages(linearChain(), [])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pathToNode
+// ---------------------------------------------------------------------------
+
+describe("pathToNode", () => {
+  test("traces from root to leaf", () => {
+    const tree = linearChain();
+    expect(pathToNode(tree, "D")).toEqual(["A", "B", "C", "D"]);
+  });
+
+  test("traces from root to middle node", () => {
+    const tree = linearChain();
+    expect(pathToNode(tree, "B")).toEqual(["A", "B"]);
+  });
+
+  test("root node returns single-element path", () => {
+    const tree = linearChain();
+    expect(pathToNode(tree, "A")).toEqual(["A"]);
+  });
+
+  test("works in branching tree", () => {
+    const tree = branchingTree();
+    expect(pathToNode(tree, "D")).toEqual(["A", "B", "D"]);
+    expect(pathToNode(tree, "E")).toEqual(["A", "E"]);
+  });
+
+  test("unknown node returns single-element path", () => {
+    expect(pathToNode(linearChain(), "UNKNOWN")).toEqual(["UNKNOWN"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// switchBranch
+// ---------------------------------------------------------------------------
+
+describe("switchBranch", () => {
+  test("switches parent activeChildId upward to root", () => {
+    const tree = branchingTree();
+    // Switch to C (child of B, which is child of A)
+    tree.get("A")!.activeChildId = "E"; // currently pointing to E
+    tree.get("B")!.activeChildId = "D"; // currently pointing to D
+
+    const result = switchBranch(tree, "C");
+
+    // A should now point to B, B should now point to C
+    expect(tree.get("A")!.activeChildId).toBe("B");
+    expect(tree.get("B")!.activeChildId).toBe("C");
+    expect(result.updatedNodes).toHaveLength(2);
+    expect(result.newLeafId).toBe("C");
+  });
+
+  test("returns empty updatedNodes when already on active path", () => {
+    const tree = branchingTree();
+    tree.get("A")!.activeChildId = "B";
+    tree.get("B")!.activeChildId = "D";
+
+    const result = switchBranch(tree, "D");
+    expect(result.updatedNodes).toHaveLength(0);
+    expect(result.newLeafId).toBe("D");
+  });
+
+  test("switching to a non-leaf walks down to find actual leaf", () => {
+    const tree = branchingTree();
+    tree.get("A")!.activeChildId = "E";
+
+    const result = switchBranch(tree, "B");
+    expect(tree.get("A")!.activeChildId).toBe("B");
+    // B has children [C, D], no activeChildId → picks last child "D"
+    expect(result.newLeafId).toBe("D");
+  });
+
+  test("switching to root works", () => {
+    const map = new Map<string, TreeNodeWithChildren>();
+    map.set("A", makeNode("A", null, ["B"]));
+    map.set("B", makeNode("B", "A"));
+
+    const result = switchBranch(map, "A");
+    expect(result.newLeafId).toBe("B");
+    // No parent to update
+    expect(result.updatedNodes).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// generateTitle
+// ---------------------------------------------------------------------------
+
+describe("generateTitle", () => {
+  test("returns short text as-is", () => {
+    expect(generateTitle("hello world")).toBe("hello world");
+  });
+
+  test("truncates at 50 chars with ellipsis", () => {
+    const long = "a".repeat(60);
+    const title = generateTitle(long);
+    expect(title.length).toBe(53); // 50 + "..."
+    expect(title.endsWith("...")).toBe(true);
+  });
+
+  test("exactly 50 chars is not truncated", () => {
+    const exact = "b".repeat(50);
+    expect(generateTitle(exact)).toBe(exact);
+  });
+
+  test("replaces newlines with spaces", () => {
+    expect(generateTitle("line1\nline2\nline3")).toBe("line1 line2 line3");
+  });
+
+  test("trims whitespace", () => {
+    expect(generateTitle("  hello  ")).toBe("hello");
+  });
+
+  test("empty string returns empty", () => {
+    expect(generateTitle("")).toBe("");
+  });
+});

--- a/packages/creative-agent/tests/slash/parse.test.ts
+++ b/packages/creative-agent/tests/slash/parse.test.ts
@@ -1,0 +1,108 @@
+import { describe, test, expect } from "bun:test";
+import { parseSlashInput, serializeCommand } from "../../src/slash/parse.js";
+
+// ---------------------------------------------------------------------------
+// parseSlashInput
+// ---------------------------------------------------------------------------
+
+describe("parseSlashInput", () => {
+  // --- Valid slash commands ---
+
+  test("parses simple command without args", () => {
+    const result = parseSlashInput("/hello");
+    expect(result).toEqual({ name: "hello", args: "" });
+  });
+
+  test("parses command with args", () => {
+    const result = parseSlashInput("/character describe the warrior");
+    expect(result).toEqual({ name: "character", args: "describe the warrior" });
+  });
+
+  test("parses hyphenated command name", () => {
+    const result = parseSlashInput("/create-character some args");
+    expect(result).toEqual({ name: "create-character", args: "some args" });
+  });
+
+  test("parses command with numeric name", () => {
+    const result = parseSlashInput("/test123");
+    expect(result).toEqual({ name: "test123", args: "" });
+  });
+
+  test("parses command starting with number", () => {
+    const result = parseSlashInput("/1up");
+    expect(result).toEqual({ name: "1up", args: "" });
+  });
+
+  test("trims leading whitespace before /", () => {
+    const result = parseSlashInput("  /hello world");
+    expect(result).toEqual({ name: "hello", args: "world" });
+  });
+
+  test("trims args whitespace", () => {
+    const result = parseSlashInput("/cmd   spaced args  ");
+    expect(result).toEqual({ name: "cmd", args: "spaced args" });
+  });
+
+  test("handles multiline args", () => {
+    const result = parseSlashInput("/cmd line1\nline2\nline3");
+    expect(result).toEqual({ name: "cmd", args: "line1\nline2\nline3" });
+  });
+
+  // --- Invalid inputs ---
+
+  test("returns null for non-slash input", () => {
+    expect(parseSlashInput("hello world")).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(parseSlashInput("")).toBeNull();
+  });
+
+  test("returns null for just a slash", () => {
+    expect(parseSlashInput("/")).toBeNull();
+  });
+
+  test("returns null for uppercase command name", () => {
+    expect(parseSlashInput("/Hello")).toBeNull();
+  });
+
+  test("returns null for command with underscore", () => {
+    expect(parseSlashInput("/my_command")).toBeNull();
+  });
+
+  test("returns null for command starting with hyphen", () => {
+    expect(parseSlashInput("/-invalid")).toBeNull();
+  });
+
+  test("returns null for slash with space before name", () => {
+    expect(parseSlashInput("/ hello")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// serializeCommand
+// ---------------------------------------------------------------------------
+
+describe("serializeCommand", () => {
+  test("serializes command without args", () => {
+    const result = serializeCommand("hello", "");
+    expect(result).toBe("<command-name>/hello</command-name>");
+  });
+
+  test("serializes command with args", () => {
+    const result = serializeCommand("character", "make a warrior");
+    expect(result).toContain("<command-name>/character</command-name>");
+    expect(result).toContain("<command-args>make a warrior</command-args>");
+  });
+
+  test("args are trimmed", () => {
+    const result = serializeCommand("cmd", "  some args  ");
+    expect(result).toContain("<command-args>some args</command-args>");
+  });
+
+  test("whitespace-only args treated as no args", () => {
+    const result = serializeCommand("cmd", "   ");
+    expect(result).toBe("<command-name>/cmd</command-name>");
+    expect(result).not.toContain("command-args");
+  });
+});

--- a/packages/creative-agent/tests/slug.test.ts
+++ b/packages/creative-agent/tests/slug.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "bun:test";
+import { slugify } from "../src/slug.js";
+
+describe("slugify", () => {
+  // --- Basic transformations ---
+
+  test("lowercases ASCII characters", () => {
+    expect(slugify("Hello World")).toBe("hello-world");
+  });
+
+  test("replaces spaces with hyphens", () => {
+    expect(slugify("my project name")).toBe("my-project-name");
+  });
+
+  test("collapses multiple spaces to single hyphen", () => {
+    expect(slugify("too   many    spaces")).toBe("too-many-spaces");
+  });
+
+  test("collapses multiple hyphens", () => {
+    expect(slugify("a--b---c")).toBe("a-b-c");
+  });
+
+  test("trims leading and trailing hyphens", () => {
+    expect(slugify("-hello-")).toBe("hello");
+    expect(slugify("  hello  ")).toBe("hello");
+  });
+
+  // --- Reserved characters ---
+
+  test("strips filesystem-reserved characters", () => {
+    expect(slugify('file/path\\to:name*with?"<>|chars')).toBe(
+      "filepathtonamewithchars",
+    );
+  });
+
+  test("strips reserved chars but preserves other content", () => {
+    expect(slugify("my:project")).toBe("myproject");
+    expect(slugify("test<file>")).toBe("testfile");
+  });
+
+  // --- Korean preservation ---
+
+  test("preserves Korean characters", () => {
+    expect(slugify("나의 프로젝트")).toBe("나의-프로젝트");
+  });
+
+  test("mixed Korean and ASCII", () => {
+    expect(slugify("Hello 세계")).toBe("hello-세계");
+  });
+
+  // --- Edge cases ---
+
+  test("returns 'project' for empty string", () => {
+    expect(slugify("")).toBe("project");
+  });
+
+  test("returns 'project' when all chars are reserved", () => {
+    expect(slugify('*?"<>|')).toBe("project");
+  });
+
+  test("handles tabs and mixed whitespace", () => {
+    expect(slugify("hello\tworld")).toBe("hello-world");
+  });
+
+  test("already-valid slug passes through", () => {
+    expect(slugify("my-project")).toBe("my-project");
+  });
+
+  test("numbers are preserved", () => {
+    expect(slugify("Project 42")).toBe("project-42");
+  });
+
+  test("leading spaces produce no leading hyphen", () => {
+    expect(slugify("  hello")).toBe("hello");
+  });
+});

--- a/packages/creative-agent/tests/workspace/frontmatter.test.ts
+++ b/packages/creative-agent/tests/workspace/frontmatter.test.ts
@@ -1,0 +1,143 @@
+import { describe, test, expect } from "bun:test";
+import { parseFrontmatter } from "../../src/workspace/frontmatter.js";
+
+describe("parseFrontmatter", () => {
+  // --- Valid frontmatter ---
+
+  test("parses standard frontmatter with body", () => {
+    const input = `---
+name: elara
+description: A brave warrior
+---
+# Character Sheet
+
+Some body content.`;
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({
+      name: "elara",
+      description: "A brave warrior",
+    });
+    expect(result.body).toBe("# Character Sheet\n\nSome body content.");
+  });
+
+  test("parses frontmatter-only (no body after closing ---)", () => {
+    const input = `---
+name: test
+value: 42
+---`;
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({ name: "test", value: 42 });
+    expect(result.body).toBe("");
+  });
+
+  test("parses nested YAML structures", () => {
+    const input = `---
+name: world
+regions:
+  - north
+  - south
+metadata:
+  author: user
+---
+Body here.`;
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter!.regions).toEqual(["north", "south"]);
+    expect((result.frontmatter!.metadata as any).author).toBe("user");
+    expect(result.body).toBe("Body here.");
+  });
+
+  test("handles multiline body correctly", () => {
+    const input = `---
+title: test
+---
+line 1
+line 2
+line 3`;
+    const result = parseFrontmatter(input);
+    expect(result.body).toBe("line 1\nline 2\nline 3");
+  });
+
+  // --- No frontmatter ---
+
+  test("returns null frontmatter when no --- delimiters", () => {
+    const input = "# Just a markdown file\n\nWith content.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toBeNull();
+    expect(result.body).toBe(input);
+  });
+
+  test("returns null frontmatter for empty string", () => {
+    const result = parseFrontmatter("");
+    expect(result.frontmatter).toBeNull();
+    expect(result.body).toBe("");
+  });
+
+  test("returns null when only opening --- exists", () => {
+    const input = "---\nname: test\nNo closing delimiter";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toBeNull();
+  });
+
+  // --- CRLF handling ---
+
+  test("normalizes CRLF to LF", () => {
+    const input = "---\r\nname: test\r\n---\r\nBody content.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({ name: "test" });
+    expect(result.body).toBe("Body content.");
+  });
+
+  // --- Malformed YAML ---
+
+  test("returns null frontmatter for invalid YAML", () => {
+    const input = "---\n: : : invalid\n---\nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toBeNull();
+    // falls back to body = original (CRLF normalized)
+  });
+
+  test("returns null frontmatter when YAML parses to non-object (scalar)", () => {
+    const input = "---\njust a string\n---\nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toBeNull();
+  });
+
+  test("returns null frontmatter when YAML parses to array", () => {
+    const input = "---\n- item1\n- item2\n---\nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toBeNull();
+  });
+
+  // --- Edge cases ---
+
+  test("handles empty frontmatter block", () => {
+    // Empty YAML between delimiters — parseYaml returns null for empty string
+    const input = "---\n\n---\nBody after empty frontmatter.";
+    const result = parseFrontmatter(input);
+    // Empty YAML → null parsed → null frontmatter
+    expect(result.frontmatter).toBeNull();
+  });
+
+  test("handles frontmatter with trailing spaces on delimiters", () => {
+    const input = "---  \nname: test\n---  \nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter).toEqual({ name: "test" });
+    expect(result.body).toBe("Body.");
+  });
+
+  test("boolean and numeric values are parsed correctly", () => {
+    const input = "---\nenabled: true\ncount: 5\nratio: 0.5\n---\nBody.";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter!.enabled).toBe(true);
+    expect(result.frontmatter!.count).toBe(5);
+    expect(result.frontmatter!.ratio).toBe(0.5);
+  });
+
+  test("Korean content in frontmatter", () => {
+    const input = "---\ndisplay-name: 엘라라 브라이트웰\nrole: 전사\n---\n캐릭터 설명";
+    const result = parseFrontmatter(input);
+    expect(result.frontmatter!["display-name"]).toBe("엘라라 브라이트웰");
+    expect(result.frontmatter!.role).toBe("전사");
+    expect(result.body).toBe("캐릭터 설명");
+  });
+});


### PR DESCRIPTION
Add 97 tests across 5 new test files covering Priority 1 untested modules:

- conversation/tree.ts: computeActivePath, switchBranch, pathToNode, generateTitle
- conversation/format.ts: parseConversationFile, buildTreeMap, deriveConversation, serializeConversation
- workspace/frontmatter.ts: parseFrontmatter (YAML extraction, CRLF, edge cases)
- slug.ts: slugify (Korean preservation, reserved chars, edge cases)
- slash/parse.ts: parseSlashInput, serializeCommand

https://claude.ai/code/session_017r6oecPfMv2Md4Tew5aTPV