### PR TITLE
fix: 모델 설정 파라미터 persistence 복원

### DIFF
--- a/apps/webui/src/server/repositories/settings.repo.ts
+++ b/apps/webui/src/server/repositories/settings.repo.ts
@@ -60,6 +60,10 @@ export function createSettingsRepo(dataDir: string) {
         [key, value],
       );
     },
+
+    deleteAppSetting(key: string): void {
+      db.run("DELETE FROM app_settings WHERE key = ?", [key]);
+    },
   };
 }
 

--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -96,6 +96,27 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     return getProviderList().some((p) => p.name === name);
   }
 
+  function loadNumber(
+    key: string,
+    parse: (raw: string) => number,
+    min: number,
+    max?: number,
+  ): number | undefined {
+    const raw = settingsRepo.getAppSetting(key);
+    if (raw == null) return undefined;
+    const value = parse(raw);
+    if (!Number.isFinite(value)) return undefined;
+    if (value < min) return undefined;
+    if (max !== undefined && value > max) return undefined;
+    return value;
+  }
+
+  function loadThinkingLevel() {
+    const raw = settingsRepo.getAppSetting("config.thinkingLevel");
+    if (raw === "low" || raw === "medium" || raw === "high") return raw;
+    return undefined;
+  }
+
   function loadConfig(): ServerConfig {
     const savedProvider = settingsRepo.getAppSetting("config.provider");
     const savedModel = settingsRepo.getAppSetting("config.model");
@@ -109,7 +130,15 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     } else {
       model = savedModel && ALLOWED_MODELS.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
     }
-    return { provider, model };
+
+    return {
+      provider,
+      model,
+      temperature: loadNumber("config.temperature", parseFloat, 0, 2),
+      maxTokens: loadNumber("config.maxTokens", (s) => parseInt(s, 10), 1),
+      contextWindow: loadNumber("config.contextWindow", (s) => parseInt(s, 10), 1024),
+      thinkingLevel: loadThinkingLevel(),
+    };
   }
 
   const currentConfig: ServerConfig = loadConfig();
@@ -130,17 +159,34 @@ export function createConfigService(settingsRepo: SettingsRepo) {
       if (body.model) {
         currentConfig.model = body.model;
       }
-      if (body.temperature !== undefined) {
-        currentConfig.temperature = body.temperature ?? undefined;
-      }
-      if (body.maxTokens !== undefined) {
-        currentConfig.maxTokens = body.maxTokens ?? undefined;
-      }
-      if (body.contextWindow !== undefined) {
-        currentConfig.contextWindow = body.contextWindow ?? undefined;
-      }
-      if (body.thinkingLevel !== undefined) {
-        currentConfig.thinkingLevel = body.thinkingLevel ?? undefined;
+
+      const persistNumber = (field: "temperature" | "maxTokens" | "contextWindow") => {
+        if (!(field in body)) return;
+        const key = `config.${field}`;
+        const value = body[field];
+        if (value == null) {
+          currentConfig[field] = undefined;
+          settingsRepo.deleteAppSetting(key);
+        } else {
+          currentConfig[field] = value;
+          settingsRepo.setAppSetting(key, String(value));
+        }
+      };
+
+      persistNumber("temperature");
+      persistNumber("maxTokens");
+      persistNumber("contextWindow");
+
+      if ("thinkingLevel" in body) {
+        const level = body.thinkingLevel;
+        // "off" and null both map to "unset" — reasoning stays disabled by default.
+        if (level == null || level === "off") {
+          currentConfig.thinkingLevel = undefined;
+          settingsRepo.deleteAppSetting("config.thinkingLevel");
+        } else {
+          currentConfig.thinkingLevel = level;
+          settingsRepo.setAppSetting("config.thinkingLevel", level);
+        }
       }
 
       settingsRepo.setAppSetting("config.provider", currentConfig.provider);


### PR DESCRIPTION
## Summary
- 서버 `config.service.ts`가 `provider`/`model`만 SQLite `app_settings`에 저장하고, `temperature`/`maxTokens`/`contextWindow`/`thinkingLevel`은 메모리 `currentConfig`에만 남겨 서버 재시작 시 유실되던 버그를 수정합니다.
- `loadConfig()`에서 네 필드를 각각 로드·범위 검증하고, `updateConfig()`에서 set/delete로 persist합니다. `null` 또는 thinking `"off"`가 오면 DB 행을 삭제해 "기본값으로 되돌리기(unset)" 시맨틱을 명시적으로 지원합니다.
- `settingsRepo`에 `deleteAppSetting(key)` 추가.

클라이언트 ModelBar는 이미 모든 필드를 `PUT /api/config`로 보내고 있어 클라이언트 수정은 없습니다.

## 설계 노트
- **스코프는 전역 단일 값** — 프로바이더·모델 전환 시 파라미터 값을 유지하는 현재 UI 동작과 일치하며, DB 키 4개만 늘어나 가장 단순합니다.
- **저장 키**: 기존 \`config.provider\`/\`config.model\`와 동일한 접두사로 \`config.temperature\`/\`config.maxTokens\`/\`config.contextWindow\`/\`config.thinkingLevel\` 추가.
- **\`thinkingLevel = \"off\"\` ≡ unset** — DB에는 \`\"low\"\`/\`\"medium\"\`/\`\"high\"\`만 저장하고, off는 행 삭제로 매핑(추론 비활성화 기본값 유지).
- **하위 호환**: 기존 \`settings.db\`에 4개 키가 없으면 \`undefined\`로 로드되어 현재 동작과 동일 — 마이그레이션 불필요.
- **\`ServerConfig\`의 새 필드는 모두 optional**이라 타입 브레이크 없음.

## Test plan
- [x] \`bunx tsc --noEmit\` (apps/webui) 통과
- [x] \`bun run lint\` 통과 (turbo 전체 패키지)
- [x] ModelBar에서 provider=anthropic, model=claude-sonnet-4-6, temperature=0.7, maxTokens=8000, contextWindow=200000, thinkingLevel=high 설정 → **dev 서버 재시작** → \`GET /api/config\`가 동일한 6개 필드를 반환함을 확인
- [x] 재시작 후 UI 접힌 ModelBar 헤더에 \`T:0.7 high 8000tok 200k ctx\` 배지 4종 모두 노출
- [x] \`PUT /api/config\` with \`thinkingLevel: null\`, \`temperature: null\` → 응답에서 해당 필드가 빠짐 (unset/delete 경로)
- [ ] 기존 \`settings.db\`(4개 키 없음)에서 첫 부팅 시 기본 동작 유지 — 코드 기본값 폴백으로 보장됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)