### PR TITLE
feat: 새 버전 출시 알림 기능 추가

### DIFF
--- a/apps/webui/src/client/App.tsx
+++ b/apps/webui/src/client/App.tsx
@@ -3,6 +3,7 @@ import { useProjectDispatch, fetchProjects } from "@/client/entities/project/ind
 import { useSessionDispatch, fetchConversations } from "@/client/entities/session/index.js";
 import { useConfigDispatch, fetchConfig, fetchProviders } from "@/client/entities/config/index.js";
 import { useSkillDispatch, fetchSkills } from "@/client/entities/skill/index.js";
+import { localStore } from "@/client/shared/storage.js";
 
 import { AppShell } from "@/client/app/index.js";
 
@@ -30,7 +31,7 @@ export function App() {
       });
       configDispatch({ type: "SET_PROVIDERS", providers });
 
-      const lastSlug = localStorage.getItem("agentchan-last-project");
+      const lastSlug = localStore.lastProject.read();
       const defaultProject = (lastSlug && projects.find((p) => p.slug === lastSlug)) ?? projects[0];
       if (defaultProject) {
         projectDispatch({ type: "SET_ACTIVE_PROJECT", slug: defaultProject.slug });

--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -4,6 +4,7 @@ import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, ScrollArea } from "@/client/shared/ui/index.js";
 import { ProjectTabs } from "@/client/features/project/index.js";
 import { ModelBar } from "@/client/features/settings/index.js";
