### PR TITLE
feat: 에디터 트리뷰 컨텍스트 메뉴 기능 추가

### DIFF
--- a/apps/webui/src/client/entities/editor/EditorContext.tsx
+++ b/apps/webui/src/client/entities/editor/EditorContext.tsx
@@ -54,6 +54,8 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
         localContent: null,
         dirty: false,
       };
+    case "RENAME_SELECTED":
+      return { ...state, selectedPath: action.newPath };
     case "CLEAR":
       return initialState;
     default:

--- a/apps/webui/src/client/entities/editor/editor.api.ts
+++ b/apps/webui/src/client/entities/editor/editor.api.ts
@@ -28,3 +28,25 @@ export function revealProjectFile(slug: string, path: string): Promise<void> {
     method: "POST",
   });
 }
+
+export function deleteProjectDir(slug: string, path: string): Promise<void> {
+  return json(`/projects/${encodeURIComponent(slug)}/dir?path=${encodeURIComponent(path)}`, {
+    method: "DELETE",
+  });
+}
+
+export function renameProjectEntry(slug: string, from: string, to: string): Promise<void> {
+  return json(`/projects/${encodeURIComponent(slug)}/file/rename`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ from, to }),
+  });
+}
+
+export function createProjectDir(slug: string, path: string): Promise<void> {
+  return json(`/projects/${encodeURIComponent(slug)}/dir`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ path }),
+  });
+}

--- a/apps/webui/src/client/entities/editor/editor.types.ts
+++ b/apps/webui/src/client/entities/editor/editor.types.ts
@@ -26,4 +26,5 @@ export type EditorAction =
   | { type: "UPDATE_LOCAL_CONTENT"; content: string }
   | { type: "MARK_CLEAN" }
   | { type: "DESELECT_FILE" }
+  | { type: "RENAME_SELECTED"; newPath: string }
   | { type: "CLEAR" };

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -1,5 +1,5 @@
 export { EditorProvider, useEditorState, useEditorDispatch } from "./EditorContext.js";
-export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile, revealProjectFile } from "./editor.api.js";
+export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile, revealProjectFile, deleteProjectDir, renameProjectEntry, createProjectDir } from "./editor.api.js";
 export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
 export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";

--- a/apps/webui/src/client/features/editor/DeleteConfirmDialog.tsx
+++ b/apps/webui/src/client/features/editor/DeleteConfirmDialog.tsx
@@ -4,22 +4,28 @@ import { useI18n } from "@/client/i18n/index.js";
 
 interface DeleteConfirmDialogProps {
   path: string | null;
+  type?: "file" | "dir";
   onConfirm: () => void;
   onCancel: () => void;
 }
 
