### PR TITLE
fix: 템플릿→프로젝트 복사 시 SYSTEM.meta.md 누락 수정

### DIFF
--- a/apps/webui/src/server/repositories/project.repo.ts
+++ b/apps/webui/src/server/repositories/project.repo.ts
@@ -48,22 +48,10 @@ export function createProjectRepo(projectsDir: string) {
     await Bun.write(projectMetaPath(slug), JSON.stringify(project, null, 2));
 
     const destDir = projectDir(slug);
-    const copies: Promise<void>[] = [];
-
-    for (const sub of ["skills", "files", "conversations"] as const) {
-      const src = join(srcDir, sub);
-      if (existsSync(src)) {
-        copies.push(cp(src, join(destDir, sub), { recursive: true }));
-      }
-    }
-
-    for (const file of ["renderer.ts", "SYSTEM.md"] as const) {
-      const src = join(srcDir, file);
-      if (existsSync(src)) {
-        copies.push(cp(src, join(destDir, file)));
-      }
-    }
-
+    const entries = await readdir(srcDir, { withFileTypes: true });
+    const copies = entries
+      .filter((e) => e.name !== "_template.json")
+      .map((e) => cp(join(srcDir, e.name), join(destDir, e.name), { recursive: e.isDirectory() }));
     await Promise.all(copies);
     return project;
   }


### PR DESCRIPTION
## Summary
- 템플릿에서 프로젝트 생성 시 `SYSTEM.meta.md`가 복사되지 않는 버그 수정
- 하드코딩된 allowlist(`["renderer.ts", "SYSTEM.md"]`) 대신 `readdir` + `_template.json` 제외 방식으로 변경하여, 향후 템플릿에 파일이 추가되어도 자동으로 복사됨

## Test plan
- [ ] 기존 템플릿(character-chat 등)에서 프로젝트 생성 후 `SYSTEM.meta.md` 포함 여부 확인
- [ ] `_template.json`이 프로젝트 디렉토리에 복사되지 않는 것 확인
- [ ] 기존 파일들(SYSTEM.md, renderer.ts, skills/, files/) 정상 복사 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)