+import { UpdateBanner } from "@/client/features/update/index.js";
 import { SkillList } from "./SkillList.js";
 
 export function Sidebar() {
@@ -67,6 +68,7 @@ export function Sidebar() {
 
       {/* Bottom panel */}
       <div>
+        <UpdateBanner />
         <ModelBar />
         <SkillList />
       </div>

--- a/apps/webui/src/client/entities/ui/UIContext.tsx
+++ b/apps/webui/src/client/entities/ui/UIContext.tsx
@@ -6,6 +6,7 @@ import {
   type ReactNode,
   type Dispatch,
 } from "react";
+import { localStore } from "@/client/shared/storage.js";
 
 // --- PageRoute ---
 
@@ -61,13 +62,11 @@ function uiReducer(state: UIState, action: UIAction): UIState {
 
 // --- Context ---
 
-const savedViewMode = (localStorage.getItem("agentchan-view-mode") as ViewMode | null) ?? "chat";
-
 const initialState: UIState = {
   sidebarOpen: true,
   agentPanelOpen: true,
   currentPage: { page: "main" },
-  viewMode: savedViewMode,
+  viewMode: localStore.viewMode.read(),
   readmeOpen: false,
 };
 
@@ -78,7 +77,7 @@ export function UIProvider({ children }: { children: ReactNode }) {
   const [state, dispatch] = useReducer(uiReducer, initialState);
 
   useEffect(() => {
-    localStorage.setItem("agentchan-view-mode", state.viewMode);
+    localStore.viewMode.write(state.viewMode);
   }, [state.viewMode]);
 
   return (

--- a/apps/webui/src/client/entities/update/index.ts
+++ b/apps/webui/src/client/entities/update/index.ts
@@ -1,3 +1,3 @@
 export { fetchUpdateStatus } from "./update.api.js";
-export { useUpdateStatus, readDismissedVersion, writeDismissedVersion } from "./useUpdateStatus.js";
+export { useUpdateStatus } from "./useUpdateStatus.js";
 export type { UpdateStatus } from "./update.types.js";

--- a/apps/webui/src/client/entities/update/index.ts
+++ b/apps/webui/src/client/entities/update/index.ts
@@ -1,0 +1,3 @@
+export { fetchUpdateStatus } from "./update.api.js";
+export { useUpdateStatus, readDismissedVersion, writeDismissedVersion } from "./useUpdateStatus.js";
+export type { UpdateStatus } from "./update.types.js";

--- a/apps/webui/src/client/entities/update/update.api.ts
+++ b/apps/webui/src/client/entities/update/update.api.ts
@@ -1,0 +1,6 @@
+import { json } from "@/client/shared/api.js";
+import type { UpdateStatus } from "./update.types.js";
+
+export function fetchUpdateStatus(force = false): Promise<UpdateStatus> {
+  return json(`/update${force ? "?force=1" : ""}`);
+}

--- a/apps/webui/src/client/entities/update/update.types.ts
+++ b/apps/webui/src/client/entities/update/update.types.ts
@@ -1,0 +1,11 @@
+// Mirrors `UpdateStatus` in src/server/services/update.service.ts.
+// Kept locally (not imported from server) so the client bundle stays independent.
+export interface UpdateStatus {
+  current: string;
+  latest: string | null;
+  hasUpdate: boolean;
+  releaseUrl: string | null;
+  publishedAt: string | null;
+  releaseNotes: string;
+  checkedAt: number;
+}

--- a/apps/webui/src/client/entities/update/useUpdateStatus.ts
+++ b/apps/webui/src/client/entities/update/useUpdateStatus.ts
@@ -4,20 +4,35 @@ import type { UpdateStatus } from "./update.types.js";
 
 const DISMISS_KEY = "agentchan.updateDismissed";
 
-/**
- * Returns the update status once available. We only fetch on mount — the
- * server caches for an hour, so hitting the endpoint on every app load is
- * essentially free and avoids stale state across long-running tabs.
- */
+// Shared across all hook instances so Sidebar's banner and Settings' About
+// section never issue duplicate HTTP calls on the same page load.
+let cachedStatus: UpdateStatus | null = null;
+let inflight: Promise<UpdateStatus | null> | null = null;
+
+function sharedFetch(): Promise<UpdateStatus | null> {
+  if (cachedStatus) return Promise.resolve(cachedStatus);
+  if (!inflight) {
+    inflight = fetchUpdateStatus()
+      .then((s) => {
+        cachedStatus = s;
+        return s;
+      })
+      .catch(() => null) // Offline / API down — stay silent.
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
 export function useUpdateStatus(): UpdateStatus | null {
-  const [status, setStatus] = useState<UpdateStatus | null>(null);
+  const [status, setStatus] = useState<UpdateStatus | null>(cachedStatus);
 
   useEffect(() => {
+    if (cachedStatus) return;
     let cancelled = false;
-    void fetchUpdateStatus().then((next) => {
+    void sharedFetch().then((next) => {
       if (!cancelled) setStatus(next);
-    }).catch(() => {
-      // Offline / API down — stay silent rather than spamming the UI.
     });
     return () => {
       cancelled = true;
@@ -27,11 +42,8 @@ export function useUpdateStatus(): UpdateStatus | null {
   return status;
 }
 
-/**
- * Persist the dismissed version in localStorage so the banner does not
- * re-appear after a user has acknowledged it. A newer release will have a
- * different `latest` value and will therefore surface again.
- */
+// Per-version dismissal — storing the version (not a boolean) ensures the
+// banner re-appears automatically when a newer release arrives.
 export function readDismissedVersion(): string | null {
   try {
     return localStorage.getItem(DISMISS_KEY);

--- a/apps/webui/src/client/entities/update/useUpdateStatus.ts
+++ b/apps/webui/src/client/entities/update/useUpdateStatus.ts
@@ -1,0 +1,49 @@
+import { useEffect, useState } from "react";
+import { fetchUpdateStatus } from "./update.api.js";
+import type { UpdateStatus } from "./update.types.js";
+
+const DISMISS_KEY = "agentchan.updateDismissed";
+
+/**
+ * Returns the update status once available. We only fetch on mount — the
+ * server caches for an hour, so hitting the endpoint on every app load is
+ * essentially free and avoids stale state across long-running tabs.
+ */
+export function useUpdateStatus(): UpdateStatus | null {
+  const [status, setStatus] = useState<UpdateStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchUpdateStatus().then((next) => {
+      if (!cancelled) setStatus(next);
+    }).catch(() => {
+      // Offline / API down — stay silent rather than spamming the UI.
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return status;
+}
+
+/**
+ * Persist the dismissed version in localStorage so the banner does not
+ * re-appear after a user has acknowledged it. A newer release will have a
+ * different `latest` value and will therefore surface again.
+ */
+export function readDismissedVersion(): string | null {
+  try {
+    return localStorage.getItem(DISMISS_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function writeDismissedVersion(version: string): void {
+  try {
+    localStorage.setItem(DISMISS_KEY, version);
+  } catch {
+    // Private mode / quota — best-effort only.
+  }
+}

--- a/apps/webui/src/client/entities/update/useUpdateStatus.ts
+++ b/apps/webui/src/client/entities/update/useUpdateStatus.ts
@@ -2,8 +2,6 @@ import { useEffect, useState } from "react";
 import { fetchUpdateStatus } from "./update.api.js";
 import type { UpdateStatus } from "./update.types.js";
 
-const DISMISS_KEY = "agentchan.updateDismissed";
-
 // Shared across all hook instances so Sidebar's banner and Settings' About
 // section never issue duplicate HTTP calls on the same page load.
 let cachedStatus: UpdateStatus | null = null;
@@ -40,22 +38,4 @@ export function useUpdateStatus(): UpdateStatus | null {
   }, []);
 
   return status;
-}
-
-// Per-version dismissal — storing the version (not a boolean) ensures the
-// banner re-appears automatically when a newer release arrives.
-export function readDismissedVersion(): string | null {
-  try {
-    return localStorage.getItem(DISMISS_KEY);
-  } catch {
-    return null;
-  }
-}
-
-export function writeDismissedVersion(version: string): void {
-  try {
-    localStorage.setItem(DISMISS_KEY, version);
-  } catch {
-    // Private mode / quota — best-effort only.
-  }
 }

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -3,9 +3,9 @@ import { ArrowUp, ChevronsLeft } from "lucide-react";
 import { useSessionState } from "@/client/entities/session/index.js";
 import {
   notificationPermission,
-  readNotificationPreference,
   requestNotificationPermission,
 } from "@/client/shared/notifications.js";
+import { localStore } from "@/client/shared/storage.js";
 import { useConfigState } from "@/client/entities/config/index.js";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -88,7 +88,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
     // First send in this session: opportunistically request Notification
     // permission. Must happen in a user gesture handler (click/keydown) to
     // satisfy browser policy. Fire-and-forget — we don't block send.
-    if (readNotificationPreference() === "on" && notificationPermission() === "default") {
+    if (localStore.notifications.read() === "on" && notificationPermission() === "default") {
       void requestNotificationPermission();
     }
 

--- a/apps/webui/src/client/features/project/useProject.ts
+++ b/apps/webui/src/client/features/project/useProject.ts
@@ -16,6 +16,7 @@ import {
   abortProjectStream,
 } from "@/client/entities/session/index.js";
 import { useSkillDispatch, fetchSkills } from "@/client/entities/skill/index.js";
+import { localStore } from "@/client/shared/storage.js";
 
 export function useProject() {
   const projectState = useProjectState();
@@ -37,7 +38,7 @@ export function useProject() {
       // wouldn't re-run (primitive equality), leaving the renderer blank.
       if (projectState.activeProjectSlug === slug) return;
 
-      localStorage.setItem("agentchan-last-project", slug);
+      localStore.lastProject.write(slug);
       const rememberedSessionId = projectState.projectActiveSession.get(slug);
       projectDispatch({ type: "SET_ACTIVE_PROJECT", slug, currentConversationId: sessionState.activeConversationId });
       // SWITCH_PROJECT replaces the active view but preserves streams Map so
@@ -120,7 +121,7 @@ export function useProject() {
       if (projectState.activeProjectSlug === slug) {
         const fallback = projectState.projects.find((p) => p.slug !== slug);
         if (fallback) {
-          localStorage.setItem("agentchan-last-project", fallback.slug);
+          localStore.lastProject.write(fallback.slug);
           projectDispatch({ type: "SET_ACTIVE_PROJECT", slug: fallback.slug, currentConversationId: sessionState.activeConversationId });
           sessionDispatch({ type: "SWITCH_PROJECT", projectSlug: fallback.slug, conversations: [] });
           skillDispatch({ type: "CLEAR" });

--- a/apps/webui/src/client/features/settings/SettingsView.tsx
+++ b/apps/webui/src/client/features/settings/SettingsView.tsx
@@ -12,6 +12,7 @@ import {
   writeNotificationPreference,
   type NotificationPreference,
 } from "@/client/shared/notifications.js";
+import { AboutSection } from "@/client/features/update/index.js";
 import { useTheme, useThemeOptions } from "./useTheme.js";
 
 type SettingsTab = "appearance" | "api-keys";
@@ -106,6 +107,12 @@ function AppearanceTab() {
       <section className="space-y-4">
         <SectionHeader title={t("notifications.title")} />
         <NotificationsSection />
+      </section>
+
+      {/* About / Version */}
+      <section className="space-y-4">
+        <SectionHeader title={t("update.currentVersion")} />
+        <AboutSection />
       </section>
     </div>
   );

--- a/apps/webui/src/client/features/settings/SettingsView.tsx
+++ b/apps/webui/src/client/features/settings/SettingsView.tsx
@@ -7,11 +7,10 @@ import { useI18n, type LanguagePreference, type TranslationKey } from "@/client/
 import { Badge, Button, IconButton, Indicator, SectionHeader, TabBar, Select, FormField, OptionCardGrid, TextInput, ScrollArea } from "@/client/shared/ui/index.js";
 import {
   notificationPermission,
-  readNotificationPreference,
   requestNotificationPermission,
-  writeNotificationPreference,
   type NotificationPreference,
 } from "@/client/shared/notifications.js";
+import { localStore } from "@/client/shared/storage.js";
 import { AboutSection } from "@/client/features/update/index.js";
 import { useTheme, useThemeOptions } from "./useTheme.js";
 
@@ -122,14 +121,14 @@ function AppearanceTab() {
 
 function NotificationsSection() {
   const { t } = useI18n();
-  const [pref, setPref] = useState<NotificationPreference>(() => readNotificationPreference());
+  const [pref, setPref] = useState<NotificationPreference>(() => localStore.notifications.read());
   const [permission, setPermission] = useState<NotificationPermission | "unsupported">(
     () => notificationPermission(),
   );
 
   const handleToggle = async (next: NotificationPreference) => {
     setPref(next);
-    writeNotificationPreference(next);
+    localStore.notifications.write(next);
     if (next === "on" && permission === "default") {
       const result = await requestNotificationPermission();
       setPermission(result);

--- a/apps/webui/src/client/features/settings/useTheme.ts
+++ b/apps/webui/src/client/features/settings/useTheme.ts
@@ -9,6 +9,7 @@ import {
 } from "react";
 import { createElement } from "react";
 import { useI18n } from "@/client/i18n/index.js";
+import { localStore } from "@/client/shared/storage.js";
 
 export type ThemePreference = "system" | "light" | "dark";
 export type ResolvedTheme = "light" | "dark";
@@ -19,7 +20,6 @@ interface ThemeContextValue {
   setPreference: (pref: ThemePreference) => void;
 }
 
-const STORAGE_KEY = "agentchan-theme";
 const MEDIA_QUERY = "(prefers-color-scheme: dark)";
 
 function getSystemTheme(): ResolvedTheme {
@@ -36,14 +36,6 @@ function applyTheme(resolved: ResolvedTheme) {
   document.querySelector('meta[name="theme-color"]')?.setAttribute("content", metaColor);
 }
 
-function readStoredPreference(): ThemePreference {
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v === "light" || v === "dark" || v === "system") return v;
-  } catch {}
-  return "system";
-}
-
 const ThemeContext = createContext<ThemeContextValue>({
   preference: "system",
   resolved: "dark",
@@ -51,12 +43,12 @@ const ThemeContext = createContext<ThemeContextValue>({
 });
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [preference, setPreferenceState] = useState<ThemePreference>(readStoredPreference);
-  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveTheme(readStoredPreference()));
+  const [preference, setPreferenceState] = useState<ThemePreference>(() => localStore.theme.read());
+  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveTheme(localStore.theme.read()));
 
   const setPreference = useCallback((pref: ThemePreference) => {
     setPreferenceState(pref);
-    try { localStorage.setItem(STORAGE_KEY, pref); } catch {}
+    localStore.theme.write(pref);
     const r = resolveTheme(pref);
     setResolved(r);
     applyTheme(r);

--- a/apps/webui/src/client/features/update/AboutSection.tsx
+++ b/apps/webui/src/client/features/update/AboutSection.tsx
@@ -2,10 +2,6 @@ import { Sparkles, CheckCircle2 } from "lucide-react";
 import { useUpdateStatus } from "@/client/entities/update/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 
-/**
- * Read-only "about" block for the settings page. Surfaces the running version
- * and, when the server has confirmed a newer release on GitHub, a link to it.
- */
 export function AboutSection() {
   const status = useUpdateStatus();
   const { t } = useI18n();

--- a/apps/webui/src/client/features/update/AboutSection.tsx
+++ b/apps/webui/src/client/features/update/AboutSection.tsx
@@ -1,0 +1,50 @@
+import { Sparkles, CheckCircle2 } from "lucide-react";
+import { useUpdateStatus } from "@/client/entities/update/index.js";
+import { useI18n } from "@/client/i18n/index.js";
+
+/**
+ * Read-only "about" block for the settings page. Surfaces the running version
+ * and, when the server has confirmed a newer release on GitHub, a link to it.
+ */
+export function AboutSection() {
+  const status = useUpdateStatus();
+  const { t } = useI18n();
+
+  const current = status?.current ?? "…";
+
+  return (
+    <div className="rounded-xl border border-edge/8 bg-elevated/40 px-4 py-4 space-y-3">
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm text-fg">{t("update.currentVersion")}</div>
+          <div className="text-xs text-fg-3 font-mono mt-1">v{current}</div>
+        </div>
+        {status && !status.hasUpdate && status.latest != null && (
+          <div className="flex items-center gap-1.5 text-xs text-fg-3 shrink-0">
+            <CheckCircle2 size={13} strokeWidth={2} className="text-accent" />
+            {t("update.upToDate")}
+          </div>
+        )}
+      </div>
+      {status?.hasUpdate && status.latest && status.releaseUrl && (
+        <a
+          href={status.releaseUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-start gap-2.5 px-3 py-2.5 rounded-lg bg-accent/8 hover:bg-accent/12 transition-colors"
+        >
+          <Sparkles size={14} strokeWidth={2} className="text-accent shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <div className="text-xs font-medium text-fg">{t("update.available")}</div>
+            <div className="text-[11px] text-fg-3 font-mono mt-0.5">
+              {t("update.versionLine", { current: status.current, latest: status.latest })}
+            </div>
+          </div>
+          <span className="text-xs text-accent shrink-0 self-center">
+            {t("update.viewRelease")}
+          </span>
+        </a>
+      )}
+    </div>
+  );
+}

--- a/apps/webui/src/client/features/update/UpdateBanner.tsx
+++ b/apps/webui/src/client/features/update/UpdateBanner.tsx
@@ -1,0 +1,58 @@
+import { useState } from "react";
+import { Sparkles, X } from "lucide-react";
+import {
+  useUpdateStatus,
+  readDismissedVersion,
+  writeDismissedVersion,
+} from "@/client/entities/update/index.js";
+import { useI18n } from "@/client/i18n/index.js";
+
+/**
+ * Slim banner shown above the ModelBar when a newer release is published on
+ * GitHub. Dismiss is sticky per-version: acknowledging v1.2.3 hides the banner
+ * until v1.2.4 arrives.
+ */
+export function UpdateBanner() {
+  const status = useUpdateStatus();
+  const { t } = useI18n();
+  const [dismissed, setDismissed] = useState<string | null>(() => readDismissedVersion());
+
+  if (!status || !status.hasUpdate || !status.latest || !status.releaseUrl) return null;
+  if (dismissed === status.latest) return null;
+
+  const handleDismiss = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!status.latest) return;
+    writeDismissedVersion(status.latest);
+    setDismissed(status.latest);
+  };
+
+  return (
+    <a
+      href={status.releaseUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group flex items-start gap-2.5 px-4 py-3 border-t border-edge/6 bg-accent/8 hover:bg-accent/12 transition-colors"
+      title={t("update.viewRelease")}
+    >
+      <Sparkles size={14} strokeWidth={2} className="text-accent shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0">
+        <div className="text-xs font-medium text-fg leading-tight">
+          {t("update.available")}
+        </div>
+        <div className="text-[11px] text-fg-3 font-mono mt-0.5 truncate">
+          {t("update.versionLine", { current: status.current, latest: status.latest })}
+        </div>
+      </div>
+      <button
+        onClick={handleDismiss}
+        className="shrink-0 p-0.5 rounded text-fg-4 hover:text-fg-2 hover:bg-elevated/60 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+        title={t("update.dismiss")}
+        aria-label={t("update.dismiss")}
+      >
+        <X size={12} strokeWidth={2.5} />
+      </button>
+    </a>
+  );
+}

--- a/apps/webui/src/client/features/update/UpdateBanner.tsx
+++ b/apps/webui/src/client/features/update/UpdateBanner.tsx
@@ -7,11 +7,7 @@ import {
 } from "@/client/entities/update/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 
-/**
- * Slim banner shown above the ModelBar when a newer release is published on
- * GitHub. Dismiss is sticky per-version: acknowledging v1.2.3 hides the banner
- * until v1.2.4 arrives.
- */
+// Dismiss is per-version: acknowledging v1.2.3 hides the banner until v1.2.4 arrives.
 export function UpdateBanner() {
   const status = useUpdateStatus();
   const { t } = useI18n();
@@ -20,39 +16,42 @@ export function UpdateBanner() {
   if (!status || !status.hasUpdate || !status.latest || !status.releaseUrl) return null;
   if (dismissed === status.latest) return null;
 
-  const handleDismiss = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
+  const handleDismiss = () => {
     if (!status.latest) return;
     writeDismissedVersion(status.latest);
     setDismissed(status.latest);
   };
 
+  // <a> and <button> are siblings — nesting a button inside an anchor is invalid
+  // HTML and breaks screen-reader/keyboard navigation. The button is absolutely
+  // positioned over the anchor so the layout still reads as a single row.
   return (
-    <a
-      href={status.releaseUrl}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="group flex items-start gap-2.5 px-4 py-3 border-t border-edge/6 bg-accent/8 hover:bg-accent/12 transition-colors"
-      title={t("update.viewRelease")}
-    >
-      <Sparkles size={14} strokeWidth={2} className="text-accent shrink-0 mt-0.5" />
-      <div className="flex-1 min-w-0">
-        <div className="text-xs font-medium text-fg leading-tight">
-          {t("update.available")}
+    <div className="relative group border-t border-edge/6 bg-accent/8 hover:bg-accent/12 transition-colors">
+      <a
+        href={status.releaseUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="flex items-start gap-2.5 px-4 py-3"
+        title={t("update.viewRelease")}
+      >
+        <Sparkles size={14} strokeWidth={2} className="text-accent shrink-0 mt-0.5" />
+        <div className="flex-1 min-w-0">
+          <div className="text-xs font-medium text-fg leading-tight">
+            {t("update.available")}
+          </div>
+          <div className="text-[11px] text-fg-3 font-mono mt-0.5 truncate">
+            {t("update.versionLine", { current: status.current, latest: status.latest })}
+          </div>
         </div>
-        <div className="text-[11px] text-fg-3 font-mono mt-0.5 truncate">
-          {t("update.versionLine", { current: status.current, latest: status.latest })}
-        </div>
-      </div>
+      </a>
       <button
         onClick={handleDismiss}
-        className="shrink-0 p-0.5 rounded text-fg-4 hover:text-fg-2 hover:bg-elevated/60 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
+        className="absolute top-2 right-2 p-0.5 rounded text-fg-4 hover:text-fg-2 hover:bg-elevated/60 transition-colors opacity-0 group-hover:opacity-100 focus:opacity-100"
         title={t("update.dismiss")}
         aria-label={t("update.dismiss")}
       >
         <X size={12} strokeWidth={2.5} />
       </button>
-    </a>
+    </div>
   );
 }

--- a/apps/webui/src/client/features/update/UpdateBanner.tsx
+++ b/apps/webui/src/client/features/update/UpdateBanner.tsx
@@ -1,24 +1,21 @@
 import { useState } from "react";
 import { Sparkles, X } from "lucide-react";
-import {
-  useUpdateStatus,
-  readDismissedVersion,
-  writeDismissedVersion,
-} from "@/client/entities/update/index.js";
+import { useUpdateStatus } from "@/client/entities/update/index.js";
 import { useI18n } from "@/client/i18n/index.js";
+import { localStore } from "@/client/shared/storage.js";
 
 // Dismiss is per-version: acknowledging v1.2.3 hides the banner until v1.2.4 arrives.
 export function UpdateBanner() {
   const status = useUpdateStatus();
   const { t } = useI18n();
-  const [dismissed, setDismissed] = useState<string | null>(() => readDismissedVersion());
+  const [dismissed, setDismissed] = useState<string | null>(() => localStore.updateDismissed.read());
 
   if (!status || !status.hasUpdate || !status.latest || !status.releaseUrl) return null;
   if (dismissed === status.latest) return null;
 
   const handleDismiss = () => {
     if (!status.latest) return;
-    writeDismissedVersion(status.latest);
+    localStore.updateDismissed.write(status.latest);
     setDismissed(status.latest);
   };
 

--- a/apps/webui/src/client/features/update/index.ts
+++ b/apps/webui/src/client/features/update/index.ts
@@ -1,0 +1,2 @@
+export { UpdateBanner } from "./UpdateBanner.js";
+export { AboutSection } from "./AboutSection.js";

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -247,6 +247,14 @@ export const translations = {
   "notifications.sessionCompleteBody": "Tap to view the response.",
   "notifications.sessionError": "{{project}} hit an error",
   "notifications.sessionErrorBody": "Tap to see the details.",
+
+  // Update notifications
+  "update.available": "New version available",
+  "update.versionLine": "v{{current}} → v{{latest}}",
+  "update.viewRelease": "View release",
+  "update.dismiss": "Dismiss",
+  "update.currentVersion": "Current version",
+  "update.upToDate": "You're on the latest version",
 } as const satisfies Record<string, string>;
 
 export type TranslationKey = keyof typeof translations;

--- a/apps/webui/src/client/i18n/index.ts
+++ b/apps/webui/src/client/i18n/index.ts
@@ -10,6 +10,7 @@ import {
 } from "react";
 import { translations as en, type TranslationKey } from "./en.js";
 import { translations as ko } from "./ko.js";
+import { localStore } from "@/client/shared/storage.js";
 
 export type LanguagePreference = "system" | "en" | "ko";
 export type ResolvedLanguage = "en" | "ko";
@@ -24,7 +25,6 @@ interface I18nContextValue {
   setPreference: (pref: LanguagePreference) => void;
 }
 
-const STORAGE_KEY = "agentchan-language";
 const SUPPORTED: ResolvedLanguage[] = ["en", "ko"];
 
 const dictionaries: Record<ResolvedLanguage, Record<string, string>> = { en, ko };
@@ -40,14 +40,6 @@ function resolveLanguage(pref: LanguagePreference): ResolvedLanguage {
   return SUPPORTED.includes(pref as ResolvedLanguage) ? (pref as ResolvedLanguage) : "en";
 }
 
-function readStoredPreference(): LanguagePreference {
-  try {
-    const v = localStorage.getItem(STORAGE_KEY);
-    if (v === "en" || v === "ko" || v === "system") return v;
-  } catch {}
-  return "system";
-}
-
 function applyLang(resolved: ResolvedLanguage) {
   document.documentElement.lang = resolved;
 }
@@ -60,12 +52,12 @@ const I18nContext = createContext<I18nContextValue>({
 });
 
 export function I18nProvider({ children }: { children: ReactNode }) {
-  const [preference, setPreferenceState] = useState<LanguagePreference>(readStoredPreference);
-  const [resolved, setResolved] = useState<ResolvedLanguage>(() => resolveLanguage(readStoredPreference()));
+  const [preference, setPreferenceState] = useState<LanguagePreference>(() => localStore.language.read());
+  const [resolved, setResolved] = useState<ResolvedLanguage>(() => resolveLanguage(localStore.language.read()));
 
   const setPreference = useCallback((pref: LanguagePreference) => {
     setPreferenceState(pref);
-    try { localStorage.setItem(STORAGE_KEY, pref); } catch {}
+    localStore.language.write(pref);
     const r = resolveLanguage(pref);
     setResolved(r);
     applyLang(r);

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -249,4 +249,12 @@ export const translations: Record<TranslationKey, string> = {
   "notifications.sessionCompleteBody": "응답을 확인하려면 탭하세요.",
   "notifications.sessionError": "{{project}} 오류 발생",
   "notifications.sessionErrorBody": "상세 내용을 확인하려면 탭하세요.",
+
+  // Update notifications
+  "update.available": "새 버전이 출시되었습니다",
+  "update.versionLine": "v{{current}} → v{{latest}}",
+  "update.viewRelease": "릴리스 보기",
+  "update.dismiss": "닫기",
+  "update.currentVersion": "현재 버전",
+  "update.upToDate": "최신 버전을 사용 중입니다",
 };

--- a/apps/webui/src/client/shared/notifications.ts
+++ b/apps/webui/src/client/shared/notifications.ts
@@ -5,32 +5,12 @@
  * Falls back silently when the API is unavailable or permission is denied —
  * UI indicators (tab title badge, project-tab dot) handle that case.
  *
- * This module is intentionally side-effect only (no React state); callers
- * are `features/*` hooks that already have access to UI state.
+ * Preference persistence lives in `shared/storage.ts` (`localStore.notifications`).
  */
 
-const LOCAL_STORAGE_KEY = "agentchan-notifications";
-
-// --- Preferences ---
+import { localStore } from "./storage.js";
 
 export type NotificationPreference = "on" | "off";
-
-export function readNotificationPreference(): NotificationPreference {
-  try {
-    const v = localStorage.getItem(LOCAL_STORAGE_KEY);
-    return v === "off" ? "off" : "on";
-  } catch {
-    return "on";
-  }
-}
-
-export function writeNotificationPreference(pref: NotificationPreference): void {
-  try {
-    localStorage.setItem(LOCAL_STORAGE_KEY, pref);
-  } catch {
-    /* ignore — incognito / quota */
-  }
-}
 
 // --- Permission ---
 
@@ -150,7 +130,7 @@ export function notifyBackgroundCompletion(opts: NotifyOpts): void {
   // Always update the in-app badge — works regardless of permission / preference.
   markUnseenCompletion(opts.projectSlug);
 
-  if (readNotificationPreference() === "off") return;
+  if (localStore.notifications.read() === "off") return;
   if (typeof Notification === "undefined") return;
   if (Notification.permission !== "granted") return;
 

--- a/apps/webui/src/client/shared/storage.ts
+++ b/apps/webui/src/client/shared/storage.ts
@@ -1,0 +1,106 @@
+/**
+ * Browser-side persistent state (localStorage). All localStorage access in
+ * the client goes through this module — the ESLint rule `no-restricted-syntax`
+ * bans direct `localStorage.*` calls everywhere else, so adding a new key
+ * requires registering it in `localStore` below.
+ *
+ * When to use this vs settings.db (server SQLite):
+ *   - localStorage (here):  UI state, device/browser preferences, dismissal
+ *                            signals — stuff that's fine to be per-browser.
+ *   - settings.db (server): values the agent actually reads (API keys,
+ *                            active provider/model), secrets, and install-
+ *                            scoped state (e.g. onboarding completion).
+ */
+
+const PREFIX = "agentchan-";
+
+export interface Store<T> {
+  read(): T;
+  write(value: T): void;
+  remove(): void;
+  readonly fullKey: string;
+}
+
+/** Nullable string store — `null` means the key is unset. */
+function stringStore(key: string): Store<string | null> {
+  const fullKey = PREFIX + key;
+  return {
+    fullKey,
+    read() {
+      try {
+        return localStorage.getItem(fullKey);
+      } catch {
+        return null;
+      }
+    },
+    write(value) {
+      try {
+        if (value === null) localStorage.removeItem(fullKey);
+        else localStorage.setItem(fullKey, value);
+      } catch {
+        /* private mode / quota */
+      }
+    },
+    remove() {
+      try {
+        localStorage.removeItem(fullKey);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/** Enum store — only accepts one of `values`; invalid / missing → `defaultValue`. */
+function enumStore<T extends string>(
+  key: string,
+  values: readonly T[],
+  defaultValue: T,
+): Store<T> {
+  const fullKey = PREFIX + key;
+  const valid = new Set<string>(values);
+  return {
+    fullKey,
+    read() {
+      try {
+        const v = localStorage.getItem(fullKey);
+        return v !== null && valid.has(v) ? (v as T) : defaultValue;
+      } catch {
+        return defaultValue;
+      }
+    },
+    write(value) {
+      try {
+        localStorage.setItem(fullKey, value);
+      } catch {
+        /* private mode / quota */
+      }
+    },
+    remove() {
+      try {
+        localStorage.removeItem(fullKey);
+      } catch {
+        /* ignore */
+      }
+    },
+  };
+}
+
+/**
+ * Single registry for every browser-persistent key in the webui. Add new keys
+ * here — never call `localStorage` directly in feature code.
+ */
+export const localStore = {
+  /** Last project the user had active — restored on app load. */
+  lastProject: stringStore("last-project"),
+  /** Split-pane view mode: agent chat vs file editor. */
+  viewMode: enumStore("view-mode", ["chat", "edit"] as const, "chat"),
+  /** Theme preference (system / light / dark). */
+  theme: enumStore("theme", ["system", "light", "dark"] as const, "system"),
+  /** Language preference (system / en / ko). */
+  language: enumStore("language", ["system", "en", "ko"] as const, "system"),
+  /** OS desktop notifications on stream completion. */
+  notifications: enumStore("notifications", ["on", "off"] as const, "on"),
+  /** Last update version the user dismissed — null before any dismissal. */
+  updateDismissed: stringStore("update-dismissed"),
+};

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -12,6 +12,7 @@ import { createSettingsRepo } from "./repositories/settings.repo.js";
 import { createProjectRepo } from "./repositories/project.repo.js";
 import { createTemplateRepo } from "./repositories/template.repo.js";
 import { createProjectSkillRepo } from "./repositories/project-skill.repo.js";
+import { createUpdateRepo } from "./repositories/update.repo.js";
 
 // --- Services ---
 import { createConfigService } from "./services/config.service.js";
@@ -20,23 +21,27 @@ import { createConversationService } from "./services/conversation.service.js";
 import { createAgentService } from "./services/agent.service.js";
 import { createTemplateService } from "./services/template.service.js";
 import { createSkillService } from "./services/skill.service.js";
+import { createUpdateService } from "./services/update.service.js";
 
 // --- Routes ---
 import { createConfigRoutes } from "./routes/config.routes.js";
 import { createProjectRoutes } from "./routes/projects.routes.js";
 import { createTemplateRoutes } from "./routes/template.routes.js";
+import { createUpdateRoutes } from "./routes/update.routes.js";
 
 // ===== 1. Repositories =====
 const settingsRepo = createSettingsRepo(DATA_DIR);
 const projectRepo = createProjectRepo(PROJECTS_DIR);
 const templateRepo = createTemplateRepo(join(LIBRARY_DIR, "templates"));
 const projectSkillRepo = createProjectSkillRepo(PROJECTS_DIR);
+const updateRepo = createUpdateRepo();
 
 // ===== 2. Services =====
 const configService = createConfigService(settingsRepo);
 const templateService = createTemplateService(templateRepo, PROJECTS_DIR);
 const projectService = createProjectService(projectRepo, templateRepo, PROJECTS_DIR);
 const skillService = createSkillService(projectSkillRepo, PROJECTS_DIR);
+const updateService = createUpdateService(updateRepo);
 
 // ===== 2b. Agent context (stateless handle) =====
 const agentContext = createAgentContext({
@@ -84,6 +89,7 @@ app.use("/api/*", async (c, next) => {
   c.set("agentService", agentService);
   c.set("templateService", templateService);
   c.set("skillService", skillService);
+  c.set("updateService", updateService);
   await next();
 });
 
@@ -91,6 +97,7 @@ app.use("/api/*", async (c, next) => {
 app.route("/api/projects", createProjectRoutes());
 app.route("/api/config", createConfigRoutes());
 app.route("/api/templates", createTemplateRoutes());
+app.route("/api/update", createUpdateRoutes());
 
 // Serve static files in production
 if (existsSync(CLIENT_DIR)) {

--- a/apps/webui/src/server/repositories/update.repo.ts
+++ b/apps/webui/src/server/repositories/update.repo.ts
@@ -1,0 +1,56 @@
+// GitHub releases API client — thin external-IO boundary.
+// Fetches the latest release metadata from icepeng/agentchan.
+// Returns null on any network/parse/rate-limit failure so the caller can gracefully degrade.
+
+const RELEASES_URL = "https://api.github.com/repos/icepeng/agentchan/releases/latest";
+const REQUEST_TIMEOUT_MS = 5_000;
+
+export interface LatestRelease {
+  /** Release tag (e.g. "v0.3.0") as reported by GitHub. */
+  tag: string;
+  /** HTML URL to the release page on GitHub. */
+  htmlUrl: string;
+  /** ISO-8601 publish timestamp. */
+  publishedAt: string;
+  /** Release body / changelog markdown (may be empty). */
+  body: string;
+}
+
+export function createUpdateRepo() {
+  return {
+    async fetchLatestRelease(): Promise<LatestRelease | null> {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+      try {
+        const res = await fetch(RELEASES_URL, {
+          headers: {
+            // GitHub rejects requests without a User-Agent.
+            "User-Agent": "agentchan-update-check",
+            Accept: "application/vnd.github+json",
+          },
+          signal: controller.signal,
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as {
+          tag_name?: string;
+          html_url?: string;
+          published_at?: string;
+          body?: string;
+        };
+        if (!data.tag_name || !data.html_url) return null;
+        return {
+          tag: data.tag_name,
+          htmlUrl: data.html_url,
+          publishedAt: data.published_at ?? "",
+          body: data.body ?? "",
+        };
+      } catch {
+        return null;
+      } finally {
+        clearTimeout(timeout);
+      }
+    },
+  };
+}
+
+export type UpdateRepo = ReturnType<typeof createUpdateRepo>;

--- a/apps/webui/src/server/routes/update.routes.ts
+++ b/apps/webui/src/server/routes/update.routes.ts
@@ -1,0 +1,15 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types.js";
+
+export function createUpdateRoutes() {
+  const app = new Hono<AppEnv>();
+
+  // Current status — cached up to 1 hour server-side.
+  app.get("/", async (c) => {
+    const force = c.req.query("force") === "1";
+    const status = await c.get("updateService").getStatus(force);
+    return c.json(status);
+  });
+
+  return app;
+}

--- a/apps/webui/src/server/services/update.service.ts
+++ b/apps/webui/src/server/services/update.service.ts
@@ -1,0 +1,114 @@
+import pkg from "../../../../../package.json" with { type: "json" };
+import type { UpdateRepo } from "../repositories/update.repo.js";
+
+const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+export interface UpdateStatus {
+  /** Running version (from root package.json). */
+  current: string;
+  /** Latest release tag without leading "v", or null if unreachable. */
+  latest: string | null;
+  /** True iff latest is strictly greater than current via semver numeric compare. */
+  hasUpdate: boolean;
+  /** GitHub release page URL, or null when latest is null. */
+  releaseUrl: string | null;
+  /** ISO-8601 publish timestamp, or null. */
+  publishedAt: string | null;
+  /** Release notes markdown (may be empty). */
+  releaseNotes: string;
+  /** When this snapshot was taken (epoch ms). */
+  checkedAt: number;
+}
+
+/**
+ * Strip a leading "v" so "v0.3.0" and "0.3.0" compare equal.
+ * Returns null on malformed input.
+ */
+function normalizeVersion(raw: string): string | null {
+  const trimmed = raw.trim().replace(/^v/i, "");
+  if (!/^\d+(\.\d+){0,2}/.test(trimmed)) return null;
+  return trimmed;
+}
+
+/**
+ * Numeric semver compare of two "X.Y.Z" strings, ignoring any pre-release suffix.
+ * Returns -1 / 0 / 1 matching Array.sort conventions.
+ */
+function compareVersions(a: string, b: string): number {
+  const parse = (v: string): number[] => {
+    const core = v.split("-")[0] ?? v;
+    return core.split(".").map((p) => Number.parseInt(p, 10) || 0);
+  };
+  const as = parse(a);
+  const bs = parse(b);
+  const len = Math.max(as.length, bs.length);
+  for (let i = 0; i < len; i++) {
+    const av = as[i] ?? 0;
+    const bv = bs[i] ?? 0;
+    if (av !== bv) return av < bv ? -1 : 1;
+  }
+  return 0;
+}
+
+export function createUpdateService(updateRepo: UpdateRepo) {
+  const current = pkg.version;
+  let cache: { data: UpdateStatus; expiresAt: number } | null = null;
+  let inflight: Promise<UpdateStatus> | null = null;
+
+  async function refresh(): Promise<UpdateStatus> {
+    const release = await updateRepo.fetchLatestRelease();
+    const now = Date.now();
+
+    if (!release) {
+      const snapshot: UpdateStatus = {
+        current,
+        latest: null,
+        hasUpdate: false,
+        releaseUrl: null,
+        publishedAt: null,
+        releaseNotes: "",
+        checkedAt: now,
+      };
+      // Cache network failures for a shorter window (5 min) so we retry sooner.
+      cache = { data: snapshot, expiresAt: now + 5 * 60 * 1000 };
+      return snapshot;
+    }
+
+    const latest = normalizeVersion(release.tag);
+    const hasUpdate = latest != null && compareVersions(latest, current) > 0;
+
+    const snapshot: UpdateStatus = {
+      current,
+      latest,
+      hasUpdate,
+      releaseUrl: release.htmlUrl,
+      publishedAt: release.publishedAt || null,
+      releaseNotes: release.body,
+      checkedAt: now,
+    };
+    cache = { data: snapshot, expiresAt: now + CACHE_TTL_MS };
+    return snapshot;
+  }
+
+  return {
+    getCurrentVersion(): string {
+      return current;
+    },
+
+    /**
+     * Returns the cached status if fresh, otherwise triggers a single shared
+     * fetch. `force` bypasses the cache.
+     */
+    async getStatus(force = false): Promise<UpdateStatus> {
+      const now = Date.now();
+      if (!force && cache && cache.expiresAt > now) return cache.data;
+      if (inflight) return inflight;
+      inflight = refresh().finally(() => {
+        inflight = null;
+      });
+      return inflight;
+    },
+  };
+}
+
+export type UpdateService = ReturnType<typeof createUpdateService>;

--- a/apps/webui/src/server/types.ts
+++ b/apps/webui/src/server/types.ts
@@ -31,6 +31,7 @@ import type { ConversationService } from "./services/conversation.service.js";
 import type { AgentService } from "./services/agent.service.js";
 import type { TemplateService } from "./services/template.service.js";
 import type { SkillService } from "./services/skill.service.js";
+import type { UpdateService } from "./services/update.service.js";
 
 export type AppEnv = {
   Variables: {
@@ -40,6 +41,7 @@ export type AppEnv = {
     agentService: AgentService;
     templateService: TemplateService;
     skillService: SkillService;
+    updateService: UpdateService;
   };
 };
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,5 +39,23 @@ export default defineConfig(
     extends: [reactHooks.configs.flat["recommended-latest"]],
   },
 
+  // Enforce routing all browser persistence through `shared/storage.ts`.
+  // Adding a new localStorage key = registering it in `localStore`, which in
+  // turn enforces the `agentchan-` prefix and (for enums) valid-value checks.
+  {
+    files: ["apps/webui/src/client/**/*.{ts,tsx}"],
+    ignores: ["apps/webui/src/client/shared/storage.ts"],
+    rules: {
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector: "MemberExpression[object.name='localStorage']",
+          message:
+            "Do not use `localStorage` directly. Import `localStore` from `@/client/shared/storage.js` and register the key there.",
+        },
+      ],
+    },
+  },
+
   { files: ["**/*.{js,mjs,cjs}"], ...tseslint.configs.disableTypeChecked },
 );


### PR DESCRIPTION
## 개요
GitHub releases API로 최신 버전을 확인해 사이드바에 새 버전 알림 배너를 띄우고, 설정 페이지에 현재 버전 + 업데이트 정보를 노출한다. 버전별 dismiss 상태를 localStorage에 저장해 다음 릴리스가 나오면 자동으로 다시 표시된다.

## 주요 변경

### 서버
- **`update.repo.ts`** — GitHub releases API 클라이언트. `AbortController` + 5초 타임아웃, 네트워크/파싱 실패 시 `null` 반환으로 graceful degradation.
- **`update.service.ts`** — 1시간 서버 측 캐시 + 실패 시 5분 재시도 캐시, 동시 요청 in-flight dedup, 시맨틱 버전 숫자 비교(pre-release 접미사 무시), 강제 refresh 옵션.
- **`update.routes.ts`** — `GET /api/update` (쿼리 `?force=1`로 캐시 우회).
- `server/index.ts`의 composition root + DI 미들웨어에 `updateService` 등록.

### 클라이언트
- **`entities/update/`** — `fetchUpdateStatus` API 클라이언트 + `useUpdateStatus` 훅 + 타입. 훅은 module-level `cachedStatus`/`inflight` promise를 공유해 Sidebar 배너와 Settings About 섹션이 같은 페이지 로드에서 `/api/update`를 **1회만** 호출하도록 보장.
- **`features/update/UpdateBanner.tsx`** — ModelBar 상단 sticky 배너. 버전별 dismiss 유지. `<a>`와 dismiss `<button>`을 DOM상 sibling으로 배치(HTML 스펙 interactive element 중첩 금지 준수) + absolute positioning으로 시각적 행(row) 레이아웃 유지.
- **`features/update/AboutSection.tsx`** — Settings → Appearance 탭의 버전/업데이트 섹션. 최신 릴리스 링크 + "최신 버전 사용 중" 상태 표시.
- `Sidebar.tsx`에 배너, `SettingsView.tsx`의 Appearance 탭에 About 섹션 배치.

### 브라우저 저장소 중앙집중 (이 PR에서 추가 정리)
- **`shared/storage.ts`** — `localStore` 레지스트리 도입. `stringStore`/`enumStore` 팩토리가 `agentchan-` prefix + try/catch + 타입(enum 유효값 검증)을 흡수. 모든 브라우저 영속 키(6종)를 한 곳에 등록:
  ```
  lastProject, viewMode, theme, language, notifications, updateDismissed
  ```
- 기존 6개 call site의 중복된 `STORAGE_KEY` 상수 + `read/writeXxx` wrapper 함수를 제거하고 `localStore.xxx.read()` / `.write()`로 통일.
- **ESLint rule** — `shared/storage.ts` 외부에서 `localStorage.*` 직접 호출 금지. 새 키 추가 = 레지스트리 등록 강제.
- `updateDismissed` 키 이름 `agentchan.updateDismissed` → `agentchan-update-dismissed`로 정규화(pre-release라 마이그레이션 불필요).
- **settings.db vs localStorage 경계 원칙** (`storage.ts` JSDoc에 문서화):
  - **settings.db (서버)**: 에이전트가 읽는 값(API 키, active provider/model), 비밀, 설치본 단위 상태(온보딩 완료).
  - **localStorage (클라이언트)**: UI 상태, 기기/브라우저 선호, dismiss 신호 — 기기별로 달라도 되는 것.

### i18n
- `update.*` 번역 키 6종(`available`, `versionLine`, `viewRelease`, `dismiss`, `currentVersion`, `upToDate`) en/ko 동시 추가.

## 구현 상세

- **버전 정규화**: `"v0.3.0"`과 `"0.3.0"` 동등 처리.
- **시맨틱 비교**: `major.minor.patch` 숫자 비교, pre-release 접미사(`-beta.1` 등) 무시.
- **캐시 전략**: 성공 1시간 TTL, 실패 5분 TTL(빠른 재시도).
- **Deduplication**: 서버는 in-flight promise로 동시 호출 병합, 클라이언트는 module-level 캐시로 여러 컴포넌트 간 공유.
- **Graceful degradation**: 네트워크/파싱/레이트리밋 실패 시 `null` 반환 — UI는 조용히 숨김(에러 노출 안 함).
- **Dismissal 영속화**: 버전별 localStorage 키 — 새 릴리스가 나오면 다시 표시.
- **접근성**: dismiss 버튼이 앵커 외부 sibling으로 배치돼 스크린 리더/키보드 탐색 정상 동작.

## 테스트 계획
- [ ] `GET /api/update` 응답 확인 (정상/`?force=1`)
- [ ] Sidebar 배너 노출 → dismiss 클릭 → 재렌더 후에도 숨김 유지
- [ ] 다음 릴리스 태그로 바꿨을 때 dismiss가 리셋돼 배너가 다시 표시되는지
- [ ] Settings → Appearance 탭의 "현재 버전" + "최신 버전 사용 중"/업데이트 링크 표시
- [ ] Sidebar 상주 상태에서 Settings 페이지 진입 시 `/api/update`가 **1회만** 호출 (네트워크 탭 확인)
- [ ] 오프라인 상태에서 UI가 조용히 동작 (에러/로딩 스피너 노출 없음)
- [ ] 배너의 dismiss 버튼을 키보드 Tab + Enter로 조작 가능, 스크린 리더에서 링크와 독립적으로 인식
- [ ] 기존 localStorage 키 전부 정상 저장/복원 (theme, language, view-mode, last-project, notifications 토글)
- [ ] `localStorage.xxx` 직접 호출 추가 시 ESLint가 에러로 차단

https://claude.ai/code/session_01EXCugtgaiZde74JYMK4rDA