### PR TITLE
fix: pi-agent-core API 변경 및 TreeNode 구조에 맞춰 테스트 수정

### DIFF
--- a/packages/creative-agent/tests/eval/harness.ts
+++ b/packages/creative-agent/tests/eval/harness.ts
@@ -1,9 +1,8 @@
-import { Agent, type AgentEvent } from "@mariozechner/pi-agent-core";
+import { Agent, type AgentEvent, type AgentMessage } from "@mariozechner/pi-agent-core";
 import type { AssistantMessage } from "@mariozechner/pi-ai";
 import { setupCreativeAgent, clearConversationAgentState } from "../../src/agent/orchestrator.js";
 import { createAgentContext } from "../../src/agent/context.js";
 import { createConversation } from "../../src/agent/lifecycle.js";
-import type { StoredMessage } from "../../src/types.js";
 import { createFixture, cleanupFixture, type Fixture } from "./fixtures.js";
 import type { CollectedToolCall } from "./assertions.js";
 
@@ -92,7 +91,7 @@ export class EvalHarness {
     });
     const created = await createConversation(ctx, fixture.slug);
     const conversationId = created.conversation.id;
-    const history: StoredMessage[] = [];
+    const history: AgentMessage[] = [];
 
     const { agent, systemPrompt } = await setupCreativeAgent(
       { provider, model, apiKey, temperature: 0 },
@@ -135,7 +134,7 @@ export class EvalHarness {
     });
 
     let toolCallCount = 0;
-    agent.setAfterToolCall(async () => {
+    agent.afterToolCall = async () => {
       toolCallCount++;
       if (toolCallCount >= maxToolCalls) {
         return {
@@ -144,7 +143,7 @@ export class EvalHarness {
         };
       }
       return undefined;
-    });
+    };
 
     return harness;
   }

--- a/packages/creative-agent/tests/eval/skill-catalog-regression.eval.test.ts
+++ b/packages/creative-agent/tests/eval/skill-catalog-regression.eval.test.ts
@@ -23,7 +23,7 @@ const hasApiKey = !!process.env.GOOGLE_API_KEY;
 const suite = hasApiKey ? describe : describe.skip;
 
 // Two skills in the catalog — model should be selective
-const MULTI_SKILLS = ["outline", "example"];
+const MULTI_SKILLS = ["outline", "journal-search"];
 
 suite("skill catalog: system prompt placement regression", () => {
   let harness: EvalHarness;
@@ -68,8 +68,8 @@ suite("skill catalog: system prompt placement regression", () => {
         name: "outline",
       });
 
-      // Should NOT activate the example skill (irrelevant to the request)
-      expectNoSkillActivation(harness.toolCalls, "example");
+      // Should NOT activate the journal-search skill (irrelevant to the request)
+      expectNoSkillActivation(harness.toolCalls, "journal-search");
     },
     { timeout: 180_000 },
   );
@@ -87,7 +87,7 @@ suite("skill catalog: system prompt placement regression", () => {
 
       // Asking "what can I do?" should ideally result in the model describing
       // the available skills from the catalog WITHOUT activating them.
-      // At most, the model might activate the example skill to demonstrate,
+      // At most, the model might activate one skill to demonstrate,
       // but it should NOT activate both.
       const activations = harness.toolCalls.filter(
         (tc) => tc.toolName === "activate_skill",

--- a/packages/creative-agent/tests/skills/skill-load-consistency.test.ts
+++ b/packages/creative-agent/tests/skills/skill-load-consistency.test.ts
@@ -13,6 +13,7 @@ import {
 } from "../../src/skills/catalog.js";
 import { createActivateSkillTool } from "../../src/skills/manager.js";
 import type { TreeNode } from "../../src/types.js";
+import type { UserMessage, TextContent } from "@mariozechner/pi-ai";
 
 // Two skill-injection paths must produce identical `<skill_content>` text:
 // 1. Slash command → buildUserNodeForPrompt creates a skill-load TreeNode
@@ -52,10 +53,17 @@ afterEach(async () => {
   await rm(projectDir, { recursive: true, force: true });
 });
 
+function getContent(node: TreeNode): string | (TextContent | { type: string })[] {
+  const msg = node.message as UserMessage;
+  return msg.content;
+}
+
 function getText(node: TreeNode): string {
-  const block = node.content[0];
+  const content = getContent(node);
+  if (typeof content === "string") return content;
+  const block = content[0];
   if (block?.type !== "text") throw new Error("expected first content block to be text");
-  return block.text;
+  return (block as TextContent).text;
 }
 
 function getToolResultText(result: { content: { type: string; text?: string }[] }): string {
@@ -65,9 +73,11 @@ function getToolResultText(result: { content: { type: string; text?: string }[] 
 }
 
 function assertSkillLoadShape(node: TreeNode, expectedSkillName: string): void {
-  expect(node.role).toBe("user");
+  expect(node.message.role).toBe("user");
   expect(node.meta).toBe("skill-load");
-  expect(node.content).toHaveLength(1);
+  const content = getContent(node);
+  expect(Array.isArray(content)).toBe(true);
+  expect((content as any[]).length).toBe(1);
   const text = getText(node);
   expect(text.startsWith(SKILL_CONTENT_PREFIX)).toBe(true);
   expect(text).toContain(`name="${expectedSkillName}"`);
@@ -87,10 +97,12 @@ describe("skill-load shape — two injection paths", () => {
     expect(result.nodes).toHaveLength(1);
     const [node] = result.nodes;
 
-    expect(node.role).toBe("user");
+    expect(node.message.role).toBe("user");
     expect(node.meta).toBe("skill-load");
     expect(node.parentId).toBe("leaf-id");
-    expect(node.content).toHaveLength(2);
+    const content = getContent(node);
+    expect(Array.isArray(content)).toBe(true);
+    expect((content as any[]).length).toBe(2);
 
     // content[0] = skill body
     const skillText = getText(node);
@@ -99,9 +111,10 @@ describe("skill-load shape — two injection paths", () => {
     expect(skillText).toContain("</skill_content>");
 
     // content[1] = serialized command
-    const cmdBlock = node.content[1];
+    const contentArr = content as (TextContent | { type: string })[];
+    const cmdBlock = contentArr[1];
     expect(cmdBlock.type).toBe("text");
-    const cmdText = (cmdBlock as { type: "text"; text: string }).text;
+    const cmdText = (cmdBlock as TextContent).text;
     expect(cmdText).toContain("<command-name>/invocable-character</command-name>");
     expect(cmdText).toContain("<command-args>hello world</command-args>");
 


### PR DESCRIPTION
## Summary
- `harness.ts`: `agent.setAfterToolCall()` 메서드가 pi-agent-core에 존재하지 않아 `agent.afterToolCall = ...` 프로퍼티 할당으로 수정, 삭제된 `StoredMessage` 타입을 `AgentMessage`로 교체
- `skill-load-consistency.test.ts`: `TreeNode` 구조 변경(`node.role`/`node.content` → `node.message.role`/`node.message.content`)에 맞춰 테스트 헬퍼 및 assertion 갱신
- `skill-catalog-regression.eval.test.ts`: 존재하지 않는 `"example"` 스킬을 실제 존재하는 `"journal-search"`로 교체

## Test plan
- [x] Unit 테스트 67개 전체 통과 확인 (skills, tools, agent, grep)
- [x] Eval 테스트 16/18 통과 확인 (나머지 2개는 LLM 비결정성으로 인한 간헐적 실패)
- [x] TypeScript 타입 체크 오류 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)