### PR TITLE
fix: 프로젝트 전환 시 테마 flash 제거 + 부드러운 색상 전환

### DIFF
--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -12,7 +12,7 @@ export function Sidebar() {
   const { t } = useI18n();
 
   return (
-    <div className="flex flex-col w-72 h-full bg-base border-r border-edge/6">
+    <div className="flex flex-col w-72 h-full bg-base border-r border-edge/6 transition-colors duration-200">
       {/* Header */}
       <div className="px-5 pt-5 pb-4 flex items-start justify-between">
         <div>

--- a/apps/webui/src/client/entities/project/ProjectContext.tsx
+++ b/apps/webui/src/client/entities/project/ProjectContext.tsx
@@ -40,12 +40,14 @@ function projectReducer(state: ProjectState, action: ProjectAction): ProjectStat
       if (state.activeProjectSlug && action.currentConversationId) {
         newMap.set(state.activeProjectSlug, action.currentConversationId);
       }
+      // rendererTheme은 새 프로젝트의 renderer가 로드되어 SET_RENDER_OUTPUT이
+      // 덮어쓸 때까지 유지한다. 즉시 null로 리셋하면 "이전 테마 → 기본 팔레트 →
+      // 새 테마"의 두 단계 깜빡임이 발생하기 때문이다.
       return {
         ...state,
         activeProjectSlug: action.slug,
         projectActiveSession: newMap,
         renderedHtml: "",
-        rendererTheme: null,
       };
     }
 
@@ -71,16 +73,27 @@ function projectReducer(state: ProjectState, action: ProjectAction): ProjectStat
     case "DELETE_PROJECT": {
       const remaining = state.projects.filter((p) => p.slug !== action.slug);
       const wasActive = state.activeProjectSlug === action.slug;
+      if (!wasActive) {
+        return { ...state, projects: remaining };
+      }
+      const nextSlug = remaining[0]?.slug ?? null;
+      if (nextSlug === null) {
+        // 프로젝트가 하나도 남지 않으면 "프로젝트 없음" 상태이므로 기본 팔레트로 리셋.
+        return {
+          ...state,
+          projects: remaining,
+          activeProjectSlug: null,
+          renderedHtml: "",
+          rendererTheme: null,
+        };
+      }
+      // 다음 active의 renderer가 로드될 때까지 rendererTheme은 유지 —
+      // SET_ACTIVE_PROJECT와 동일한 flash-free 전환 원칙.
       return {
         ...state,
         projects: remaining,
-        ...(wasActive
-          ? {
-              activeProjectSlug: remaining[0]?.slug ?? null,
-              renderedHtml: "",
-              rendererTheme: null,
-            }
-          : {}),
+        activeProjectSlug: nextSlug,
+        renderedHtml: "",
       };
     }
 

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -196,7 +196,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   }
 
   return (
-    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4">
+    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4 transition-colors duration-200">
       {inputContent}
     </div>
   );

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -49,7 +49,7 @@ export function EditModePanel() {
       {/* Tree panel */}
       <div
         style={{ width: treeWidth }}
-        className="flex-shrink-0 border-r border-edge/6 bg-base/40"
+        className="flex-shrink-0 border-r border-edge/6 bg-base/40 transition-colors duration-200"
       >
         <FileTree
           entries={treeEntries}
@@ -72,7 +72,7 @@ export function EditModePanel() {
       />
 
       {/* Editor panel */}
-      <div className="flex-1 flex flex-col min-w-0 bg-surface/30">
+      <div className="flex-1 flex flex-col min-w-0 bg-surface/30 transition-colors duration-200">
         <FileEditor
           path={selectedPath}
           content={fileContent}

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -60,7 +60,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
           </Suspense>
         ) : (
           // Chat mode: Rendered View
-          <div className={`flex-1 flex flex-col min-w-0 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
+          <div className={`flex-1 flex flex-col min-w-0 transition-colors duration-200 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
             {project.activeProjectSlug ? (
               <RenderedView />
             ) : (
@@ -85,13 +85,13 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
         {agentPanelOpen ? (
           <div
             style={{ width: panelWidth }}
-            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 hidden lg:flex"
+            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 transition-colors duration-200 hidden lg:flex"
           >
             <AgentPanel />
             {isEdit && <BottomInput variant="embedded" />}
           </div>
         ) : (
-          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20">
+          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20 transition-colors duration-200">
             <EditModeToggle />
             <div className="flex-1" />
             <button


### PR DESCRIPTION
## Summary

- 테마를 선언한 프로젝트 간(또는 테마 ↔ 기본 팔레트 간) 전환 시 중간에 기본 Obsidian Teal이 한 번 번쩍이던 2단계 깜빡임을 제거했습니다. 원인은 `ProjectContext` reducer가 `SET_ACTIVE_PROJECT` 시점에 `rendererTheme`을 즉시 `null`로 리셋해서 새 테마가 도착하기 전까지 기본 팔레트로 복귀했기 때문입니다. 이제 새 프로젝트의 `renderer.ts`가 로드되어 `SET_RENDER_OUTPUT`이 덮어쓸 때까지 이전 테마를 유지합니다.
- Sidebar/BottomInput/EditModePanel/ProjectPage의 테마 색상 의존 컨테이너에 `transition-colors duration-200`을 추가해 주요 레이아웃이 일관된 200ms 색상 전환을 공유하도록 했습니다.
- `DELETE_PROJECT`도 동일 원칙으로 재작성했습니다. 다음 active 프로젝트가 있으면 `rendererTheme` 유지, 프로젝트가 하나도 남지 않는 경우에만 기본 팔레트로 리셋합니다.

## 변경 파일

- `apps/webui/src/client/entities/project/ProjectContext.tsx` — `SET_ACTIVE_PROJECT` 에서 `rendererTheme: null` 제거, `DELETE_PROJECT`를 3분기(`!wasActive` / `nextSlug === null` / 일반)로 재작성
- `apps/webui/src/client/app/Sidebar.tsx` — 루트에 `transition-colors duration-200`
- `apps/webui/src/client/features/chat/BottomInput.tsx` — standalone variant 루트에 추가
- `apps/webui/src/client/features/editor/EditModePanel.tsx` — 트리/에디터 패널 양쪽에 추가
- `apps/webui/src/client/pages/ProjectPage.tsx` — 렌더뷰, 에이전트 패널 컨테이너, collapsed rail 세 곳에 추가

## 검증 방법

`agent-browser` + `MutationObserver`로 root element의 `style` attribute 변경 이벤트를 before/after pair로 기록하여 테마 전환이 1회 mutation으로 끝나는지 직접 관찰했습니다.

- [x] **테마 없음 → 테마 있음 (Char Neutral → Sentinel B)**: `(empty) → #140a1e` 단일 mutation. 중간 기본 팔레트 경유 없음.
- [x] **테마 있음 → 테마 없음 (Sentinel B → Char Neutral)**: `#140a1e → (empty)` 단일 mutation. `transition-colors`로 자연스러운 fade.
- [x] **테마 ↔ 테마 (핵심 재현 케이스, Sentinel A ↔ Sentinel B)**: `#0a0e14 → #140a1e` 단일 mutation. **기본 Obsidian Teal이 중간에 끼지 않음** 확인.
- [x] **Edit Mode 토글 (Ctrl+E)**: `#140a1e → (empty)` 단일 mutation. `themeActive=false` 조건으로 기본 팔레트 복귀.
- [x] 빌드: `bunx tsc --noEmit` (apps/webui), `bun run lint`, `bun run test` 모두 통과.
- [x] 검증 중 콘솔 에러 없음, 4xx/5xx 네트워크 요청 없음.

## Test plan

- [ ] 여러 테마 프로젝트가 있는 환경에서 실제로 프로젝트를 오가며 중간 기본 팔레트 번쩍임이 보이지 않는지 확인
- [ ] 테마 있는 프로젝트 ↔ 테마 없는 프로젝트 전환이 부드럽게 페이드되는지 확인
- [ ] Chat ↔ Edit 모드 토글 시 팔레트 전환이 급격한 점프 없이 자연스러운지 확인
- [ ] 프로젝트 삭제로 active가 교체되는 경우 다음 프로젝트 테마가 적용될 때까지 이전 테마가 유지되는지, 마지막 프로젝트 삭제 시 기본 팔레트로 정상 복귀하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)