### PR TITLE
feat: 프로젝트·템플릿 커버 이미지 (COVER.* 컨벤션)

### DIFF
--- a/apps/webui/src/client/entities/project/project.types.ts
+++ b/apps/webui/src/client/entities/project/project.types.ts
@@ -6,6 +6,7 @@ export interface Project {
   createdAt: number;
   updatedAt: number;
   notes?: string;
+  hasCover?: boolean;
 }
 
 export interface RenderContext {

--- a/apps/webui/src/client/entities/template/template.types.ts
+++ b/apps/webui/src/client/entities/template/template.types.ts
@@ -2,4 +2,5 @@ export interface TemplateMeta {
   slug: string;
   name: string;
   description?: string;
+  hasCover?: boolean;
 }

--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -3,7 +3,7 @@ import { Check, Plus, Settings, X } from "lucide-react";
 import { ContextMenu } from "@base-ui/react/context-menu";
 import { Menu } from "@base-ui/react/menu";
 import { useI18n } from "@/client/i18n/index.js";
-import { Indicator } from "@/client/shared/ui/index.js";
+import { Indicator, CoverImage } from "@/client/shared/ui/index.js";
 import { fetchTemplates, type TemplateMeta } from "@/client/entities/template/index.js";
 import { useProject } from "./useProject.js";
 import { ProjectSettingsModal } from "./ProjectSettingsModal.js";
@@ -226,6 +226,7 @@ export function ProjectTabs() {
               {isActive && (
                 <Indicator />
               )}
+              <CoverImage type="projects" slug={project.slug} hasCover={project.hasCover} size="sm" />
               <span className="flex-1 truncate">{project.name}</span>
               <span
                 onClick={(e) => {

--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -4,7 +4,7 @@ import { useI18n } from "@/client/i18n/index.js";
 import { useUIDispatch } from "@/client/entities/ui/index.js";
 import { fetchTemplates, type TemplateMeta } from "@/client/entities/template/index.js";
 import { useProject } from "@/client/features/project/index.js";
-import { IconButton, ScrollArea } from "@/client/shared/ui/index.js";
+import { IconButton, ScrollArea, CoverImage } from "@/client/shared/ui/index.js";
 
 export function TemplatesPage() {
   const { t } = useI18n();
@@ -64,8 +64,9 @@ export function TemplatesPage() {
             {templates.map((tpl) => (
               <div
                 key={tpl.slug}
-                className="group border border-edge/8 rounded-xl bg-elevated/50 hover:bg-elevated hover:border-edge/16 transition-all duration-150"
+                className="group border border-edge/8 rounded-xl bg-elevated/50 hover:bg-elevated hover:border-edge/16 transition-all duration-150 overflow-hidden"
               >
+                <CoverImage type="templates" slug={tpl.slug} hasCover={tpl.hasCover} size="md" />
                 <div className="px-5 py-4 flex items-start justify-between gap-4">
                   <div className="flex-1 min-w-0">
                     <h3 className="font-display font-semibold text-sm tracking-tight">

--- a/apps/webui/src/client/shared/ui/CoverImage.tsx
+++ b/apps/webui/src/client/shared/ui/CoverImage.tsx
@@ -1,0 +1,32 @@
+import { Image } from "lucide-react";
+
+interface CoverImageProps {
+  type: "projects" | "templates";
+  slug: string;
+  hasCover?: boolean;
+  size?: "sm" | "md";
+  className?: string;
+}
+
+export function CoverImage({ type, slug, hasCover, size = "sm", className = "" }: CoverImageProps) {
+  const base = size === "sm"
+    ? "w-7 h-7 rounded-lg shrink-0"
+    : "w-full h-32 rounded-t-xl";
+
+  if (!hasCover) {
+    return (
+      <div className={`${base} bg-elevated/80 flex items-center justify-center ${className}`}>
+        <Image size={size === "sm" ? 12 : 24} className="text-fg-4/40" strokeWidth={1.5} />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={`/api/${type}/${encodeURIComponent(slug)}/cover`}
+      alt=""
+      className={`${base} object-cover ${className}`}
+      loading="lazy"
+    />
+  );
+}

--- a/apps/webui/src/client/shared/ui/index.ts
+++ b/apps/webui/src/client/shared/ui/index.ts
@@ -13,3 +13,4 @@ export { Indicator } from "./Indicator.js";
 export { TextInput } from "./TextInput.js";
 export { OptionCardGrid } from "./OptionCardGrid.js";
 export { ScrollArea } from "./ScrollArea.js";
+export { CoverImage } from "./CoverImage.js";

--- a/apps/webui/src/server/paths.ts
+++ b/apps/webui/src/server/paths.ts
@@ -20,6 +20,16 @@ export const PROJECTS_DIR = join(DATA_DIR, "projects");
 
 export const LIBRARY_DIR = join(DATA_DIR, "library");
 
+export const IMAGE_EXTS = ["webp", "png", "jpg", "jpeg", "gif", "svg", "avif"];
+
+export async function probeCover(dir: string): Promise<string | null> {
+  for (const ext of IMAGE_EXTS) {
+    const file = Bun.file(join(dir, `COVER.${ext}`));
+    if (await file.exists()) return `COVER.${ext}`;
+  }
+  return null;
+}
+
 export function assertSafePathSegment(segment: string): void {
   if (
     !segment ||

--- a/apps/webui/src/server/repositories/project.repo.ts
+++ b/apps/webui/src/server/repositories/project.repo.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { slugify, scanWorkspaceFiles, type ProjectFile } from "@agentchan/creative-agent";
 import type { Project } from "../types.js";
+import { probeCover } from "../paths.js";
 
 export interface TreeEntry {
   path: string;
@@ -57,24 +58,33 @@ export function createProjectRepo(projectsDir: string) {
   }
 
   return {
-    async list(): Promise<Project[]> {
+    async list(): Promise<(Project & { hasCover: boolean })[]> {
       if (!existsSync(projectsDir)) {
         await mkdir(projectsDir, { recursive: true });
       }
 
       const entries = await readdir(projectsDir, { withFileTypes: true });
-      const projects: Project[] = [];
+      const results = await Promise.all(
+        entries
+          .filter((e) => e.isDirectory())
+          .map(async (entry) => {
+            const metaPath = projectMetaPath(entry.name);
+            if (!existsSync(metaPath)) return null;
+            const meta = JSON.parse(await readFile(metaPath, "utf-8")) as Project;
+            const hasCover = (await probeCover(projectDir(entry.name))) !== null;
+            return { ...meta, hasCover };
+          }),
+      );
 
-      for (const entry of entries) {
-        if (!entry.isDirectory()) continue;
-        const metaPath = projectMetaPath(entry.name);
-        if (!existsSync(metaPath)) continue;
+      return results
+        .filter((p): p is Project & { hasCover: boolean } => p !== null)
+        .sort((a, b) => b.updatedAt - a.updatedAt);
+    },
 
-        const meta = JSON.parse(await readFile(metaPath, "utf-8")) as Project;
-        projects.push(meta);
-      }
-
-      return projects.sort((a, b) => b.updatedAt - a.updatedAt);
+    async getCoverFile(slug: string): Promise<ReturnType<typeof Bun.file> | null> {
+      const name = await probeCover(projectDir(slug));
+      if (!name) return null;
+      return Bun.file(join(projectDir(slug), name));
     },
 
     async get(slug: string): Promise<Project | null> {

--- a/apps/webui/src/server/repositories/template.repo.ts
+++ b/apps/webui/src/server/repositories/template.repo.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, mkdir, rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
-import { assertSafePathSegment } from "../paths.js";
+import { assertSafePathSegment, probeCover } from "../paths.js";
 
 export interface TemplateMeta {
   slug: string;
@@ -15,7 +15,7 @@ export function createTemplateRepo(templatesDir: string) {
       await mkdir(templatesDir, { recursive: true });
     },
 
-    async list(): Promise<TemplateMeta[]> {
+    async list(): Promise<(TemplateMeta & { hasCover: boolean })[]> {
       if (!existsSync(templatesDir)) return [];
       const entries = await readdir(templatesDir, { withFileTypes: true });
       const dirs = entries.filter((e) => e.isDirectory());
@@ -25,10 +25,18 @@ export function createTemplateRepo(templatesDir: string) {
           if (!existsSync(metaPath)) return null;
           const raw = await readFile(metaPath, "utf-8");
           const meta = JSON.parse(raw) as { name: string; description?: string };
-          return { slug: entry.name, ...meta } as TemplateMeta;
+          const hasCover = (await probeCover(join(templatesDir, entry.name))) !== null;
+          return { slug: entry.name, ...meta, hasCover } as TemplateMeta & { hasCover: boolean };
         }),
       );
-      return results.filter((m): m is TemplateMeta => m !== null);
+      return results.filter((m): m is TemplateMeta & { hasCover: boolean } => m !== null);
+    },
+
+    async getCoverFile(name: string): Promise<ReturnType<typeof Bun.file> | null> {
+      assertSafePathSegment(name);
+      const coverName = await probeCover(join(templatesDir, name));
+      if (!coverName) return null;
+      return Bun.file(join(templatesDir, name, coverName));
     },
 
     getSourceDir(name: string): string {

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -3,7 +3,7 @@ import type { AppEnv } from "../types.js";
 import { createConversationRoutes } from "./conversations.routes.js";
 import { createSkillRoutes } from "./skills.routes.js";
 
-const IMAGE_EXTS = ["webp", "png", "jpg", "jpeg", "gif", "svg", "avif"];
+import { IMAGE_EXTS } from "../paths.js";
 
 export function createProjectRoutes() {
   const app = new Hono<AppEnv>();
@@ -118,6 +118,15 @@ export function createProjectRoutes() {
     const js = await c.get("projectService").transpileRenderer(slug);
     if (js === null) return c.json({ error: "renderer.ts not found" }, 404);
     return c.json({ js });
+  });
+
+  app.get("/:slug/cover", async (c) => {
+    const slug = c.req.param("slug");
+    const file = await c.get("projectService").getCoverFile(slug);
+    if (!file) return c.json({ error: "No cover image" }, 404);
+    return new Response(file, {
+      headers: { "Content-Type": file.type, "Cache-Control": "public, max-age=3600" },
+    });
   });
 
   // Static file serving from files/ workspace with extensionless image fallback

--- a/apps/webui/src/server/routes/template.routes.ts
+++ b/apps/webui/src/server/routes/template.routes.ts
@@ -8,5 +8,14 @@ export function createTemplateRoutes() {
     return c.json(await c.get("templateService").list());
   });
 
+  app.get("/:slug/cover", async (c) => {
+    const slug = c.req.param("slug");
+    const file = await c.get("templateService").getCoverFile(slug);
+    if (!file) return c.json({ error: "No cover image" }, 404);
+    return new Response(file, {
+      headers: { "Content-Type": file.type, "Cache-Control": "public, max-age=3600" },
+    });
+  });
+
   return app;
 }

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -8,6 +8,7 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
 
   return {
     async list() { return projectRepo.list(); },
+    async getCoverFile(slug: string) { return projectRepo.getCoverFile(slug); },
     async get(slug: string) { return projectRepo.get(slug); },
     async create(name: string) { return projectRepo.create(name); },
     async update(slug: string, updates: { name?: string; notes?: string }) {

--- a/apps/webui/src/server/services/template.service.ts
+++ b/apps/webui/src/server/services/template.service.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs";
 import { cp, mkdir, readdir } from "node:fs/promises";
 import { join, dirname } from "node:path";
-import { assertSafePathSegment } from "../paths.js";
+import { assertSafePathSegment, probeCover } from "../paths.js";
 import type { TemplateRepo } from "../repositories/template.repo.js";
 
 interface SaveAsTemplateOptions {
@@ -36,6 +36,7 @@ export function createTemplateService(templateRepo: TemplateRepo, projectsDir: s
 
   return {
     async list() { return templateRepo.list(); },
+    async getCoverFile(name: string) { return templateRepo.getCoverFile(name); },
     getSourceDir(name: string) { return templateRepo.getSourceDir(name); },
 
     async saveProjectAsTemplate(
@@ -65,6 +66,10 @@ export function createTemplateService(templateRepo: TemplateRepo, projectsDir: s
       const skillsSrc = join(srcDir, "skills");
       if (existsSync(skillsSrc)) {
         copies.push(cp(skillsSrc, join(destDir, "skills"), { recursive: true }));
+      }
+      const coverName = await probeCover(srcDir);
+      if (coverName) {
+        copies.push(cp(join(srcDir, coverName), join(destDir, coverName)));
       }
       await Promise.all(copies);
 

--- a/example_data/library/templates/character-chat/COVER.svg
+++ b/example_data/library/templates/character-chat/COVER.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#0d9488;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#134e4a;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#bg)" rx="16"/>
+  <text x="400" y="180" font-family="system-ui,sans-serif" font-size="48" font-weight="700" fill="white" text-anchor="middle" opacity="0.9">Character Chat</text>
+  <text x="400" y="240" font-family="system-ui,sans-serif" font-size="20" fill="white" text-anchor="middle" opacity="0.5">Template Cover</text>
+</svg>

--- a/example_data/library/templates/rpg-chat/COVER.svg
+++ b/example_data/library/templates/rpg-chat/COVER.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="400" viewBox="0 0 800 400">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#7c3aed;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#312e81;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="800" height="400" fill="url(#bg)" rx="16"/>
+  <text x="400" y="180" font-family="system-ui,sans-serif" font-size="48" font-weight="700" fill="white" text-anchor="middle" opacity="0.9">RPG Chat</text>
+  <text x="400" y="240" font-family="system-ui,sans-serif" font-size="20" fill="white" text-anchor="middle" opacity="0.5">Template Cover</text>
+</svg>


### PR DESCRIPTION
## Summary

- 프로젝트/템플릿 루트에 `COVER.*` 파일을 두면 자동으로 커버 이미지로 인식 (SYSTEM.md와 같은 대문자 시스템 파일 컨벤션)
- 사이드바 프로젝트 목록에 28x28 썸네일, 템플릿 선택 페이지에 배너 이미지로 표시
- 커버 이미지가 없으면 플레이스홀더 아이콘 표시

## 변경 사항

### 서버
- `paths.ts`: `IMAGE_EXTS` 상수 + `probeCover()` 유틸리티 추출
- `project.repo.ts` / `template.repo.ts`: `list()`에 `hasCover` 필드 추가, `getCoverFile()` 메서드 추가
- `projects.routes.ts` / `template.routes.ts`: `GET /:slug/cover` 엔드포인트 추가
- `template.service.ts`: 프로젝트→템플릿 저장 시 커버 파일 복사

### 클라이언트
- `CoverImage.tsx`: 재사용 가능한 커버 이미지 + 플레이스홀더 컴포넌트 (sm/md 사이즈)
- `ProjectTabs.tsx`: 사이드바 프로젝트 아이템에 커버 썸네일 추가
- `TemplatesPage.tsx`: 템플릿 카드에 커버 배너 추가

### 예시 데이터
- `character-chat`, `rpg-chat` 템플릿에 테스트용 `COVER.svg` 추가

## Test plan

- [x] 템플릿 페이지에서 커버 이미지가 있는 카드에 이미지 표시 확인
- [x] 커버 이미지 없는 템플릿에 플레이스홀더 표시 확인
- [x] 템플릿에서 프로젝트 생성 후 커버 이미지가 복사되어 사이드바에 표시 확인
- [x] `bunx tsc --noEmit` 통과
- [x] `bun run lint` 통과
- [x] `bun run test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)