### PR TITLE
refactor: slash command 팝업 — fuzzy 매칭과 listbox a11y 도입

### DIFF
--- a/apps/webui/package.json
+++ b/apps/webui/package.json
@@ -29,6 +29,7 @@
     "@codemirror/state": "^6.6.0",
     "@codemirror/view": "^6.41.0",
     "@lezer/highlight": "^1.2.3",
+    "command-score": "^0.1.2",
     "hono": "^4.12.12",
     "idiomorph": "^0.7.4",
     "lucide-react": "^1.8.0",

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -92,7 +92,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   };
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (slash.handleKeyDown(e)) return;
+    if (slash.palette.handleKeyDown(e)) return;
 
     if (e.key === "Enter" && !e.shiftKey) {
       e.preventDefault();
@@ -103,12 +103,13 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   const inputContent = (
     <div className={variant === "standalone" ? "max-w-4xl mx-auto" : ""}>
       <div className="relative">
-        {slash.isOpen && (
+        {slash.palette.isOpen && (
           <SlashCommandPopup
-            commands={slash.filteredCommands}
-            selectedIndex={slash.selectedIndex}
+            listboxId={slash.palette.listboxId}
+            commands={slash.palette.items}
+            selectedIndex={slash.palette.selectedIndex}
             onSelect={slash.selectCommand}
-            onHover={slash.setSelectedIndex}
+            onHover={slash.palette.setSelectedIndex}
           />
         )}
         <div className="relative flex items-end gap-2 bg-surface rounded-2xl border border-edge/8 input-glow transition-all duration-200">
@@ -134,6 +135,10 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
                 : t("input.placeholder")
             }
             rows={1}
+            aria-autocomplete="list"
+            aria-expanded={slash.palette.isOpen}
+            aria-controls={slash.palette.isOpen ? slash.palette.listboxId : undefined}
+            aria-activedescendant={slash.palette.isOpen ? slash.palette.activeOptionId : undefined}
             className="flex-1 bg-transparent px-5 py-3.5 text-sm resize-none focus:outline-none text-fg placeholder-fg-4 max-h-[200px] font-body"
           />
           <button

--- a/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
+++ b/apps/webui/src/client/features/chat/SlashCommandPopup.tsx
@@ -1,55 +1,76 @@
 import { useEffect, useRef } from "react";
 import type { SlashEntry } from "./commands.js";
-import { ScrollArea } from "@/client/shared/ui/index.js";
+import { optionId } from "./useCommandPalette.js";
+import { useI18n } from "@/client/i18n/index.js";
 
 interface SlashCommandPopupProps {
+  listboxId: string;
   commands: SlashEntry[];
   selectedIndex: number;
   onSelect: (cmd: SlashEntry) => void;
   onHover: (index: number) => void;
 }
 
-export function SlashCommandPopup({ commands, selectedIndex, onSelect, onHover }: SlashCommandPopupProps) {
+export function SlashCommandPopup({
+  listboxId,
+  commands,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: SlashCommandPopupProps) {
   const listRef = useRef<HTMLDivElement>(null);
+  const { t } = useI18n();
 
   // Scroll selected item into view
   useEffect(() => {
     const container = listRef.current;
     if (!container) return;
-    const item = container.children[selectedIndex] as HTMLElement | undefined;
+    const item = container.querySelector<HTMLElement>(`[data-index="${selectedIndex}"]`);
     item?.scrollIntoView({ block: "nearest" });
   }, [selectedIndex]);
 
-  if (commands.length === 0) return null;
+  const isEmpty = commands.length === 0;
 
   return (
-    <ScrollArea
+    <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated/95 backdrop-blur-md border border-edge/12 rounded-xl shadow-xl shadow-void/60 max-h-[240px] animate-fade z-50"
+      id={listboxId}
+      role="listbox"
+      aria-label={t("slash.listboxLabel")}
+      className="absolute bottom-full left-0 right-0 mb-2 bg-elevated/95 backdrop-blur-md border border-edge/12 rounded-xl shadow-xl shadow-void/60 max-h-[240px] overflow-y-auto animate-fade z-50"
     >
-      {commands.map((cmd, i) => (
-        <button
-          key={`${cmd.kind}:${cmd.name}`}
-          onClick={() => onSelect(cmd)}
-          onMouseEnter={() => onHover(i)}
-          className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
-            i === selectedIndex
-              ? "bg-accent/10 text-accent"
-              : "text-fg-2 hover:bg-white/4"
-          }`}
-        >
-          <span className="font-mono text-sm">/{cmd.name}</span>
-          <span className="text-xs text-fg-3 flex-1 truncate">{cmd.description}</span>
-          {cmd.kind === "skill" && (
-            <span className="text-[10px] uppercase tracking-wider text-accent/70 font-mono px-1.5 py-0.5 rounded bg-accent/10">
-              skill
-            </span>
-          )}
-          {cmd.kind === "local" && cmd.needsArg && cmd.argPlaceholder && (
-            <span className="text-[10px] text-fg-3 font-mono opacity-70">{cmd.argPlaceholder}</span>
-          )}
-        </button>
-      ))}
-    </ScrollArea>
+      {isEmpty ? (
+        <div className="px-4 py-3 text-xs text-fg-3 text-center">{t("slash.noMatches")}</div>
+      ) : (
+        commands.map((cmd, i) => (
+          <button
+            key={`${cmd.kind}:${cmd.name}`}
+            id={optionId(listboxId, cmd)}
+            role="option"
+            aria-selected={i === selectedIndex}
+            tabIndex={-1}
+            data-index={i}
+            onClick={() => onSelect(cmd)}
+            onMouseEnter={() => onHover(i)}
+            className={`w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors ${
+              i === selectedIndex
+                ? "bg-accent/10 text-accent"
+                : "text-fg-2 hover:bg-white/4"
+            }`}
+          >
+            <span className="font-mono text-sm">/{cmd.name}</span>
+            <span className="text-xs text-fg-3 flex-1 truncate">{cmd.description}</span>
+            {cmd.kind === "skill" && (
+              <span className="text-[10px] uppercase tracking-wider text-accent/70 font-mono px-1.5 py-0.5 rounded bg-accent/10">
+                {t("slash.skillTag")}
+              </span>
+            )}
+            {cmd.kind === "local" && cmd.needsArg && cmd.argPlaceholder && (
+              <span className="text-[10px] text-fg-3 font-mono opacity-70">{cmd.argPlaceholder}</span>
+            )}
+          </button>
+        ))
+      )}
+    </div>
   );
 }

--- a/apps/webui/src/client/features/chat/commands.ts
+++ b/apps/webui/src/client/features/chat/commands.ts
@@ -1,3 +1,4 @@
+import commandScore from "command-score";
 import type { SkillMetadata, SkillEnvironment } from "@/client/entities/skill/index.js";
 
 export interface LocalSlashCommand {
@@ -32,4 +33,15 @@ export function buildSlashEntries(skills: SkillMetadata[]): SlashEntry[] {
     .map((s) => ({ kind: "skill" as const, name: s.name, description: s.description, environment: s.environment }))
     .sort((a, b) => a.name.localeCompare(b.name));
   return [...LOCAL_COMMANDS, ...skillEntries];
+}
+
+// command-score returns tiny non-zero scores for unrelated subsequences,
+// so callers need a floor to drop noise matches.
+export const MIN_SCORE = 0.01;
+
+export function scoreEntry(entry: SlashEntry, query: string): number {
+  if (query === "") return 1;
+  const nameScore = commandScore(entry.name, query);
+  const descScore = commandScore(entry.description, query);
+  return Math.max(nameScore, descScore * 0.6);
 }

--- a/apps/webui/src/client/features/chat/useCommandPalette.ts
+++ b/apps/webui/src/client/features/chat/useCommandPalette.ts
@@ -1,0 +1,105 @@
+import { useCallback, useId, useMemo, useState } from "react";
+import { MIN_SCORE, scoreEntry, type SlashEntry } from "./commands.js";
+
+export function optionId(listboxId: string, entry: SlashEntry): string {
+  return `${listboxId}-${entry.kind}-${entry.name}`;
+}
+
+interface UseCommandPaletteArgs {
+  text: string;
+  setText: (s: string) => void;
+  entries: SlashEntry[];
+  onSelect: (entry: SlashEntry) => void;
+}
+
+export interface CommandPalette {
+  /** Palette visible? */
+  isOpen: boolean;
+  /** Fuzzy-filtered + scored entries, already sorted. */
+  items: SlashEntry[];
+  /** Highlighted index (clamped into items range). */
+  selectedIndex: number;
+  setSelectedIndex: (i: number) => void;
+  /** aria ids for listbox + aria-activedescendant wiring. */
+  listboxId: string;
+  activeOptionId: string | undefined;
+  /** Handles ArrowUp/Down/Enter/Tab/Escape. Returns true when event was consumed. */
+  handleKeyDown: (e: React.KeyboardEvent) => boolean;
+}
+
+export function useCommandPalette({
+  text,
+  setText,
+  entries,
+  onSelect,
+}: UseCommandPaletteArgs): CommandPalette {
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const listboxId = useId();
+
+  const query = text.startsWith("/") ? text.slice(1).toLowerCase() : "";
+  const isOpen = text.startsWith("/") && !query.includes(" ");
+
+  const items = useMemo<SlashEntry[]>(() => {
+    if (!isOpen) return [];
+    return entries
+      .map((entry) => ({ entry, score: scoreEntry(entry, query) }))
+      .filter((x) => x.score >= MIN_SCORE)
+      .sort((a, b) => b.score - a.score)
+      .map((x) => x.entry);
+  }, [isOpen, entries, query]);
+
+  const clampedIndex = Math.min(selectedIndex, Math.max(items.length - 1, 0));
+  const activeOptionId = items[clampedIndex] ? optionId(listboxId, items[clampedIndex]) : undefined;
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!isOpen) return false;
+
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setText("");
+        setSelectedIndex(0);
+        return true;
+      }
+
+      // Empty-result state: consume nav keys so stray Enter doesn't submit.
+      if (items.length === 0) {
+        if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Tab") {
+          e.preventDefault();
+          return true;
+        }
+        return false;
+      }
+
+      switch (e.key) {
+        case "ArrowDown":
+          e.preventDefault();
+          setSelectedIndex((i) => (i + 1) % items.length);
+          return true;
+        case "ArrowUp":
+          e.preventDefault();
+          setSelectedIndex((i) => (i - 1 + items.length) % items.length);
+          return true;
+        case "Enter":
+        case "Tab":
+          e.preventDefault();
+          onSelect(items[clampedIndex]);
+          setSelectedIndex(0);
+          return true;
+        default:
+          return false;
+      }
+    },
+    [isOpen, items, clampedIndex, onSelect, setText],
+  );
+
+  return {
+    isOpen,
+    items,
+    selectedIndex: clampedIndex,
+    setSelectedIndex,
+    listboxId,
+    activeOptionId,
+    handleKeyDown,
+  };
+}

--- a/apps/webui/src/client/features/chat/useSlashCommands.ts
+++ b/apps/webui/src/client/features/chat/useSlashCommands.ts
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from "react";
+import { useCallback, useMemo } from "react";
 import { useConfigDispatch, updateConfig } from "@/client/entities/config/index.js";
 import { useSkillState } from "@/client/entities/skill/index.js";
 import { useSessionState } from "@/client/entities/session/index.js";
@@ -6,6 +6,7 @@ import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useConversation } from "./useConversation.js";
 import { useStreaming } from "./useStreaming.js";
 import { buildSlashEntries, LOCAL_COMMANDS, type SlashEntry, type SkillSlashCommand } from "./commands.js";
+import { useCommandPalette } from "./useCommandPalette.js";
 
 export function useSlashCommands(text: string, setText: (s: string) => void) {
   const configDispatch = useConfigDispatch();
@@ -15,24 +16,11 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
   const uiDispatch = useUIDispatch();
   const { create, compact } = useConversation();
   const { send } = useStreaming();
-  const [selectedIndex, setSelectedIndex] = useState(0);
-
-  const query = text.startsWith("/") ? text.slice(1) : "";
-  const isOpen = text.startsWith("/") && !query.includes(" ");
 
   const entries = useMemo(
     () => buildSlashEntries(skillState.skills),
     [skillState.skills],
   );
-
-  const filteredCommands = useMemo<SlashEntry[]>(() => {
-    if (!isOpen) return [];
-    if (query === "") return entries;
-    return entries.filter((cmd) => cmd.name.startsWith(query.toLowerCase()));
-  }, [isOpen, query, entries]);
-
-  // Clamp selectedIndex when filtered list changes
-  const clampedIndex = Math.min(selectedIndex, Math.max(filteredCommands.length - 1, 0));
 
   const executeLocalCommand = useCallback(
     async (name: string, arg: string) => {
@@ -69,10 +57,11 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
       const needsTextInsert = cmd.kind === "skill" || cmd.needsArg;
       if (needsTextInsert) setText("/" + cmd.name + " ");
       else void executeLocalCommand(cmd.name, "");
-      setSelectedIndex(0);
     },
     [executeLocalCommand, setText],
   );
+
+  const palette = useCommandPalette({ text, setText, entries, onSelect: selectCommand });
 
   const tryExecuteCommand = useCallback(
     (input: string): boolean => {
@@ -113,43 +102,5 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
     [executeLocalCommand, entries, session.conversations, session.activeConversationId, create, send, setText],
   );
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent): boolean => {
-      if (!isOpen || filteredCommands.length === 0) return false;
-
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setSelectedIndex((i) => (i + 1) % filteredCommands.length);
-          return true;
-        case "ArrowUp":
-          e.preventDefault();
-          setSelectedIndex((i) => (i - 1 + filteredCommands.length) % filteredCommands.length);
-          return true;
-        case "Enter":
-        case "Tab":
-          e.preventDefault();
-          selectCommand(filteredCommands[clampedIndex]);
-          return true;
-        case "Escape":
-          e.preventDefault();
-          setText("");
-          setSelectedIndex(0);
-          return true;
-        default:
-          return false;
-      }
-    },
-    [isOpen, filteredCommands, clampedIndex, selectCommand, setText],
-  );
-
-  return {
-    isOpen,
-    filteredCommands,
-    selectedIndex: clampedIndex,
-    handleKeyDown,
-    selectCommand,
-    tryExecuteCommand,
-    setSelectedIndex,
-  };
+  return { palette, selectCommand, tryExecuteCommand };
 }

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -59,6 +59,11 @@ export const translations = {
   "input.tokenOut": "out",
   "input.context": "context",
 
+  // Slash command popup
+  "slash.listboxLabel": "Slash commands",
+  "slash.noMatches": "No commands match",
+  "slash.skillTag": "skill",
+
   // Project tabs
   "project.new": "New project",
   "project.namePlaceholder": "Project name...",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -61,6 +61,11 @@ export const translations: Record<TranslationKey, string> = {
   "input.tokenOut": "출력",
   "input.context": "컨텍스트",
 
+  // Slash command popup
+  "slash.listboxLabel": "슬래시 명령",
+  "slash.noMatches": "일치하는 명령이 없습니다",
+  "slash.skillTag": "skill",
+
   // Project tabs
   "project.new": "새 프로젝트",
   "project.namePlaceholder": "프로젝트 이름...",

--- a/apps/webui/src/command-score.d.ts
+++ b/apps/webui/src/command-score.d.ts
@@ -1,0 +1,9 @@
+declare module "command-score" {
+  /**
+   * Fuzzy score of `query` against `string`. Returns a number in [0, 1].
+   * 0 = no match. Exact prefix matches score near 1.
+   * Same scorer used internally by cmdk.
+   */
+  const commandScore: (string: string, query: string) => number;
+  export default commandScore;
+}

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@codemirror/state": "^6.6.0",
         "@codemirror/view": "^6.41.0",
         "@lezer/highlight": "^1.2.3",
+        "command-score": "^0.1.2",
         "hono": "^4.12.12",
         "idiomorph": "^0.7.4",
         "lucide-react": "^1.8.0",
@@ -605,6 +606,8 @@
     "caniuse-lite": ["caniuse-lite@1.0.30001781", "", {}, "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw=="],
 
     "chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "command-score": ["command-score@0.1.2", "", {}, "sha512-VtDvQpIJBvBatnONUsPzXYFVKQQAhuf3XTNOAsdBxCNO/QCtUUd8LSgjn0GVarBkCad6aJCZfXgrjYbl/KRr7w=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 


### PR DESCRIPTION
## Summary

- cmdk 도입을 검토했으나 **textarea 중심 UX ↔ cmdk의 `<Command.Input>` 모델** 사이의 근본적 불일치가 발견되어, cmdk가 내부적으로 쓰는 `command-score`(300LOC, 단일 목적 패키지)만 채택하고 나머지(키보드·a11y·상태)는 얇은 훅(`useCommandPalette`)으로 직접 뽑아냈다.
- `useSlashCommands` 훅의 **파싱·필터링·키보드·selectedIndex**가 한 훅에 몰려 있던 구조를 **프레젠테이션(useCommandPalette)** / **실행 분기(useSlashCommands: executeLocalCommand·tryExecuteCommand·meta skill 자동 세션)**로 분리했다.
- fuzzy 매칭(`/cmp` → `/compact`, `/edt` → `/edit`) 지원, `role=\"listbox\"`/`role=\"option\"`/`aria-selected`/`aria-activedescendant` WAI-ARIA 세트 적용.

## 변경 파일

### 신규
- `apps/webui/src/client/features/chat/useCommandPalette.ts` — 프레젠테이션 제어 훅 (isOpen·items·selectedIndex·listboxId·activeOptionId·handleKeyDown). DOM id 유틸 `optionId`도 이 파일에 colocate.
- `apps/webui/src/command-score.d.ts` — `command-score` default export 타입 선언

### 수정
- `apps/webui/src/client/features/chat/commands.ts` — `scoreEntry(entry, query)`·`MIN_SCORE` 추가. `command-score`는 unrelated subsequence에도 작은 점수를 주므로 floor 필요
- `apps/webui/src/client/features/chat/useSlashCommands.ts` — 실행 전용으로 축소. 반환값을 `{ palette, selectCommand, tryExecuteCommand }`로 변경해 도메인/프레젠테이션 경계 명시
- `apps/webui/src/client/features/chat/SlashCommandPopup.tsx` — `ScrollArea`(공용 컴포넌트가 `role`·`id`·`aria-*`를 수용하지 않음) → native `div`+`overflow-y-auto`로 전환, `role=\"listbox\"`/`role=\"option\"`/`aria-selected` 부착, 빈 결과 텍스트 렌더
- `apps/webui/src/client/features/chat/BottomInput.tsx` — textarea에 `aria-autocomplete=\"list\"`/`aria-expanded`/`aria-controls`/`aria-activedescendant` 연결
- `apps/webui/src/client/i18n/{en,ko}.ts` — \`slash.listboxLabel\`, \`slash.noMatches\`, \`slash.skillTag\` 키 병렬 추가
- `apps/webui/package.json`, `bun.lock` — \`command-score@^0.1.2\` 의존성

## 설계 메모 — 왜 cmdk가 아닌가

- **textarea가 주 입력**이라 cmdk의 `<Command.Input>` 중심 모델과 긴장. 제어 모드로 강제하면 라이브러리 추상화가 오히려 방해
- `tryExecuteCommand`(팝업 없이 `/new` 직접 타이핑 후 Enter) 같은 **팝업 밖 경로**는 cmdk의 mental model 밖
- meta skill 자동 세션 생성 같은 도메인 특화 분기가 많아 어차피 외부에 있음
- 결과적으로 cmdk를 쓰면 **들어가는 wiring이 빼주는 것보다 많음**. `command-score`만 골라 쓰는 게 최소 의존성 + 최대 이점

## Test plan

- [x] `bunx tsc --noEmit` (apps/webui) — 통과
- [x] `bun run lint` — 통과
- [x] `bun run test` — 44 pass (webui에는 유닛테스트 없음, creative-agent만)
- [x] 브라우저 검증 12 시나리오 (agent-browser로 실행):
  - [x] **S1**: `/` → 팝업 열림 + 로컬 5개 + skill 알파벳순
  - [x] **S2**: `/cmp` → `/compact` 매칭, `/edt` → `/edit`
  - [x] **S3**: ArrowDown 2회 + Enter → `/edit` 실행 (편집 모드 토글 확인)
  - [x] **S4**: `/model` 선택 → textbox에 `/model ` prefill (length=7, trailing space)
  - [x] **S5**: `/provider openai` 직접 Enter → Footer가 `GOO gemini-3-flash-preview`에서 `OPE gpt-5.1`로 갱신
  - [x] **S6**: `/characters` 선택 → `/characters ` prefill + 팝업 닫힘
  - [x] **S7**: `/build-renderer hello` Enter → 새 conversation의 \`mode: \"meta\"\` 자동 설정
  - [x] **S8**: `/xyzzy` → optionCount=0, \"일치하는 명령이 없습니다\" 렌더
  - [x] **S9**: Escape → 팝업 닫힘 + textarea 비워짐
  - [x] **S10**: `/model `(공백) → 팝업 자동 닫힘
  - [x] **S11**: Tab으로 선택 확정
  - [x] **S12**: 스트리밍 중 Enter guard 보존(`BottomInput.tsx:78`의 `if (!trimmed || isStreaming) return` 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)