-export function DeleteConfirmDialog({ path, onConfirm, onCancel }: DeleteConfirmDialogProps) {
+export function DeleteConfirmDialog({ path, type = "file", onConfirm, onCancel }: DeleteConfirmDialogProps) {
   const { t } = useI18n();
   const fileName = path?.split("/").pop() ?? "";
+
+  const title = type === "dir" ? t("editMode.deleteFolderConfirmTitle") : t("editMode.deleteConfirmTitle");
+  const message = type === "dir"
+    ? t("editMode.deleteFolderConfirmMessage", { name: fileName })
+    : t("editMode.deleteConfirmMessage", { name: fileName });
 
   return (
     <Dialog open={path !== null} onOpenChange={(o) => { if (!o) onCancel(); }}>
       <div className="p-6 space-y-4">
         <h3 className="font-display text-lg font-bold text-fg">
-          {t("editMode.deleteConfirmTitle")}
+          {title}
         </h3>
         <p className="text-sm text-fg-2">
-          {t("editMode.deleteConfirmMessage", { name: fileName })}
+          {message}
         </p>
         <div className="flex justify-end gap-3">
           <Button variant="ghost" onClick={onCancel}>

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -28,6 +28,13 @@ export function EditModePanel() {
     confirmDeleteFile,
     cancelDeleteFile,
     revealFile,
+    deleteConfirmDir,
+    requestDeleteDir,
+    confirmDeleteDir,
+    cancelDeleteDir,
+    renameEntry,
+    createFileInDir,
+    createDirInDir,
   } = useEditMode();
 
   const [treeWidth, setTreeWidth] = useState(DEFAULT_TREE_WIDTH);
@@ -50,7 +57,11 @@ export function EditModePanel() {
           dirty={dirty}
           onSelect={selectFile}
           onDelete={requestDeleteFile}
+          onDeleteDir={requestDeleteDir}
           onReveal={revealFile}
+          onRename={renameEntry}
+          onCreateFile={createFileInDir}
+          onCreateDir={createDirInDir}
         />
       </div>
 
@@ -79,11 +90,20 @@ export function EditModePanel() {
         onCancel={handleUnsavedCancel}
       />
 
-      {/* Delete confirmation dialog */}
+      {/* File delete confirmation dialog */}
       <DeleteConfirmDialog
         path={deleteConfirmPath}
+        type="file"
         onConfirm={() => void confirmDeleteFile()}
         onCancel={cancelDeleteFile}
+      />
+
+      {/* Folder delete confirmation dialog */}
+      <DeleteConfirmDialog
+        path={deleteConfirmDir}
+        type="dir"
+        onConfirm={() => void confirmDeleteDir()}
+        onCancel={cancelDeleteDir}
       />
     </>
   );

--- a/apps/webui/src/client/features/editor/FileTree.tsx
+++ b/apps/webui/src/client/features/editor/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import {
   ChevronRight,
   ChevronDown,
@@ -17,6 +17,13 @@ const MENU_ITEM_CLASS =
   "px-4 py-1.5 text-sm text-fg-2 cursor-pointer outline-none data-[highlighted]:bg-accent/10";
 const MENU_ITEM_DANGER_CLASS =
   "px-4 py-1.5 text-sm text-danger cursor-pointer outline-none data-[highlighted]:bg-danger/10";
+const MENU_SEPARATOR_CLASS = "my-1 border-t border-edge/8";
+
+type InlineEdit =
+  | { mode: "new-file"; parentPath: string | null }
+  | { mode: "new-dir"; parentPath: string | null }
+  | { mode: "rename"; path: string; currentName: string }
+  | null;
 
 interface FileTreeProps {
   entries: TreeEntry[];
@@ -24,12 +31,21 @@ interface FileTreeProps {
   dirty: boolean;
   onSelect: (path: string) => void;
   onDelete: (path: string) => void;
+  onDeleteDir: (path: string) => void;
   onReveal: (path: string) => void;
+  onRename: (oldPath: string, newName: string) => void;
+  onCreateFile: (dirPath: string | null, fileName: string) => void;
+  onCreateDir: (dirPath: string | null, dirName: string) => void;
 }
 
-export function FileTree({ entries, selectedPath, dirty, onSelect, onDelete, onReveal }: FileTreeProps) {
+export function FileTree({
+  entries, selectedPath, dirty,
+  onSelect, onDelete, onDeleteDir, onReveal, onRename, onCreateFile, onCreateDir,
+}: FileTreeProps) {
+  const { t } = useI18n();
   const tree = useMemo(() => buildTree(entries), [entries]);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [inlineEdit, setInlineEdit] = useState<InlineEdit>(null);
 
   const toggle = useCallback((path: string) => {
     setCollapsed((prev) => {
@@ -40,23 +56,178 @@ export function FileTree({ entries, selectedPath, dirty, onSelect, onDelete, onR
     });
   }, []);
 
+  const expandFolder = useCallback((path: string) => {
+    setCollapsed((prev) => {
+      if (!prev.has(path)) return prev;
+      const next = new Set(prev);
+      next.delete(path);
+      return next;
+    });
+  }, []);
+
+  const startNewFile = useCallback((parentPath: string | null) => {
+    if (parentPath) expandFolder(parentPath);
+    setInlineEdit({ mode: "new-file", parentPath });
+  }, [expandFolder]);
+
+  const startNewDir = useCallback((parentPath: string | null) => {
+    if (parentPath) expandFolder(parentPath);
+    setInlineEdit({ mode: "new-dir", parentPath });
+  }, [expandFolder]);
+
+  const startRename = useCallback((path: string, currentName: string) => {
+    setInlineEdit({ mode: "rename", path, currentName });
+  }, []);
+
+  const cancelInline = useCallback(() => {
+    setInlineEdit(null);
+  }, []);
+
+  const commitInline = useCallback((value: string) => {
+    if (!inlineEdit) return;
+    const name = value.trim();
+    if (!name || name.includes("/") || name.includes("\\")) {
+      setInlineEdit(null);
+      return;
+    }
+
+    if (inlineEdit.mode === "new-file") {
+      onCreateFile(inlineEdit.parentPath, name);
+    } else if (inlineEdit.mode === "new-dir") {
+      onCreateDir(inlineEdit.parentPath, name);
+    } else if (inlineEdit.mode === "rename") {
+      if (name !== inlineEdit.currentName) {
+        onRename(inlineEdit.path, name);
+      }
+    }
+    setInlineEdit(null);
+  }, [inlineEdit, onCreateFile, onCreateDir, onRename]);
+
+  const rootInline = inlineEdit && inlineEdit.mode !== "rename" && inlineEdit.parentPath === null;
+
   return (
-    <ScrollArea className="h-full" viewportClassName="py-2 text-[12px] select-none">
-      {tree.map((node) => (
-        <TreeItem
-          key={node.path}
-          node={node}
-          depth={0}
-          selectedPath={selectedPath}
-          dirtyPath={dirty ? selectedPath : null}
-          collapsed={collapsed}
-          onToggle={toggle}
-          onSelect={onSelect}
-          onDelete={onDelete}
-          onReveal={onReveal}
+    <ScrollArea className="h-full" viewportClassName="py-2 text-[12px] select-none flex flex-col">
+      <div className="flex-1">
+        {tree.map((node) => (
+          <TreeItem
+            key={node.path}
+            node={node}
+            depth={0}
+            selectedPath={selectedPath}
+            dirtyPath={dirty ? selectedPath : null}
+            collapsed={collapsed}
+            inlineEdit={inlineEdit}
+            onToggle={toggle}
+            onSelect={onSelect}
+            onDelete={onDelete}
+            onDeleteDir={onDeleteDir}
+            onReveal={onReveal}
+            onStartNewFile={startNewFile}
+            onStartNewDir={startNewDir}
+            onStartRename={startRename}
+            onCommitInline={commitInline}
+            onCancelInline={cancelInline}
+          />
+        ))}
+        {rootInline && (
+          <InlineInput
+            depth={0}
+            defaultValue={inlineEdit.mode === "new-file" ? ".md" : ""}
+            selectRange={inlineEdit.mode === "new-file" ? [0, 0] : undefined}
+            icon={inlineEdit.mode === "new-file" ? "file" : "folder"}
+            onCommit={commitInline}
+            onCancel={cancelInline}
+          />
+        )}
+      </div>
+      {/* Empty area for root-level context menu */}
+      <ContextMenu.Root>
+        <ContextMenu.Trigger
+          render={<div className="min-h-[40px] flex-shrink-0" />}
         />
-      ))}
+        <ContextMenu.Portal>
+          <ContextMenu.Positioner sideOffset={4}>
+            <ContextMenu.Popup className={MENU_POPUP_CLASS}>
+              <ContextMenu.Item onClick={() => startNewFile(null)} className={MENU_ITEM_CLASS}>
+                {t("editMode.newFile")}
+              </ContextMenu.Item>
+              <ContextMenu.Item onClick={() => startNewDir(null)} className={MENU_ITEM_CLASS}>
+                {t("editMode.newFolder")}
+              </ContextMenu.Item>
+            </ContextMenu.Popup>
+          </ContextMenu.Positioner>
+        </ContextMenu.Portal>
+      </ContextMenu.Root>
     </ScrollArea>
+  );
+}
+
+interface InlineInputProps {
+  depth: number;
+  defaultValue: string;
+  selectRange?: [number, number];
+  icon: "file" | "folder";
+  onCommit: (value: string) => void;
+  onCancel: () => void;
+}
+
+function InlineInput({ depth, defaultValue, selectRange, icon, onCommit, onCancel }: InlineInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const committedRef = useRef(false);
+  const mountedRef = useRef(false);
+
+  useEffect(() => {
+    // Delay focus to next frame so context menu closing doesn't steal it back
+    const raf = requestAnimationFrame(() => {
+      const el = inputRef.current;
+      if (!el) return;
+      el.focus();
+      if (selectRange) {
+        el.setSelectionRange(selectRange[0], selectRange[1]);
+      } else {
+        el.select();
+      }
+      mountedRef.current = true;
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [selectRange]);
+
+  const handleCommit = () => {
+    if (committedRef.current) return;
+    committedRef.current = true;
+    onCommit(inputRef.current?.value ?? "");
+  };
+
+  return (
+    <div
+      className="flex items-center gap-1.5 px-2 py-1"
+      style={{ paddingLeft: `${icon === "folder" ? depth * 12 + 8 : depth * 12 + 20}px` }}
+    >
+      {icon === "folder"
+        ? <FolderOpen size={13} strokeWidth={2} className="text-accent/60 flex-shrink-0 ml-[14px]" />
+        : <FileIcon name={defaultValue || "file.md"} />
+      }
+      <input
+        ref={inputRef}
+        type="text"
+        defaultValue={defaultValue}
+        className="flex-1 min-w-0 bg-transparent border border-accent/40 rounded px-1 py-0 text-fg text-[12px] outline-none focus:border-accent"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleCommit();
+          } else if (e.key === "Escape") {
+            e.preventDefault();
+            onCancel();
+          }
+        }}
+        onBlur={() => {
+          // Ignore blur before mount completes (context menu closing can steal focus)
+          if (!mountedRef.current) return;
+          if (!committedRef.current) onCancel();
+        }}
+      />
+    </div>
   );
 }
 
@@ -66,18 +237,46 @@ interface TreeItemProps {
   selectedPath: string | null;
   dirtyPath: string | null;
   collapsed: Set<string>;
+  inlineEdit: InlineEdit;
   onToggle: (path: string) => void;
   onSelect: (path: string) => void;
   onDelete: (path: string) => void;
+  onDeleteDir: (path: string) => void;
   onReveal: (path: string) => void;
+  onStartNewFile: (parentPath: string | null) => void;
+  onStartNewDir: (parentPath: string | null) => void;
+  onStartRename: (path: string, currentName: string) => void;
+  onCommitInline: (value: string) => void;
+  onCancelInline: () => void;
 }
 
-function TreeItem({ node, depth, selectedPath, dirtyPath, collapsed, onToggle, onSelect, onDelete, onReveal }: TreeItemProps) {
+function TreeItem({
+  node, depth, selectedPath, dirtyPath, collapsed, inlineEdit,
+  onToggle, onSelect, onDelete, onDeleteDir, onReveal,
+  onStartNewFile, onStartNewDir, onStartRename, onCommitInline, onCancelInline,
+}: TreeItemProps) {
   const { t } = useI18n();
   const isDir = node.type === "dir";
   const isCollapsed = collapsed.has(node.path);
   const isSelected = node.path === selectedPath;
   const isDirty = node.path === dirtyPath;
+
+  const isRenaming = inlineEdit?.mode === "rename" && inlineEdit.path === node.path;
+  const showChildInline = isDir && !isCollapsed && inlineEdit && inlineEdit.mode !== "rename" && inlineEdit.parentPath === node.path;
+
+  if (isRenaming) {
+    const ext = node.name.includes(".") ? node.name.lastIndexOf(".") : node.name.length;
+    return (
+      <InlineInput
+        depth={depth}
+        defaultValue={node.name}
+        selectRange={[0, ext]}
+        icon={isDir ? "folder" : "file"}
+        onCommit={onCommitInline}
+        onCancel={onCancelInline}
+      />
+    );
+  }
 
   if (isDir) {
     const FolderIcon = isCollapsed ? FolderClosed : FolderOpen;
@@ -85,15 +284,44 @@ function TreeItem({ node, depth, selectedPath, dirtyPath, collapsed, onToggle, o
 
     return (
       <>
-        <button
-          onClick={() => onToggle(node.path)}
-          className="w-full flex items-center gap-1 px-2 py-1 hover:bg-accent/8 text-fg-2 hover:text-fg transition-colors rounded-md"
-          style={{ paddingLeft: `${depth * 12 + 8}px` }}
-        >
-          <ChevronIcon size={12} strokeWidth={2} className="text-fg-4 flex-shrink-0" />
-          <FolderIcon size={13} strokeWidth={2} className="text-accent/60 flex-shrink-0" />
-          <span className="truncate ml-0.5">{node.name}</span>
-        </button>
+        <ContextMenu.Root>
+          <ContextMenu.Trigger
+            render={
+              <button
+                onClick={() => onToggle(node.path)}
+                className="w-full flex items-center gap-1 px-2 py-1 hover:bg-accent/8 text-fg-2 hover:text-fg transition-colors rounded-md"
+                style={{ paddingLeft: `${depth * 12 + 8}px` }}
+              />
+            }
+          >
+            <ChevronIcon size={12} strokeWidth={2} className="text-fg-4 flex-shrink-0" />
+            <FolderIcon size={13} strokeWidth={2} className="text-accent/60 flex-shrink-0" />
+            <span className="truncate ml-0.5">{node.name}</span>
+          </ContextMenu.Trigger>
+          <ContextMenu.Portal>
+            <ContextMenu.Positioner sideOffset={4}>
+              <ContextMenu.Popup className={MENU_POPUP_CLASS}>
+                <ContextMenu.Item onClick={() => onStartNewFile(node.path)} className={MENU_ITEM_CLASS}>
+                  {t("editMode.newFile")}
+                </ContextMenu.Item>
+                <ContextMenu.Item onClick={() => onStartNewDir(node.path)} className={MENU_ITEM_CLASS}>
+                  {t("editMode.newFolder")}
+                </ContextMenu.Item>
+                <div className={MENU_SEPARATOR_CLASS} />
+                <ContextMenu.Item onClick={() => onStartRename(node.path, node.name)} className={MENU_ITEM_CLASS}>
+                  {t("editMode.rename")}
+                </ContextMenu.Item>
+                <ContextMenu.Item onClick={() => onReveal(node.path)} className={MENU_ITEM_CLASS}>
+                  {t("editMode.revealInExplorer")}
+                </ContextMenu.Item>
+                <div className={MENU_SEPARATOR_CLASS} />
+                <ContextMenu.Item onClick={() => onDeleteDir(node.path)} className={MENU_ITEM_DANGER_CLASS}>
+                  {t("editMode.deleteFile")}
+                </ContextMenu.Item>
+              </ContextMenu.Popup>
+            </ContextMenu.Positioner>
+          </ContextMenu.Portal>
+        </ContextMenu.Root>
         {!isCollapsed && node.children.map((child) => (
           <TreeItem
             key={child.path}
@@ -102,16 +330,34 @@ function TreeItem({ node, depth, selectedPath, dirtyPath, collapsed, onToggle, o
             selectedPath={selectedPath}
             dirtyPath={dirtyPath}
             collapsed={collapsed}
+            inlineEdit={inlineEdit}
             onToggle={onToggle}
             onSelect={onSelect}
             onDelete={onDelete}
+            onDeleteDir={onDeleteDir}
             onReveal={onReveal}
+            onStartNewFile={onStartNewFile}
+            onStartNewDir={onStartNewDir}
+            onStartRename={onStartRename}
+            onCommitInline={onCommitInline}
+            onCancelInline={onCancelInline}
           />
         ))}
+        {showChildInline && (
+          <InlineInput
+            depth={depth + 1}
+            defaultValue={inlineEdit.mode === "new-file" ? ".md" : ""}
+            selectRange={inlineEdit.mode === "new-file" ? [0, 0] : undefined}
+            icon={inlineEdit.mode === "new-file" ? "file" : "folder"}
+            onCommit={onCommitInline}
+            onCancel={onCancelInline}
+          />
+        )}
       </>
     );
   }
 
+  // File item
   return (
     <ContextMenu.Root>
       <ContextMenu.Trigger
@@ -134,12 +380,16 @@ function TreeItem({ node, depth, selectedPath, dirtyPath, collapsed, onToggle, o
       <ContextMenu.Portal>
         <ContextMenu.Positioner sideOffset={4}>
           <ContextMenu.Popup className={MENU_POPUP_CLASS}>
+            <ContextMenu.Item onClick={() => onStartRename(node.path, node.name)} className={MENU_ITEM_CLASS}>
+              {t("editMode.rename")}
+            </ContextMenu.Item>
             <ContextMenu.Item
               onClick={() => onReveal(node.path)}
               className={MENU_ITEM_CLASS}
             >
               {t("editMode.revealInExplorer")}
             </ContextMenu.Item>
+            <div className={MENU_SEPARATOR_CLASS} />
             <ContextMenu.Item
               onClick={() => onDelete(node.path)}
               className={MENU_ITEM_DANGER_CLASS}

--- a/apps/webui/src/client/features/editor/useEditMode.ts
+++ b/apps/webui/src/client/features/editor/useEditMode.ts
@@ -9,6 +9,9 @@ import {
   readProjectFile,
   writeProjectFile,
   deleteProjectFile,
+  deleteProjectDir,
+  renameProjectEntry,
+  createProjectDir,
   revealProjectFile,
 } from "@/client/entities/editor/index.js";
 
@@ -33,6 +36,7 @@ export function useEditMode() {
 
   // Pending delete confirmation
   const [deleteConfirmPath, setDeleteConfirmPath] = useState<string | null>(null);
+  const [deleteConfirmDir, setDeleteConfirmDir] = useState<string | null>(null);
 
   // Fetch tree when entering edit mode or switching project
   useEffect(() => {
@@ -135,6 +139,73 @@ export function useEditMode() {
     setDeleteConfirmPath(null);
   }, []);
 
+  // Folder delete flow
+  const requestDeleteDir = useCallback((path: string) => {
+    setDeleteConfirmDir(path);
+  }, []);
+
+  const confirmDeleteDir = useCallback(async () => {
+    if (!slug || !deleteConfirmDir) return;
+    try {
+      await deleteProjectDir(slug, deleteConfirmDir);
+      if (selectedPathRef.current && (
+        selectedPathRef.current === deleteConfirmDir ||
+        selectedPathRef.current.startsWith(deleteConfirmDir + "/")
+      )) {
+        editorDispatch({ type: "DESELECT_FILE" });
+      }
+      const { entries } = await fetchProjectTree(slug);
+      editorDispatch({ type: "SET_TREE", entries });
+    } finally {
+      setDeleteConfirmDir(null);
+    }
+  }, [slug, deleteConfirmDir, editorDispatch]);
+
+  const cancelDeleteDir = useCallback(() => {
+    setDeleteConfirmDir(null);
+  }, []);
+
+  // Rename
+  const renameEntry = useCallback(async (oldPath: string, newName: string) => {
+    if (!slug) return;
+    const parentPath = oldPath.includes("/") ? oldPath.substring(0, oldPath.lastIndexOf("/")) : null;
+    const newPath = parentPath ? `${parentPath}/${newName}` : newName;
+    await renameProjectEntry(slug, oldPath, newPath);
+
+    // Update selectedPath if the renamed item is the open file or a parent folder
+    const selected = selectedPathRef.current;
+    if (selected) {
+      if (selected === oldPath) {
+        editorDispatch({ type: "RENAME_SELECTED", newPath });
+      } else if (selected.startsWith(oldPath + "/")) {
+        editorDispatch({ type: "RENAME_SELECTED", newPath: newPath + selected.slice(oldPath.length) });
+      }
+    }
+
+    const { entries } = await fetchProjectTree(slug);
+    editorDispatch({ type: "SET_TREE", entries });
+  }, [slug, editorDispatch]);
+
+  // Create file / dir
+  const createFileInDir = useCallback(async (dirPath: string | null, fileName: string) => {
+    if (!slug) return;
+    const filePath = dirPath ? `${dirPath}/${fileName}` : fileName;
+    await writeProjectFile(slug, filePath, "");
+    const [{ entries }] = await Promise.all([
+      fetchProjectTree(slug),
+      loadFile(filePath),
+    ]);
+    editorDispatch({ type: "SET_TREE", entries });
+  }, [slug, editorDispatch, loadFile]);
+
+  const createDirInDir = useCallback(async (parentPath: string | null, dirName: string) => {
+    if (!slug) return;
+    const dirPath = parentPath ? `${parentPath}/${dirName}` : dirName;
+    await createProjectDir(slug, dirPath);
+    const { entries } = await fetchProjectTree(slug);
+    editorDispatch({ type: "SET_TREE", entries });
+  }, [slug, editorDispatch]);
+
   const revealFile = useCallback((path: string) => {
     if (!slug) return;
     void revealProjectFile(slug, path);
@@ -160,5 +231,15 @@ export function useEditMode() {
     cancelDeleteFile,
     // Reveal in explorer
     revealFile,
+    // Folder delete dialog
+    deleteConfirmDir,
+    requestDeleteDir,
+    confirmDeleteDir,
+    cancelDeleteDir,
+    // Rename
+    renameEntry,
+    // Create
+    createFileInDir,
+    createDirInDir,
   };
 }

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -204,6 +204,11 @@ export const translations = {
   "editMode.deleteFile": "Delete",
   "editMode.deleteConfirmTitle": "Delete File",
   "editMode.deleteConfirmMessage": "Are you sure you want to delete \"{{name}}\"? This cannot be undone.",
+  "editMode.newFile": "New File",
+  "editMode.newFolder": "New Folder",
+  "editMode.rename": "Rename",
+  "editMode.deleteFolderConfirmTitle": "Delete Folder",
+  "editMode.deleteFolderConfirmMessage": "Are you sure you want to delete \"{{name}}\" and all its contents? This cannot be undone.",
 } as const satisfies Record<string, string>;
 
 export type TranslationKey = keyof typeof translations;

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -206,4 +206,9 @@ export const translations: Record<TranslationKey, string> = {
   "editMode.deleteFile": "삭제",
   "editMode.deleteConfirmTitle": "파일 삭제",
   "editMode.deleteConfirmMessage": "\"{{name}}\" 파일을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  "editMode.newFile": "새 파일",
+  "editMode.newFolder": "새 폴더",
+  "editMode.rename": "이름 변경",
+  "editMode.deleteFolderConfirmTitle": "폴더 삭제",
+  "editMode.deleteFolderConfirmMessage": "\"{{name}}\" 폴더와 모든 내용을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
 };

--- a/apps/webui/src/server/repositories/project.repo.ts
+++ b/apps/webui/src/server/repositories/project.repo.ts
@@ -1,6 +1,6 @@
 import { readFile, mkdir, readdir, rename, rm, cp, stat, unlink } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, resolve, sep } from "node:path";
+import { dirname, join, resolve, sep } from "node:path";
 import { slugify, scanWorkspaceFiles, type ProjectFile } from "@agentchan/creative-agent";
 import type { Project } from "../types.js";
 
@@ -227,6 +227,29 @@ export function createProjectRepo(projectsDir: string) {
         if (code === "ENOENT") throw new Error("File not found", { cause: err });
         throw err;
       }
+    },
+
+    async deleteProjectDir(slug: string, dirPath: string): Promise<void> {
+      const resolved = this.resolveProjectFile(slug, dirPath);
+      if (!resolved) throw new Error(`Invalid path: ${dirPath}`);
+      await rm(resolved.fullPath, { recursive: true });
+    },
+
+    async renameProjectEntry(slug: string, fromPath: string, toPath: string): Promise<void> {
+      const resolvedFrom = this.resolveProjectFile(slug, fromPath);
+      if (!resolvedFrom) throw new Error(`Invalid path: ${fromPath}`);
+      const resolvedTo = this.resolveProjectFile(slug, toPath);
+      if (!resolvedTo) throw new Error(`Invalid path: ${toPath}`);
+      if (dirname(resolvedFrom.fullPath) !== dirname(resolvedTo.fullPath)) {
+        await mkdir(dirname(resolvedTo.fullPath), { recursive: true });
+      }
+      await rename(resolvedFrom.fullPath, resolvedTo.fullPath);
+    },
+
+    async createProjectDir(slug: string, dirPath: string): Promise<void> {
+      const resolved = this.resolveProjectFile(slug, dirPath);
+      if (!resolved) throw new Error(`Invalid path: ${dirPath}`);
+      await mkdir(resolved.fullPath, { recursive: true });
     },
   };
 }

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -220,6 +220,57 @@ export function createProjectRoutes() {
     }
   });
 
+  app.delete("/:slug/dir", async (c) => {
+    const slug = c.req.param("slug");
+    const path = c.req.query("path");
+    if (!path) return c.json({ error: "path query parameter is required" }, 400);
+
+    const existing = await c.get("projectService").get(slug);
+    if (!existing) return c.json({ error: "Project not found" }, 404);
+
+    try {
+      await c.get("projectService").deleteProjectDir(slug, path);
+      return c.json({ ok: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to delete directory";
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  app.post("/:slug/file/rename", async (c) => {
+    const slug = c.req.param("slug");
+    const existing = await c.get("projectService").get(slug);
+    if (!existing) return c.json({ error: "Project not found" }, 404);
+
+    const { from, to } = await c.req.json<{ from: string; to: string }>();
+    if (!from || !to) return c.json({ error: "from and to are required" }, 400);
+
+    try {
+      await c.get("projectService").renameProjectEntry(slug, from, to);
+      return c.json({ ok: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to rename";
+      return c.json({ error: message }, 400);
+    }
+  });
+
+  app.post("/:slug/dir", async (c) => {
+    const slug = c.req.param("slug");
+    const existing = await c.get("projectService").get(slug);
+    if (!existing) return c.json({ error: "Project not found" }, 404);
+
+    const { path } = await c.req.json<{ path: string }>();
+    if (!path) return c.json({ error: "path is required" }, 400);
+
+    try {
+      await c.get("projectService").createProjectDir(slug, path);
+      return c.json({ ok: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Failed to create directory";
+      return c.json({ error: message }, 400);
+    }
+  });
+
   app.route("/:slug/conversations", createConversationRoutes());
   app.route("/:slug/skills", createSkillRoutes());
 

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -43,6 +43,18 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
       return projectRepo.deleteProjectFile(slug, filePath);
     },
 
+    async deleteProjectDir(slug: string, dirPath: string) {
+      return projectRepo.deleteProjectDir(slug, dirPath);
+    },
+
+    async renameProjectEntry(slug: string, fromPath: string, toPath: string) {
+      return projectRepo.renameProjectEntry(slug, fromPath, toPath);
+    },
+
+    async createProjectDir(slug: string, dirPath: string) {
+      return projectRepo.createProjectDir(slug, dirPath);
+    },
+
     async ensureInitialProject(): Promise<void> {
       const projects = await projectRepo.list();
       if (projects.length > 0) return;


### PR DESCRIPTION
## Summary

에디터 트리뷰의 컨텍스트 메뉴를 확장하여 파일/폴더 관리 기능을 추가합니다.

- **폴더 우클릭**: 새 파일, 새 폴더, 이름 변경, 탐색기에서 열기, 삭제
- **파일 우클릭**: 이름 변경 추가 (기존 탐색기/삭제에 더해)
- **빈 영역 우클릭**: 루트에 새 파일/새 폴더 생성
- **인라인 편집**: VS Code 스타일 — 트리 내에서 직접 이름 입력/변경
- **새 파일 기본 확장자**: `.md` 기본값, 커서가 확장자 앞에 위치
- **열린 파일 이름 변경**: `RENAME_SELECTED` 액션으로 `selectedPath` 동기화 → 저장 시 새 이름으로 저장

### 서버 변경
- `DELETE /:slug/dir` — 폴더 재귀 삭제
- `POST /:slug/file/rename` — 파일/폴더 이름 변경
- `POST /:slug/dir` — 폴더 생성

### 엣지 케이스 처리
- dirty 파일 이름 변경 시 메모리 내용 유지, 다음 저장에 새 경로 사용
- 폴더 이름 변경 시 내부 열린 파일의 경로 prefix 자동 갱신
- 폴더 삭제 시 내부 열린 파일 자동 deselect

## Test plan

- [ ] 폴더 우클릭 → 새 파일 → 인라인 입력 (.md 기본) → Enter → 트리에 표시 + 에디터에 열림
- [ ] 빈 영역 우클릭 → 새 폴더 → 이름 입력 → Enter → 루트에 폴더 생성
- [ ] 파일 우클릭 → 이름 변경 → 인라인 편집 → Enter → 이름 변경 확인
- [ ] 폴더 우클릭 → 삭제 → 확인 다이얼로그 → 삭제됨
- [ ] 파일 열기 → 편집 → 이름 변경 → Ctrl+S → 새 이름으로 저장 확인 (기존 이름 저장 버그 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)