### PR TITLE
feat: "General" 기본 프로젝트 자동 생성 제거 + 0개 상태 지원

### DIFF
--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -270,7 +270,7 @@ export function ProjectTabs() {
               >
                 <Settings size={10} strokeWidth={2} />
               </span>
-              {isActive && projects.length > 1 && (
+              {isActive && (
                 <span
                   onClick={(e) => {
                     e.stopPropagation();

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -50,6 +50,8 @@ export const translations = {
 
   // Empty state
   "empty.subtitle": "creative writing studio",
+  "empty.noProjectTitle": "Start your first project from a template",
+  "empty.browseTemplates": "Browse templates",
   "empty.openAgentPanel": "Open agent panel",
   "empty.showAgentPanel": "Show agent panel",
 

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -52,6 +52,8 @@ export const translations: Record<TranslationKey, string> = {
 
   // Empty state
   "empty.subtitle": "크리에이티브 라이팅 스튜디오",
+  "empty.noProjectTitle": "첫 프로젝트를 템플릿에서 시작하세요",
+  "empty.browseTemplates": "템플릿 둘러보기",
   "empty.openAgentPanel": "에이전트 패널 열기",
   "empty.showAgentPanel": "에이전트 패널 표시",
 

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,10 +1,10 @@
 import { useState, useRef, useCallback, Suspense, lazy } from "react";
 import { ChevronsLeft } from "lucide-react";
 import { useProjectState } from "@/client/entities/project/index.js";
-import { useUIState, EditModeToggle } from "@/client/entities/ui/index.js";
+import { useUIState, useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { RenderedView } from "@/client/features/project/index.js";
-import { AgentPanel, BottomInput, useConversation } from "@/client/features/chat/index.js";
+import { AgentPanel, BottomInput } from "@/client/features/chat/index.js";
 import { ResizeHandle } from "@/client/shared/ui/ResizeHandle.js";
 
 const EditModePanel = lazy(() =>
@@ -25,8 +25,8 @@ interface ProjectPageProps {
 export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageProps) {
   const project = useProjectState();
   const ui = useUIState();
+  const uiDispatch = useUIDispatch();
   const { t } = useI18n();
-  const { create } = useConversation();
   const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef(0);
@@ -64,10 +64,11 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
             {project.activeProjectSlug ? (
               <RenderedView />
             ) : (
-              <EmptyState onCreate={async () => {
-                await create();
-                if (!agentPanelOpen) onToggleAgentPanel();
-              }} />
+              <EmptyState
+                onBrowseTemplates={() =>
+                  uiDispatch({ type: "NAVIGATE", route: { page: "templates" } })
+                }
+              />
             )}
           </div>
         )}
@@ -110,7 +111,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
   );
 }
 
-function EmptyState({ onCreate }: { onCreate: () => void }) {
+function EmptyState({ onBrowseTemplates }: { onBrowseTemplates: () => void }) {
   const { t } = useI18n();
   return (
     <div className="flex-1 flex items-center justify-center">
@@ -121,14 +122,21 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
         <h2 className="font-display text-3xl font-bold tracking-tight text-fg mb-2">
           agent<span className="text-accent">chan</span>
         </h2>
-        <p className="text-sm text-fg-3 mb-8 tracking-wide">
+        <p className="text-sm text-fg-3 mb-2 tracking-wide">
           {t("empty.subtitle")}
         </p>
+        <p className="text-sm text-fg-2 mb-8 tracking-wide">
+          {t("empty.noProjectTitle")}
+        </p>
         <button
-          onClick={onCreate}
-          className="px-6 py-2.5 rounded-xl bg-accent/10 border border-accent/20 text-accent text-sm font-medium hover:bg-accent/15 hover:border-accent/30 active:scale-[0.98] transition-all duration-200"
+          type="button"
+          onClick={onBrowseTemplates}
+          className="group inline-flex items-center gap-2 px-6 py-2.5 rounded-xl bg-accent/10 border border-accent/20 text-accent text-sm font-medium hover:bg-accent/15 hover:border-accent/30 active:scale-[0.98] transition-all duration-200"
         >
-          {t("session.new")}
+          {t("empty.browseTemplates")}
+          <span aria-hidden className="transition-transform group-hover:translate-x-0.5">
+            →
+          </span>
         </button>
       </div>
     </div>

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -63,7 +63,6 @@ const agentService = createAgentService(agentContext);
 
 // ===== 3. Bootstrap =====
 await templateRepo.ensureDir();
-await projectService.ensureInitialProject();
 
 // ===== 4. Hono App =====
 const app = new Hono<AppEnv>();

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -14,11 +14,7 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
     async update(slug: string, updates: { name?: string; notes?: string }) {
       return projectRepo.update(slug, updates);
     },
-    async delete(slug: string) {
-      const projects = await projectRepo.list();
-      if (projects.length <= 1) throw new Error("Cannot delete the last project");
-      return projectRepo.delete(slug);
-    },
+    async delete(slug: string) { return projectRepo.delete(slug); },
     async duplicate(sourceSlug: string, name: string) { return projectRepo.duplicate(sourceSlug, name); },
     async createFromTemplate(name: string, templateName: string) {
       const templateDir = templateRepo.getSourceDir(templateName);
@@ -54,12 +50,6 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
 
     async createProjectDir(slug: string, dirPath: string) {
       return projectRepo.createProjectDir(slug, dirPath);
-    },
-
-    async ensureInitialProject(): Promise<void> {
-      const projects = await projectRepo.list();
-      if (projects.length > 0) return;
-      await projectRepo.create("General");
     },
 
     async transpileRenderer(slug: string): Promise<string | null> {


### PR DESCRIPTION
## Summary

- 서버 부트스트랩에서 **\"General\" 기본 프로젝트 자동 생성 로직**을 제거했습니다. 프로젝트 0개 상태를 정상 상태로 지원합니다.
- 서버의 \"Cannot delete the last project\" 가드와 클라이언트의 \`projects.length > 1\` 가드를 함께 제거해, 사용자가 원하면 마지막 프로젝트까지 삭제할 수 있습니다.
- 프로젝트 0개일 때 \`ProjectPage\` EmptyState의 버튼이 기존에는 활성 프로젝트 없이 no-op로 호출되는 \`useConversation.create()\`였는데, 이를 **\"템플릿 둘러보기 →\"** 버튼으로 교체해 Templates 페이지로 자연스럽게 유도합니다.

## 배경

- 기존 동작은 첫 실행 시 항상 \"General\"이라는 빈 프로젝트를 강제로 만들어 사용자에게 노출했습니다. 최근 재단장된 \"The Library\" UX(템플릿에서 시작) 방향과 어긋났습니다.
- 코드베이스 조사 결과 프로젝트 0개 상태는 이미 \`App.tsx\`, \`ProjectPage.tsx\`, \`projectReducer\` 등 대부분의 클라이언트 표면에서 안전하게 처리되고 있었고, 서버 자동 생성/삭제 가드만 제거하면 엣지 케이스가 발생하지 않습니다.

## 변경 파일

- \`apps/webui/src/server/services/project.service.ts\` — \`ensureInitialProject()\` 메서드 제거, \`delete()\` 가드 제거(단일 라인 passthrough로 축약)
- \`apps/webui/src/server/index.ts\` — 부트스트랩에서 \`ensureInitialProject()\` 호출 삭제
- \`apps/webui/src/client/features/project/ProjectTabs.tsx\` — 마지막 프로젝트 삭제 X 버튼을 숨기던 \`projects.length > 1\` 가드 제거
- \`apps/webui/src/client/pages/ProjectPage.tsx\` — \`EmptyState\`를 Templates 네비게이션 전용으로 재작성. \`useConversation\` 의존성 제거, \`useUIDispatch\` 추가. 버튼은 \`TemplatesPage\`의 hover-translate \`→\` 패턴(\`<span aria-hidden>\`) 채택
- \`apps/webui/src/client/i18n/en.ts\`, \`ko.ts\` — \`empty.noProjectTitle\`, \`empty.browseTemplates\` 키 추가 (en/ko 동시 갱신)

## Test plan

- [x] **S1 (신규 사용자)**: \`apps/webui/data/projects/\`가 빈 상태에서 서버 기동 → \"General\" 자동 생성 없음 확인. EmptyState에서 \"템플릿 둘러보기 →\" 클릭 → Templates 페이지 이동 → 템플릿 선택 → 이름 입력 → 프로젝트 생성 및 메인 전환
- [x] **S2 (마지막 프로젝트 삭제)**: 프로젝트 1개 상태에서 탭의 X 버튼 클릭 → 확인 팝업 체크 → 삭제 성공(서버 4xx 에러 없음), 자동으로 EmptyState 렌더
- [x] **S3 (새로고침 복원력)**: 0개 상태에서 페이지 리로드 → EmptyState 유지, 서버가 자동 재생성하지 않음, 콘솔 에러 없음, 4xx/5xx 네트워크 요청 없음
- [x] \`bunx tsc --noEmit\` (apps/webui) 통과
- [x] \`bun run lint\` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)