### PR TITLE
fix: 에디터 모드 이탈 시 미저장 확인 다이얼로그 표시

### DIFF
--- a/apps/webui/src/client/app/AppShell.tsx
+++ b/apps/webui/src/client/app/AppShell.tsx
@@ -40,18 +40,6 @@ export function AppShell() {
   const { resolved: userScheme } = useTheme();
   const { t } = useI18n();
 
-  // Ctrl+E / Cmd+E to toggle edit mode (main page only)
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if ((e.ctrlKey || e.metaKey) && e.key === "e" && ui.currentPage.page === "main") {
-        e.preventDefault();
-        uiDispatch({ type: "SET_VIEW_MODE", mode: ui.viewMode === "edit" ? "chat" : "edit" });
-      }
-    };
-    document.addEventListener("keydown", handler);
-    return () => document.removeEventListener("keydown", handler);
-  }, [ui.currentPage.page, ui.viewMode, uiDispatch]);
-
   // Clear tab title badge for the currently-viewed project.
   // Runs on: project switch, visibility change (user returns to tab).
   useEffect(() => {

--- a/apps/webui/src/client/entities/editor/EditorContext.tsx
+++ b/apps/webui/src/client/entities/editor/EditorContext.tsx
@@ -13,6 +13,7 @@ const initialState: EditorState = {
   fileContent: null,
   localContent: null,
   dirty: false,
+  pendingTransition: null,
 };
 
 function editorReducer(state: EditorState, action: EditorAction): EditorState {
@@ -26,6 +27,7 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
         fileContent: action.content,
         localContent: action.content,
         dirty: false,
+        pendingTransition: null,
       };
     case "SYNC_EXTERNAL_CONTENT":
       return {
@@ -53,11 +55,16 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
         fileContent: null,
         localContent: null,
         dirty: false,
+        pendingTransition: null,
       };
     case "RENAME_SELECTED":
       return { ...state, selectedPath: action.newPath };
     case "CLEAR":
       return initialState;
+    case "SET_PENDING_TRANSITION":
+      return { ...state, pendingTransition: action.transition };
+    case "CLEAR_PENDING_TRANSITION":
+      return { ...state, pendingTransition: null };
     default:
       return state;
   }

--- a/apps/webui/src/client/entities/editor/editor.types.ts
+++ b/apps/webui/src/client/entities/editor/editor.types.ts
@@ -11,12 +11,19 @@ export interface TreeEntry {
   modifiedAt?: number;
 }
 
+// Local literal for view mode to avoid cross-entity import from entities/ui.
+// Must stay in sync with ViewMode in entities/ui/UIContext.tsx.
+export type EditorPendingTransition =
+  | { type: "select-file"; path: string }
+  | { type: "change-mode"; mode: "chat" | "edit" };
+
 export interface EditorState {
   treeEntries: TreeEntry[];
   selectedPath: string | null;
   fileContent: string | null;
   localContent: string | null;
   dirty: boolean;
+  pendingTransition: EditorPendingTransition | null;
 }
 
 export type EditorAction =
@@ -27,4 +34,6 @@ export type EditorAction =
   | { type: "MARK_CLEAN" }
   | { type: "DESELECT_FILE" }
   | { type: "RENAME_SELECTED"; newPath: string }
-  | { type: "CLEAR" };
+  | { type: "CLEAR" }
+  | { type: "SET_PENDING_TRANSITION"; transition: EditorPendingTransition }
+  | { type: "CLEAR_PENDING_TRANSITION" };

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -1,5 +1,5 @@
 export { EditorProvider, useEditorState, useEditorDispatch } from "./EditorContext.js";
 export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile, revealProjectFile, deleteProjectDir, renameProjectEntry, createProjectDir } from "./editor.api.js";
-export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
+export type { TreeEntry, EditorState, EditorAction, EditorPendingTransition } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
 export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";

--- a/apps/webui/src/client/entities/ui/EditModeToggle.tsx
+++ b/apps/webui/src/client/entities/ui/EditModeToggle.tsx
@@ -1,10 +1,15 @@
 import { PenLine, Eye } from "lucide-react";
-import { useUIState, useUIDispatch, type ViewMode } from "./UIContext.js";
+import { useUIState, type ViewMode } from "./UIContext.js";
 import { useI18n } from "@/client/i18n/index.js";
 
-export function EditModeToggle() {
+interface EditModeToggleProps {
+  // Parent owns the guarded toggle behavior (e.g. prompting on unsaved
+  // changes); required to prevent accidental unguarded dispatches.
+  onToggle: (nextMode: ViewMode) => void;
+}
+
+export function EditModeToggle({ onToggle }: EditModeToggleProps) {
   const ui = useUIState();
-  const uiDispatch = useUIDispatch();
   const { t } = useI18n();
 
   const isEdit = ui.viewMode === "edit";
@@ -14,7 +19,7 @@ export function EditModeToggle() {
 
   return (
     <button
-      onClick={() => uiDispatch({ type: "SET_VIEW_MODE", mode: nextMode })}
+      onClick={() => onToggle(nextMode)}
       className="p-2 rounded-lg text-fg-3 hover:text-accent hover:bg-accent/8 transition-all"
       title={label}
     >

--- a/apps/webui/src/client/features/chat/SessionTabs.tsx
+++ b/apps/webui/src/client/features/chat/SessionTabs.tsx
@@ -1,6 +1,7 @@
 import { ChevronsRight, Plus, Settings, X } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import { useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
+import { useEditorGuard } from "@/client/features/editor/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { ScrollArea } from "@/client/shared/ui/index.js";
 import { useConversation } from "./useConversation.js";
@@ -10,6 +11,7 @@ export function SessionTabs() {
   const uiDispatch = useUIDispatch();
   const { t } = useI18n();
   const { create, load, remove } = useConversation();
+  const { requestViewMode } = useEditorGuard();
 
   return (
     <div className="flex items-center border-b border-edge/6">
@@ -62,7 +64,7 @@ export function SessionTabs() {
         </button>
       </ScrollArea>
 
-      <EditModeToggle />
+      <EditModeToggle onToggle={requestViewMode} />
       <button
         onClick={() => uiDispatch({ type: "TOGGLE_AGENT_PANEL" })}
         className="flex-shrink-0 px-2 py-1.5 text-fg-3 hover:text-fg-2 transition-colors"

--- a/apps/webui/src/client/features/chat/useSlashCommands.ts
+++ b/apps/webui/src/client/features/chat/useSlashCommands.ts
@@ -2,7 +2,8 @@ import { useCallback, useMemo } from "react";
 import { useConfigDispatch, updateConfig } from "@/client/entities/config/index.js";
 import { useSkillState } from "@/client/entities/skill/index.js";
 import { useSessionState } from "@/client/entities/session/index.js";
-import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
+import { useUIState } from "@/client/entities/ui/index.js";
+import { useEditorGuard } from "@/client/features/editor/index.js";
 import { useConversation } from "./useConversation.js";
 import { useStreaming } from "./useStreaming.js";
 import { buildSlashEntries, LOCAL_COMMANDS, type SlashEntry, type SkillSlashCommand } from "./commands.js";
@@ -13,7 +14,7 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
   const skillState = useSkillState();
   const session = useSessionState();
   const ui = useUIState();
-  const uiDispatch = useUIDispatch();
+  const { requestViewMode } = useEditorGuard();
   const { create, compact } = useConversation();
   const { send } = useStreaming();
 
@@ -32,7 +33,7 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
           await compact();
           break;
         case "edit":
-          uiDispatch({ type: "SET_VIEW_MODE", mode: ui.viewMode === "edit" ? "chat" : "edit" });
+          requestViewMode(ui.viewMode === "edit" ? "chat" : "edit");
           break;
         case "model": {
           const result = await updateConfig({ model: arg });
@@ -47,7 +48,7 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
       }
       setText("");
     },
-    [create, compact, configDispatch, uiDispatch, ui.viewMode, setText],
+    [create, compact, configDispatch, requestViewMode, ui.viewMode, setText],
   );
 
   const selectCommand = useCallback(

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -86,7 +86,7 @@ export function EditModePanel() {
       <UnsavedDialog
         open={unsavedDialogOpen}
         onSave={() => void handleUnsavedSave()}
-        onDiscard={handleUnsavedDiscard}
+        onDiscard={() => void handleUnsavedDiscard()}
         onCancel={handleUnsavedCancel}
       />
 

--- a/apps/webui/src/client/features/editor/index.ts
+++ b/apps/webui/src/client/features/editor/index.ts
@@ -3,3 +3,4 @@ export { FileEditor } from "./FileEditor.js";
 export { EditModePanel } from "./EditModePanel.js";
 export { UnsavedDialog } from "./UnsavedDialog.js";
 export { useEditMode } from "./useEditMode.js";
+export { useEditorGuard } from "./useEditorGuard.js";

--- a/apps/webui/src/client/features/editor/useEditMode.ts
+++ b/apps/webui/src/client/features/editor/useEditMode.ts
@@ -14,6 +14,7 @@ import {
   createProjectDir,
   revealProjectFile,
 } from "@/client/entities/editor/index.js";
+import { useEditorGuard } from "./useEditorGuard.js";
 
 export function useEditMode() {
   const ui = useUIState();
@@ -21,6 +22,7 @@ export function useEditMode() {
   const stream = useActiveStream();
   const editor = useEditorState();
   const editorDispatch = useEditorDispatch();
+  const guard = useEditorGuard();
 
   const slug = project.activeProjectSlug;
   const isEdit = ui.viewMode === "edit";
@@ -30,9 +32,6 @@ export function useEditMode() {
 
   useEffect(() => { selectedPathRef.current = editor.selectedPath; }, [editor.selectedPath]);
   useEffect(() => { dirtyRef.current = editor.dirty; }, [editor.dirty]);
-
-  // Pending navigation while unsaved dialog is shown
-  const [pendingPath, setPendingPath] = useState<string | null>(null);
 
   // Pending delete confirmation
   const [deleteConfirmPath, setDeleteConfirmPath] = useState<string | null>(null);
@@ -77,44 +76,9 @@ export function useEditMode() {
     editorDispatch({ type: "SELECT_FILE", path, content });
   }, [slug, editorDispatch]);
 
-  const selectFile = useCallback((path: string) => {
-    if (path === editor.selectedPath) return;
-    if (editor.dirty) {
-      setPendingPath(path);
-      return;
-    }
-    void loadFile(path);
-  }, [editor.selectedPath, editor.dirty, loadFile]);
-
-  const saveCurrentFile = useCallback(async () => {
-    if (!slug || !editor.selectedPath || editor.localContent === null) return;
-    await writeProjectFile(slug, editor.selectedPath, editor.localContent);
-    editorDispatch({ type: "MARK_CLEAN" });
-  }, [slug, editor.selectedPath, editor.localContent, editorDispatch]);
-
   const handleDocChange = useCallback((content: string) => {
     editorDispatch({ type: "UPDATE_LOCAL_CONTENT", content });
   }, [editorDispatch]);
-
-  // Unsaved dialog handlers
-  const handleUnsavedSave = useCallback(async () => {
-    await saveCurrentFile();
-    if (pendingPath) {
-      void loadFile(pendingPath);
-      setPendingPath(null);
-    }
-  }, [saveCurrentFile, pendingPath, loadFile]);
-
-  const handleUnsavedDiscard = useCallback(() => {
-    if (pendingPath) {
-      void loadFile(pendingPath);
-      setPendingPath(null);
-    }
-  }, [pendingPath, loadFile]);
-
-  const handleUnsavedCancel = useCallback(() => {
-    setPendingPath(null);
-  }, []);
 
   // Delete flow
   const requestDeleteFile = useCallback((path: string) => {
@@ -216,14 +180,13 @@ export function useEditMode() {
     selectedPath: editor.selectedPath,
     fileContent: editor.localContent,
     dirty: editor.dirty,
-    selectFile,
-    saveCurrentFile,
+    selectFile: guard.requestSelectFile,
+    saveCurrentFile: guard.saveCurrentFile,
     handleDocChange,
-    // Unsaved dialog
-    unsavedDialogOpen: pendingPath !== null,
-    handleUnsavedSave,
-    handleUnsavedDiscard,
-    handleUnsavedCancel,
+    unsavedDialogOpen: guard.unsavedDialogOpen,
+    handleUnsavedSave: guard.handleUnsavedSave,
+    handleUnsavedDiscard: guard.handleUnsavedDiscard,
+    handleUnsavedCancel: guard.handleUnsavedCancel,
     // Delete dialog
     deleteConfirmPath,
     requestDeleteFile,

--- a/apps/webui/src/client/features/editor/useEditorGuard.ts
+++ b/apps/webui/src/client/features/editor/useEditorGuard.ts
@@ -1,0 +1,95 @@
+import { useCallback } from "react";
+import { useProjectState } from "@/client/entities/project/index.js";
+import { useUIDispatch, type ViewMode } from "@/client/entities/ui/index.js";
+import {
+  useEditorState,
+  useEditorDispatch,
+  readProjectFile,
+  writeProjectFile,
+  type EditorPendingTransition,
+} from "@/client/entities/editor/index.js";
+
+/**
+ * Guards mode switches and file selections against unsaved editor changes.
+ *
+ * When the editor is dirty, a transition request is stored in EditorContext
+ * (pendingTransition) instead of firing immediately. `EditModePanel` observes
+ * this flag to render `UnsavedDialog`; the user's choice (save/discard/cancel)
+ * then either applies the pending transition or clears it.
+ *
+ * Safe to call from multiple components in parallel — all share the same
+ * EditorContext/UIContext state.
+ */
+export function useEditorGuard() {
+  const editor = useEditorState();
+  const editorDispatch = useEditorDispatch();
+  const uiDispatch = useUIDispatch();
+  const project = useProjectState();
+  const slug = project.activeProjectSlug;
+
+  const applyTransition = useCallback(async (t: EditorPendingTransition) => {
+    if (t.type === "change-mode") {
+      uiDispatch({ type: "SET_VIEW_MODE", mode: t.mode });
+      return;
+    }
+    if (!slug) return;
+    const { content } = await readProjectFile(slug, t.path);
+    editorDispatch({ type: "SELECT_FILE", path: t.path, content });
+  }, [slug, editorDispatch, uiDispatch]);
+
+  const requestViewMode = useCallback((mode: ViewMode) => {
+    if (editor.dirty) {
+      editorDispatch({
+        type: "SET_PENDING_TRANSITION",
+        transition: { type: "change-mode", mode },
+      });
+    } else {
+      uiDispatch({ type: "SET_VIEW_MODE", mode });
+    }
+  }, [editor.dirty, editorDispatch, uiDispatch]);
+
+  const requestSelectFile = useCallback((path: string) => {
+    if (path === editor.selectedPath) return;
+    if (editor.dirty) {
+      editorDispatch({
+        type: "SET_PENDING_TRANSITION",
+        transition: { type: "select-file", path },
+      });
+    } else {
+      void applyTransition({ type: "select-file", path });
+    }
+  }, [editor.selectedPath, editor.dirty, editorDispatch, applyTransition]);
+
+  const saveCurrentFile = useCallback(async () => {
+    if (!slug || !editor.selectedPath || editor.localContent === null) return;
+    await writeProjectFile(slug, editor.selectedPath, editor.localContent);
+    editorDispatch({ type: "MARK_CLEAN" });
+  }, [slug, editor.selectedPath, editor.localContent, editorDispatch]);
+
+  const handleUnsavedSave = useCallback(async () => {
+    const pending = editor.pendingTransition;
+    await saveCurrentFile();
+    editorDispatch({ type: "CLEAR_PENDING_TRANSITION" });
+    if (pending) await applyTransition(pending);
+  }, [editor.pendingTransition, saveCurrentFile, editorDispatch, applyTransition]);
+
+  const handleUnsavedDiscard = useCallback(async () => {
+    const pending = editor.pendingTransition;
+    editorDispatch({ type: "CLEAR_PENDING_TRANSITION" });
+    if (pending) await applyTransition(pending);
+  }, [editor.pendingTransition, editorDispatch, applyTransition]);
+
+  const handleUnsavedCancel = useCallback(() => {
+    editorDispatch({ type: "CLEAR_PENDING_TRANSITION" });
+  }, [editorDispatch]);
+
+  return {
+    requestViewMode,
+    requestSelectFile,
+    saveCurrentFile,
+    unsavedDialogOpen: editor.pendingTransition !== null,
+    handleUnsavedSave,
+    handleUnsavedDiscard,
+    handleUnsavedCancel,
+  };
+}

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef, useCallback, Suspense, lazy } from "react";
+import { useState, useRef, useCallback, useEffect, Suspense, lazy } from "react";
 import { ChevronsLeft } from "lucide-react";
 import { useProjectState } from "@/client/entities/project/index.js";
 import { useUIState, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { RenderedView } from "@/client/features/project/index.js";
 import { AgentPanel, BottomInput, useConversation } from "@/client/features/chat/index.js";
+import { useEditorGuard } from "@/client/features/editor/index.js";
 import { ResizeHandle } from "@/client/shared/ui/ResizeHandle.js";
 
 const EditModePanel = lazy(() =>
@@ -27,6 +28,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
   const ui = useUIState();
   const { t } = useI18n();
   const { create } = useConversation();
+  const { requestViewMode } = useEditorGuard();
   const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef(0);
@@ -39,6 +41,20 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
     const maxWidth = container.getBoundingClientRect().width * MAX_PANEL_RATIO;
     setPanelWidth(Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, dragStartRef.current - delta)));
   }, []);
+
+  // Ctrl+E / Cmd+E to toggle edit mode. Scoped to ProjectPage so the shortcut
+  // is naturally inactive on non-project pages, and so the AppShell tree does
+  // not need to subscribe to editor state.
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === "e") {
+        e.preventDefault();
+        requestViewMode(isEdit ? "chat" : "edit");
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [isEdit, requestViewMode]);
 
   return (
     <>
@@ -91,7 +107,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
           </div>
         ) : (
           <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20">
-            <EditModeToggle />
+            <EditModeToggle onToggle={requestViewMode} />
             <div className="flex-1" />
             <button
               onClick={onToggleAgentPanel}


### PR DESCRIPTION
## Summary
- 에디터에서 파일을 dirty 상태로 둔 채 Edit → Chat 모드로 전환할 때 `UnsavedDialog`가 뜨지 않고 변경사항이 조용히 날아가던 버그 수정
- 파일 전환 / 모드 전환(토글 버튼, Ctrl+E, `/edit`) 네 트리거가 `useEditorGuard` 훅을 공유하도록 통일
- pending transition 상태를 EditorContext로 승격해 `EditModePanel` 언마운트 이후에도 다이얼로그 상태가 살아남도록 구조 변경

## 원인
- 파일 선택(`useEditMode.selectFile`)은 `editor.dirty`를 체크해 로컬 `pendingPath` state로 가드하고 있었으나, 모드 전환 3곳은 모두 `uiDispatch({ type: "SET_VIEW_MODE", ... })`를 직접 호출해 가드를 우회
- pending 상태가 `EditModePanel` 내부 `useEditMode` 훅의 로컬 state에 있어서 Chat 모드로 전환되는 순간 EditModePanel이 언마운트되고 다이얼로그를 띄울 방법이 사라짐

## 주요 변경
- **신규**: `features/editor/useEditorGuard.ts` — `requestViewMode`, `requestSelectFile`, `saveCurrentFile`, unsaved 다이얼로그 핸들러 제공. 어디서든 호출 가능한 경량 훅
- **EditorContext 확장**: `pendingTransition: { type: "select-file" | "change-mode" } | null` 상태와 `SET_PENDING_TRANSITION`/`CLEAR_PENDING_TRANSITION` 액션 추가
- **EditModeToggle**: `onToggle` prop required로 변경, 내부 `uiDispatch` fallback 제거해 unguarded 전환 경로 봉쇄
- **Ctrl+E 단축키**: `AppShell` → `ProjectPage`로 이동. main 페이지 가드가 자연스러워지고 AppShell 트리가 editor state를 구독하지 않게 되어 타이핑 시 전역 리렌더 카스케이드 방지
- `useEditMode`는 `selectFile`/`saveCurrentFile`/unsaved 핸들러를 `useEditorGuard`에서 재export — 중복 구현 제거

## 테스트 계획
- [x] 토글 버튼 시나리오 — Cancel(Edit 유지) / Discard(즉시 Chat + 파일 원본 유지) / Save(변경 저장 후 Chat 전환) 모두 정상 동작
- [x] Ctrl+E 단축키 — dirty 상태에서 다이얼로그 표시, 클린 상태에서는 즉시 전환
- [x] `/edit` 슬래시 커맨드 — 동일하게 다이얼로그 경유
- [x] 기존 파일 전환 플로우 보존 — 파일 A dirty 상태에서 파일 B 클릭 시 다이얼로그 표시, Discard/Save 후 파일 B로 전환
- [x] 클린 상태에서 모드 전환 — 다이얼로그 없이 즉시
- [x] `bunx tsc --noEmit` (apps/webui), `bun run lint`, `bun run test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)