### PR TITLE
feat(renderer): 모듈 분리 + 타입 공유 번들러 도입

### DIFF
--- a/apps/webui/package.json
+++ b/apps/webui/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "@agentchan/creative-agent": "workspace:*",
     "@agentchan/estimate-tokens": "workspace:*",
+    "@agentchan/renderer-bundle": "workspace:*",
+    "@agentchan/renderer-runtime": "workspace:*",
+    "@agentchan/renderer-types": "workspace:*",
     "@base-ui/react": "^1.3.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.3",

--- a/apps/webui/scripts/build-exe.ts
+++ b/apps/webui/scripts/build-exe.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { join } from "node:path";
-import { cp, mkdir, rm } from "node:fs/promises";
+import { cp, mkdir, rm, copyFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 
 const WEBUI_ROOT = join(import.meta.dir, "..");
@@ -40,7 +40,21 @@ await cp(join(MONOREPO_ROOT, "example_data"), join(DIST_DIR, "data"), {
   recursive: true,
 });
 
+// Renderer authoring assets (consumed by /api/system/* and the bundler). The
+// server's paths.ts looks them up under data/_system/ in compiled mode.
+const systemDir = join(DIST_DIR, "data/_system");
+await mkdir(systemDir, { recursive: true });
+await copyFile(
+  join(MONOREPO_ROOT, "packages/renderer-runtime/src/index.ts"),
+  join(systemDir, "renderer-runtime.ts"),
+);
+await copyFile(
+  join(MONOREPO_ROOT, "packages/renderer-types/src/index.ts"),
+  join(systemDir, "renderer-types.ts"),
+);
+
 console.log(`\nBuild complete: ${DIST_DIR}/`);
 console.log(`  ${exeName}`);
 console.log("  public/");
 console.log("  data/");
+console.log("  data/_system/ (renderer runtime + types)");

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -3,3 +3,4 @@ export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile,
 export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
 export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";
+export { rendererCompletions, prefetchRendererTypes } from "./rendererDts.js";

--- a/apps/webui/src/client/entities/editor/rendererDts.ts
+++ b/apps/webui/src/client/entities/editor/rendererDts.ts
@@ -1,0 +1,144 @@
+// Fetch renderer-types + renderer-runtime source from the server and extract
+// completion options for the CodeMirror autocomplete plugin. The parser is
+// deliberately minimal (top-level `export interface` fields and `export function`
+// signatures) — that covers the common renderer authoring flow and avoids
+// pulling a real TS language service into the bundle. Falls back to the
+// previously-hardcoded options when the fetch or parse fails.
+import type { CompletionContext, CompletionResult } from "@codemirror/autocomplete";
+
+export interface RendererTypeInfo {
+  /** interface name → fields */
+  interfaces: Map<string, Array<{ name: string; type: string }>>;
+  /** runtime top-level function names with their signature strings */
+  runtime: Array<{ name: string; signature: string }>;
+}
+
+let cache: RendererTypeInfo | null = null;
+let pending: Promise<RendererTypeInfo> | null = null;
+
+async function loadInfo(): Promise<RendererTypeInfo> {
+  if (cache) return cache;
+  if (pending) return pending;
+
+  pending = (async () => {
+    const [typesRes, runtimeRes] = await Promise.all([
+      fetch("/api/system/renderer-types.ts").catch(() => null),
+      fetch("/api/system/renderer-runtime.ts").catch(() => null),
+    ]);
+    const typesText = typesRes && typesRes.ok ? await typesRes.text() : "";
+    const runtimeText =
+      runtimeRes && runtimeRes.ok ? await runtimeRes.text() : "";
+
+    const info: RendererTypeInfo = {
+      interfaces: parseInterfaces(typesText),
+      runtime: parseRuntimeExports(runtimeText),
+    };
+    cache = info;
+    return info;
+  })();
+
+  try {
+    return await pending;
+  } finally {
+    pending = null;
+  }
+}
+
+// Triggers a background fetch so the first typing-driven completion isn't slow.
+export function prefetchRendererTypes(): void {
+  void loadInfo();
+}
+
+// Match `export interface Name {\n  field: type;\n  ...}` — top-level only.
+// Body braces nested deeper than one level are not supported (sufficient for
+// the current type surface; complex shapes degrade to the fallback path).
+function parseInterfaces(src: string): Map<string, Array<{ name: string; type: string }>> {
+  const out = new Map<string, Array<{ name: string; type: string }>>();
+  const rx = /export\s+interface\s+(\w+)\s*{([^{}]*)}/g;
+  let match: RegExpExecArray | null;
+  while ((match = rx.exec(src)) !== null) {
+    const name = match[1];
+    const body = match[2];
+    if (!name || !body) continue;
+    const fields: Array<{ name: string; type: string }> = [];
+    const fieldRx = /(\w+)\s*\??\s*:\s*([^;\n]+);/g;
+    let fm: RegExpExecArray | null;
+    while ((fm = fieldRx.exec(body)) !== null) {
+      const fname = fm[1];
+      const ftype = fm[2]?.trim();
+      if (fname && ftype) fields.push({ name: fname, type: ftype });
+    }
+    out.set(name, fields);
+  }
+  return out;
+}
+
+// Match `export function name(args): ret` — signature is descriptive only.
+function parseRuntimeExports(src: string): Array<{ name: string; signature: string }> {
+  const out: Array<{ name: string; signature: string }> = [];
+  const rx = /export\s+function\s+(\w+)\s*(\([^)]*\)(?:\s*:\s*[^\n{]+)?)/g;
+  let match: RegExpExecArray | null;
+  while ((match = rx.exec(src)) !== null) {
+    const name = match[1];
+    const sig = match[2]?.trim();
+    if (name && sig) out.push({ name, signature: `(fn) ${name}${sig}` });
+  }
+  return out;
+}
+
+// Variable-name heuristics for `.`-completion. Mirrors the legacy hardcoded
+// table but is now cheap to extend without changing code — add a variable
+// pattern here, and the fields come from whichever interface we map to.
+function identifierTypeHint(varName: string): string | null {
+  if (varName === "ctx") return "RenderContext";
+  if (/^(f|file|entry|item|doc|textFile|tf)$/i.test(varName)) return "TextFile";
+  return null;
+}
+
+export async function rendererCompletions(
+  context: CompletionContext,
+): Promise<CompletionResult | null> {
+  // `.`-completion on a known identifier name
+  const dotMatch = context.matchBefore(/\b(\w+)\.(\w*)$/);
+  if (dotMatch) {
+    const info = await loadInfo();
+    const text = dotMatch.text;
+    const dotPos = text.lastIndexOf(".");
+    const varName = text.substring(0, dotPos);
+    const from = dotMatch.from + dotPos + 1;
+
+    const typeName = identifierTypeHint(varName);
+    if (!typeName) return null;
+
+    const fields = info.interfaces.get(typeName);
+    if (!fields || fields.length === 0) return null;
+
+    return {
+      from,
+      options: fields.map((f) => ({
+        label: f.name,
+        type: "property",
+        detail: f.type,
+      })),
+    };
+  }
+
+  // Top-of-word completion surfaces runtime helper names as they're typed
+  const wordMatch = context.matchBefore(/\w+$/);
+  if (wordMatch && wordMatch.from !== wordMatch.to) {
+    const info = await loadInfo();
+    if (info.runtime.length === 0) return null;
+    return {
+      from: wordMatch.from,
+      options: info.runtime.map((fn) => ({
+        label: fn.name,
+        type: "function",
+        detail: fn.signature,
+      })),
+      // Do not block other sources — this is a supplementary list.
+      validFor: /^\w*$/,
+    };
+  }
+
+  return null;
+}

--- a/apps/webui/src/client/entities/project/project.types.ts
+++ b/apps/webui/src/client/entities/project/project.types.ts
@@ -1,4 +1,4 @@
-import type { ProjectFile } from "@agentchan/creative-agent";
+import type { ProjectFile, RenderContext } from "@agentchan/renderer-types";
 
 export interface Project {
   slug: string;
@@ -9,9 +9,4 @@ export interface Project {
   hasCover?: boolean;
 }
 
-export interface RenderContext {
-  files: ProjectFile[];
-  baseUrl: string;
-}
-
-export type { ProjectFile };
+export type { ProjectFile, RenderContext };

--- a/apps/webui/src/client/entities/project/projectTheme.ts
+++ b/apps/webui/src/client/entities/project/projectTheme.ts
@@ -1,35 +1,6 @@
-/**
- * Renderer-owned theme: 렌더러가 프로젝트 페이지 한정으로 전역 CSS custom property를
- * 오버라이드할 수 있도록 하는 계약.
- *
- * - 색상 전용. 폰트는 렌더러 자체 `<style>` 안에서 `font-family`로 직접 지정한다.
- * - `base`만 있으면 단일 모드, `dark`가 있으면 듀얼 모드.
- * - `prefersScheme`이 명시되면 프로젝트 페이지에서만 사용자 Appearance 토글을 강제 오버라이드.
- */
+import type { RendererTheme, RendererThemeTokens } from "@agentchan/renderer-types";
 
-/**
- * 토큰 이름은 agentchan 전역 CSS 변수(`--color-*`)와 1:1로 대응한다.
- * 렌더러 작성자가 토큰을 선언하면 그대로 해당 `--color-*`가 오버라이드된다.
- */
-export interface RendererThemeTokens {
-  void?: string; // --color-void     (앱 최상위 배경)
-  base?: string; // --color-base     (Sidebar / AgentPanel / BottomInput)
-  surface?: string; // --color-surface  (카드 / 인풋 박스)
-  elevated?: string; // --color-elevated (hover / 강조)
-  accent?: string; // --color-accent   (포인트 색)
-  fg?: string; // --color-fg       (본문 텍스트)
-  fg2?: string; // --color-fg-2     (메타 텍스트 / 아이콘 기본)
-  fg3?: string; // --color-fg-3     (부드러운 텍스트)
-  edge?: string; // --color-edge     (테두리 베이스)
-}
-
-export interface RendererTheme {
-  base: RendererThemeTokens;
-  /** base(=light) 위에 덮어쓰는 dark 토큰. 생략하면 base 단일 모드. */
-  dark?: Partial<RendererThemeTokens>;
-  /** 명시되면 프로젝트 페이지 안에서 사용자 토글과 무관하게 해당 scheme으로 강제 고정. */
-  prefersScheme?: "light" | "dark";
-}
+export type { RendererTheme, RendererThemeTokens };
 
 const TOKEN_TO_CSS: Record<keyof RendererThemeTokens, string> = {
   void: "--color-void",

--- a/apps/webui/src/client/features/editor/FileEditor.tsx
+++ b/apps/webui/src/client/features/editor/FileEditor.tsx
@@ -19,12 +19,14 @@ import {
   closeBrackets,
   closeBracketsKeymap,
   completionKeymap,
-  type CompletionContext,
-  type CompletionResult,
 } from "@codemirror/autocomplete";
 import { useI18n } from "@/client/i18n/index.js";
 import { useProjectState } from "@/client/entities/project/index.js";
-import { isImagePath } from "@/client/entities/editor/index.js";
+import {
+  isImagePath,
+  rendererCompletions,
+  prefetchRendererTypes,
+} from "@/client/entities/editor/index.js";
 import { estimateTokens, formatTokens } from "@/client/shared/pricing.utils.js";
 
 // --- Obsidian Teal theme (from former TextEditor) ---
@@ -189,43 +191,6 @@ function getLanguageExtension(lang?: EditorLanguage) {
   }
 }
 
-// --- Renderer autocomplete ---
-
-function rendererCompletions(context: CompletionContext): CompletionResult | null {
-  const match = context.matchBefore(/\b(\w+)\.(\w*)$/);
-  if (!match) return null;
-
-  const text = match.text;
-  const dotPos = text.lastIndexOf(".");
-  const varName = text.substring(0, dotPos);
-  const from = match.from + dotPos + 1;
-
-  if (varName === "ctx") {
-    return {
-      from,
-      options: [
-        { label: "files", type: "property", detail: "ProjectFile[]" },
-        { label: "baseUrl", type: "property", detail: "string" },
-      ],
-    };
-  }
-
-  if (/^(f|file|entry|item|doc|textFile|tf)$/i.test(varName)) {
-    return {
-      from,
-      options: [
-        { label: "type", type: "property", detail: '"text" | "binary"' },
-        { label: "path", type: "property", detail: "string" },
-        { label: "content", type: "property", detail: "string (TextFile)" },
-        { label: "frontmatter", type: "property", detail: "Record<string, unknown> | null" },
-        { label: "modifiedAt", type: "property", detail: "number" },
-      ],
-    };
-  }
-
-  return null;
-}
-
 // --- Component ---
 
 interface FileEditorProps {
@@ -255,6 +220,12 @@ export function FileEditor({ path, content, dirty, onDocChange, onSave }: FileEd
   }, []);
 
   const language = path ? detectLanguage(path) : undefined;
+
+  // Warm the d.ts cache once per session so the first typing-driven completion
+  // on a renderer file doesn't pay the fetch round-trip.
+  useEffect(() => {
+    if (language === "typescript") prefetchRendererTypes();
+  }, [language]);
 
   // Create / destroy EditorView when path changes
   useEffect(() => {

--- a/apps/webui/src/client/features/project/useOutput.ts
+++ b/apps/webui/src/client/features/project/useOutput.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { escapeHtml } from "@agentchan/renderer-runtime";
 import {
   useProjectState,
   useProjectDispatch,
@@ -7,13 +8,6 @@ import {
   validateTheme,
 } from "@/client/entities/project/index.js";
 import type { RenderContext, RendererTheme } from "@/client/entities/project/index.js";
-
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
 
 function errorHtml(message: string): string {
   return `<div style="color: var(--color-danger); font-size: 14px; font-family: var(--font-family-mono); padding: 16px;">

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -4,7 +4,7 @@ import { serveStatic } from "hono/bun";
 import { join } from "node:path";
 import { existsSync } from "node:fs";
 import { createAgentContext, type ResolvedAgentConfig } from "@agentchan/creative-agent";
-import { CLIENT_DIR, DATA_DIR, PROJECTS_DIR, LIBRARY_DIR, isDev } from "./paths.js";
+import { CLIENT_DIR, DATA_DIR, PROJECTS_DIR, LIBRARY_DIR, RENDERER_RUNTIME_ENTRY, isDev } from "./paths.js";
 import type { AppEnv } from "./types.js";
 
 // --- Repositories ---
@@ -28,6 +28,7 @@ import { createConfigRoutes } from "./routes/config.routes.js";
 import { createProjectRoutes } from "./routes/projects.routes.js";
 import { createTemplateRoutes } from "./routes/template.routes.js";
 import { createUpdateRoutes } from "./routes/update.routes.js";
+import { createSystemRoutes } from "./routes/system.routes.js";
 
 // ===== 1. Repositories =====
 const settingsRepo = createSettingsRepo(DATA_DIR);
@@ -46,6 +47,7 @@ const updateService = createUpdateService(updateRepo);
 // ===== 2b. Agent context (stateless handle) =====
 const agentContext = createAgentContext({
   projectsDir: PROJECTS_DIR,
+  rendererRuntimeEntry: RENDERER_RUNTIME_ENTRY,
   resolveAgentConfig: (): ResolvedAgentConfig => {
     const cfg = configService.getConfig();
     const providerInfo = configService.findProvider(cfg.provider);
@@ -68,6 +70,7 @@ const agentService = createAgentService(agentContext);
 
 // ===== 3. Bootstrap =====
 await templateRepo.ensureDir();
+const systemRoutes = await createSystemRoutes();
 
 // ===== 4. Hono App =====
 const app = new Hono<AppEnv>();
@@ -98,6 +101,7 @@ app.route("/api/projects", createProjectRoutes());
 app.route("/api/config", createConfigRoutes());
 app.route("/api/templates", createTemplateRoutes());
 app.route("/api/update", createUpdateRoutes());
+app.route("/api/system", systemRoutes);
 
 // Serve static files in production
 if (existsSync(CLIENT_DIR)) {

--- a/apps/webui/src/server/paths.ts
+++ b/apps/webui/src/server/paths.ts
@@ -20,6 +20,16 @@ export const PROJECTS_DIR = join(DATA_DIR, "projects");
 
 export const LIBRARY_DIR = join(DATA_DIR, "library");
 
+// System assets (renderer runtime source + type declarations) shipped to
+// renderer authors. Source-first packages in dev; sidecar copies in exe.
+const monorepoRoot = join(devWebUIRoot, "..", "..");
+export const RENDERER_RUNTIME_ENTRY = isDev
+  ? join(monorepoRoot, "packages/renderer-runtime/src/index.ts")
+  : join(exeDir, "data/_system/renderer-runtime.ts");
+export const RENDERER_TYPES_ENTRY = isDev
+  ? join(monorepoRoot, "packages/renderer-types/src/index.ts")
+  : join(exeDir, "data/_system/renderer-types.ts");
+
 export const IMAGE_EXTS = ["webp", "png", "jpg", "jpeg", "gif", "svg", "avif"];
 
 export async function probeCover(dir: string): Promise<string | null> {

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -116,9 +116,10 @@ export function createProjectRoutes() {
 
   app.get("/:slug/renderer.js", async (c) => {
     const slug = c.req.param("slug");
-    const js = await c.get("projectService").transpileRenderer(slug);
-    if (js === null) return c.json({ error: "renderer.ts not found" }, 404);
-    return c.json({ js });
+    const result = await c.get("projectService").transpileRenderer(slug);
+    if (result === null) return c.json({ error: "renderer.ts not found" }, 404);
+    if ("error" in result) return c.json({ error: result.error }, 400);
+    return c.json({ js: result.js });
   });
 
   app.get("/:slug/cover", async (c) => {

--- a/apps/webui/src/server/routes/system.routes.ts
+++ b/apps/webui/src/server/routes/system.routes.ts
@@ -1,0 +1,33 @@
+import { Hono } from "hono";
+import type { AppEnv } from "../types.js";
+import { RENDERER_RUNTIME_ENTRY, RENDERER_TYPES_ENTRY } from "../paths.js";
+
+async function loadAsset(path: string): Promise<string | null> {
+  const file = Bun.file(path);
+  return (await file.exists()) ? file.text() : null;
+}
+
+export async function createSystemRoutes() {
+  const app = new Hono<AppEnv>();
+
+  const assets: Array<{ route: string; body: string | null }> = await Promise.all(
+    [
+      { route: "/renderer-types.ts", path: RENDERER_TYPES_ENTRY },
+      { route: "/renderer-runtime.ts", path: RENDERER_RUNTIME_ENTRY },
+    ].map(async ({ route, path }) => ({ route, body: await loadAsset(path) })),
+  );
+
+  for (const { route, body } of assets) {
+    app.get(route, (c) => {
+      if (body === null) return c.text("", 404);
+      return new Response(body, {
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Cache-Control": "no-cache",
+        },
+      });
+    });
+  }
+
+  return app;
+}

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -1,10 +1,11 @@
-import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
+import { buildRenderer, createBundleCache } from "@agentchan/renderer-bundle";
+import { RENDERER_RUNTIME_ENTRY } from "../paths.js";
 import type { ProjectRepo } from "../repositories/project.repo.js";
 import type { TemplateRepo } from "../repositories/template.repo.js";
 
 export function createProjectService(projectRepo: ProjectRepo, templateRepo: TemplateRepo, projectsDir: string) {
-  const transpiler = new Bun.Transpiler({ loader: "ts" });
+  const rendererCache = createBundleCache();
 
   return {
     async list() { return projectRepo.list(); },
@@ -33,30 +34,46 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
     },
 
     async writeProjectFile(slug: string, filePath: string, content: string) {
+      rendererCache.invalidate(slug);
       return projectRepo.writeProjectFile(slug, filePath, content);
     },
 
     async deleteProjectFile(slug: string, filePath: string) {
+      rendererCache.invalidate(slug);
       return projectRepo.deleteProjectFile(slug, filePath);
     },
 
     async deleteProjectDir(slug: string, dirPath: string) {
+      rendererCache.invalidate(slug);
       return projectRepo.deleteProjectDir(slug, dirPath);
     },
 
     async renameProjectEntry(slug: string, fromPath: string, toPath: string) {
+      rendererCache.invalidate(slug);
       return projectRepo.renameProjectEntry(slug, fromPath, toPath);
     },
 
     async createProjectDir(slug: string, dirPath: string) {
+      rendererCache.invalidate(slug);
       return projectRepo.createProjectDir(slug, dirPath);
     },
 
-    async transpileRenderer(slug: string): Promise<string | null> {
-      const rendererPath = join(projectsDir, slug, "renderer.ts");
-      if (!existsSync(rendererPath)) return null;
-      const source = await Bun.file(rendererPath).text();
-      return transpiler.transformSync(source);
+    async transpileRenderer(slug: string): Promise<
+      { js: string } | { error: string } | null
+    > {
+      const cached = rendererCache.get(slug);
+      if (cached !== null) return { js: cached };
+
+      const projectDir = join(projectsDir, slug);
+      const result = await buildRenderer(projectDir, {
+        runtimeEntry: RENDERER_RUNTIME_ENTRY,
+      });
+      if ("error" in result) {
+        if (result.error === "renderer.ts not found") return null;
+        return { error: result.error };
+      }
+      rendererCache.set(slug, result.js, result.sources);
+      return { js: result.js };
     },
 
     serveWorkspaceFile(slug: string, filePath: string): { fullPath: string } | null {

--- a/bun.lock
+++ b/bun.lock
@@ -22,6 +22,9 @@
       "dependencies": {
         "@agentchan/creative-agent": "workspace:*",
         "@agentchan/estimate-tokens": "workspace:*",
+        "@agentchan/renderer-bundle": "workspace:*",
+        "@agentchan/renderer-runtime": "workspace:*",
+        "@agentchan/renderer-types": "workspace:*",
         "@base-ui/react": "^1.3.0",
         "@codemirror/autocomplete": "^6.20.1",
         "@codemirror/commands": "^6.10.3",
@@ -61,6 +64,9 @@
       "dependencies": {
         "@agentchan/estimate-tokens": "workspace:*",
         "@agentchan/grep": "workspace:*",
+        "@agentchan/renderer-bundle": "workspace:*",
+        "@agentchan/renderer-runtime": "workspace:*",
+        "@agentchan/renderer-types": "workspace:*",
         "@google/genai": "^1.49.0",
         "@mariozechner/pi-agent-core": "^0.66.1",
         "@mariozechner/pi-ai": "^0.66.1",
@@ -82,6 +88,25 @@
       "name": "@agentchan/grep",
       "version": "0.1.0",
     },
+    "packages/renderer-bundle": {
+      "name": "@agentchan/renderer-bundle",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agentchan/renderer-runtime": "workspace:*",
+        "@agentchan/renderer-types": "workspace:*",
+      },
+    },
+    "packages/renderer-runtime": {
+      "name": "@agentchan/renderer-runtime",
+      "version": "0.1.0",
+      "dependencies": {
+        "@agentchan/renderer-types": "workspace:*",
+      },
+    },
+    "packages/renderer-types": {
+      "name": "@agentchan/renderer-types",
+      "version": "0.1.0",
+    },
   },
   "packages": {
     "@agentchan/creative-agent": ["@agentchan/creative-agent@workspace:packages/creative-agent"],
@@ -89,6 +114,12 @@
     "@agentchan/estimate-tokens": ["@agentchan/estimate-tokens@workspace:packages/estimate-tokens"],
 
     "@agentchan/grep": ["@agentchan/grep@workspace:packages/grep"],
+
+    "@agentchan/renderer-bundle": ["@agentchan/renderer-bundle@workspace:packages/renderer-bundle"],
+
+    "@agentchan/renderer-runtime": ["@agentchan/renderer-runtime@workspace:packages/renderer-runtime"],
+
+    "@agentchan/renderer-types": ["@agentchan/renderer-types@workspace:packages/renderer-types"],
 
     "@agentchan/webui": ["@agentchan/webui@workspace:apps/webui"],
 

--- a/packages/creative-agent/package.json
+++ b/packages/creative-agent/package.json
@@ -13,6 +13,9 @@
   "dependencies": {
     "@agentchan/estimate-tokens": "workspace:*",
     "@agentchan/grep": "workspace:*",
+    "@agentchan/renderer-bundle": "workspace:*",
+    "@agentchan/renderer-runtime": "workspace:*",
+    "@agentchan/renderer-types": "workspace:*",
     "@google/genai": "^1.49.0",
     "@mariozechner/pi-agent-core": "^0.66.1",
     "@mariozechner/pi-ai": "^0.66.1",

--- a/packages/creative-agent/src/agent/context.ts
+++ b/packages/creative-agent/src/agent/context.ts
@@ -14,11 +14,14 @@ export interface AgentContext {
   /** Absolute path to the projects root — agent functions resolve per-project skill paths from here. */
   projectsDir: string;
   resolveAgentConfig: () => ResolvedAgentConfig;
+  /** Absolute path to @agentchan/renderer-runtime's source entry. */
+  rendererRuntimeEntry: string;
 }
 
 export interface AgentContextOptions {
   projectsDir: string;
   resolveAgentConfig: () => ResolvedAgentConfig;
+  rendererRuntimeEntry: string;
 }
 
 export function createAgentContext(opts: AgentContextOptions): AgentContext {
@@ -26,6 +29,7 @@ export function createAgentContext(opts: AgentContextOptions): AgentContext {
     storage: createConversationStorage(opts.projectsDir),
     projectsDir: opts.projectsDir,
     resolveAgentConfig: opts.resolveAgentConfig,
+    rendererRuntimeEntry: opts.rendererRuntimeEntry,
   };
 }
 

--- a/packages/creative-agent/src/agent/orchestrator.ts
+++ b/packages/creative-agent/src/agent/orchestrator.ts
@@ -166,6 +166,7 @@ export async function setupCreativeAgent(
   history: AgentMessage[],
   conversationId: string,
   sessionMode?: SessionMode,
+  rendererRuntimeEntry?: string,
 ): Promise<CreativeAgentSetup> {
   const allSkills = await discoverProjectSkills(join(projectDir, "skills"));
   const env: SkillEnvironment = sessionMode === "meta" ? "meta" : "creative";
@@ -181,7 +182,9 @@ export async function setupCreativeAgent(
   // Build tools
   const tools: any[] = createProjectTools(projectDir);
   if (envSkills.size > 0) tools.push(createActivateSkillTool(envSkills, projectDir));
-  if (sessionMode === "meta") tools.push(createValidateRendererTool(projectDir));
+  if (sessionMode === "meta" && rendererRuntimeEntry) {
+    tools.push(createValidateRendererTool(projectDir, { runtimeEntry: rendererRuntimeEntry }));
+  }
 
   // Compose system prompt: DEFAULT + system file + skill catalog
   const systemFile = sessionMode === "meta" ? "SYSTEM.meta.md" : "SYSTEM.md";

--- a/packages/creative-agent/src/agent/prompt.ts
+++ b/packages/creative-agent/src/agent/prompt.ts
@@ -239,6 +239,7 @@ async function runAgentTurn(args: AgentTurnArgs): Promise<void> {
     history,
     conversationId,
     args.sessionMode,
+    ctx.rendererRuntimeEntry,
   );
 
   let lastNodeId = args.promptParentId;

--- a/packages/creative-agent/src/tools/validate-renderer.ts
+++ b/packages/creative-agent/src/tools/validate-renderer.ts
@@ -1,23 +1,31 @@
 import { join } from "node:path";
-import { readFile, writeFile, unlink } from "node:fs/promises";
+import { writeFile, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { nanoid } from "nanoid";
 import { Type } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
+import { buildRenderer } from "@agentchan/renderer-bundle";
 import { textResult } from "../tool-result.js";
 import { scanWorkspaceFiles } from "../workspace/scan.js";
 
 const ValidateRendererParams = Type.Object({});
 
-const DESCRIPTION = `Validate the project's renderer.ts by transpiling and executing it with the current project files.
+const DESCRIPTION = `Validate the project's renderer by bundling and executing it with the current project files.
 
+Supports flat renderer.ts or a renderer/ directory with relative imports.
 Returns rendered HTML on success, or a detailed error message with the failure phase (transpile / export / runtime).
-Use this after writing or editing renderer.ts to verify it works before asking the user to check.`;
+Use this after writing or editing the renderer to verify it works before asking the user to check.`;
 
 const MAX_HTML_CHARS = 3000;
 
+export interface CreateValidateRendererToolOptions {
+  /** Absolute path to @agentchan/renderer-runtime's source entry. */
+  runtimeEntry: string;
+}
+
 export function createValidateRendererTool(
   projectDir: string,
+  opts: CreateValidateRendererToolOptions,
 ): AgentTool<typeof ValidateRendererParams, void> {
   return {
     name: "validate-renderer",
@@ -26,42 +34,24 @@ export function createValidateRendererTool(
     label: "Validate renderer",
 
     async execute(): Promise<AgentToolResult<void>> {
-      // 1. Read renderer.ts
-      const rendererPath = join(projectDir, "renderer.ts");
-      let source: string;
-      try {
-        source = await readFile(rendererPath, "utf-8");
-      } catch {
-        return textResult("Error: renderer.ts not found in project root.");
-      }
+      const built = await buildRenderer(projectDir, {
+        runtimeEntry: opts.runtimeEntry,
+      });
+      if ("error" in built) return textResult(built.error);
 
-      // 2. Transpile TS → JS
-      const transpiler = new Bun.Transpiler({ loader: "ts" });
-      let js: string;
-      try {
-        js = transpiler.transformSync(source);
-      } catch (e) {
-        return textResult(
-          `Transpile error:\n${e instanceof Error ? e.message : String(e)}`,
-        );
-      }
-
-      // 3. Scan workspace files
       const files = await scanWorkspaceFiles(join(projectDir, "files"));
 
-      // 4. Write to temp file and dynamic import
       const tmpPath = join(tmpdir(), `agentchan-renderer-${nanoid(8)}.mjs`);
-      await writeFile(tmpPath, js);
+      await writeFile(tmpPath, built.js);
       try {
         const mod = await import(tmpPath);
 
         if (typeof mod.render !== "function") {
           return textResult(
-            "Export error: renderer.ts does not export a render() function.",
+            "Export error: renderer does not export a render() function.",
           );
         }
 
-        // 5. Execute render()
         const ctx = { files, baseUrl: "/api/projects/_validate" };
         const html: string = mod.render(ctx);
 

--- a/packages/creative-agent/src/workspace/types.ts
+++ b/packages/creative-agent/src/workspace/types.ts
@@ -1,24 +1,6 @@
-export interface TextFile {
-  type: "text";
-  path: string;
-  content: string;
-  frontmatter: Record<string, unknown> | null;
-  modifiedAt: number;
-}
-
-export interface DataFile {
-  type: "data";
-  path: string;
-  content: string;
-  data: unknown;
-  format: "yaml" | "json";
-  modifiedAt: number;
-}
-
-export interface BinaryFile {
-  type: "binary";
-  path: string;
-  modifiedAt: number;
-}
-
-export type ProjectFile = TextFile | DataFile | BinaryFile;
+export type {
+  TextFile,
+  DataFile,
+  BinaryFile,
+  ProjectFile,
+} from "@agentchan/renderer-types";

--- a/packages/creative-agent/tests/eval/harness.ts
+++ b/packages/creative-agent/tests/eval/harness.ts
@@ -88,6 +88,12 @@ export class EvalHarness {
     const ctx = createAgentContext({
       projectsDir: fixture.projectsDir,
       resolveAgentConfig: () => ({ provider, model, apiKey, temperature: 0 }),
+      // eval harness doesn't run meta-session tools; point at the runtime source
+      // so code that reads this field still sees a valid path.
+      rendererRuntimeEntry: new URL(
+        "../../../renderer-runtime/src/index.ts",
+        import.meta.url,
+      ).pathname,
     });
     const created = await createConversation(ctx, fixture.slug);
     const conversationId = created.conversation.id;

--- a/packages/renderer-bundle/package.json
+++ b/packages/renderer-bundle/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@agentchan/renderer-bundle",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@agentchan/renderer-runtime": "workspace:*",
+    "@agentchan/renderer-types": "workspace:*"
+  }
+}

--- a/packages/renderer-bundle/src/index.ts
+++ b/packages/renderer-bundle/src/index.ts
@@ -1,0 +1,282 @@
+// Bundle a project's renderer.ts (or renderer/index.ts) into a browser-ready
+// ES module. Used by both the webui server and the creative-agent's
+// validate-renderer tool.
+//
+// Policy:
+// - Project-local relative imports must stay inside projectDir.
+// - Only @agentchan/renderer-{runtime,types} may be imported by bare specifier.
+// - All other bare specifiers (npm, node:*, URLs) are rejected pre-flight.
+
+import { existsSync, statSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { extname, join, resolve, relative, dirname, isAbsolute } from "node:path";
+
+export interface BuildRendererOptions {
+  /** Absolute path to @agentchan/renderer-runtime's entry file (src/index.ts). */
+  runtimeEntry: string;
+}
+
+export interface BuildSuccess {
+  js: string;
+  /** Absolute paths of files whose mtime participates in cache invalidation. */
+  sources: string[];
+}
+
+export interface BuildFailure {
+  error: string;
+}
+
+export type BuildResult = BuildSuccess | BuildFailure;
+
+const RUNTIME_SPEC = "@agentchan/renderer-runtime";
+const TYPES_SPEC = "@agentchan/renderer-types";
+const ALLOWED_BARE = new Set([RUNTIME_SPEC, TYPES_SPEC]);
+
+// Hoisted once — `typeof Bun.build === "function"` is invariant for the life
+// of a process, and the fallback transpile cache keeps runtime-JS stable.
+interface BunApi {
+  build?: (cfg: unknown) => Promise<BunBuildResult>;
+  Transpiler?: new (o: { loader: string }) => { transformSync: (s: string) => string };
+}
+interface BunBuildResult {
+  success: boolean;
+  logs: { message: string; level: string }[];
+  outputs: { text(): Promise<string>; path: string }[];
+}
+const bun = (globalThis as { Bun?: BunApi }).Bun ?? {};
+const HAS_BUN_BUILD = typeof bun.build === "function";
+
+function resolveEntry(projectDir: string): string | null {
+  for (const candidate of [join(projectDir, "renderer", "index.ts"), join(projectDir, "renderer.ts")]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+export async function buildRenderer(
+  projectDir: string,
+  opts: BuildRendererOptions,
+): Promise<BuildResult> {
+  const entry = resolveEntry(projectDir);
+  if (!entry) return { error: "renderer.ts not found" };
+
+  if (HAS_BUN_BUILD) {
+    try {
+      return await buildWithBunBuild(entry, projectDir);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const fallback = await buildWithTranspiler(entry, opts);
+      if ("error" in fallback) {
+        return { error: `Bun.build failed: ${message}\nFallback also failed: ${fallback.error}` };
+      }
+      return fallback;
+    }
+  }
+
+  return buildWithTranspiler(entry, opts);
+}
+
+async function buildWithBunBuild(entry: string, projectDir: string): Promise<BuildResult> {
+  const policyError = await checkImportPolicy(entry, projectDir);
+  if (policyError) return { error: policyError };
+
+  const result = await bun.build!({
+    entrypoints: [entry],
+    target: "browser",
+    format: "esm",
+    minify: false,
+    sourcemap: "none",
+    external: [TYPES_SPEC],
+  });
+
+  if (!result.success) {
+    const messages = result.logs
+      .filter((l) => l.level === "error")
+      .map((l) => l.message)
+      .join("\n");
+    return { error: `transpile: ${messages || "Bun.build failed"}` };
+  }
+  const output = result.outputs[0];
+  if (!output) return { error: "transpile: no output produced" };
+
+  const js = await output.text();
+  // Full dep graph isn't tracked here — the service layer invalidates the
+  // cache on any write through ProjectRepo, which covers all in-app mutations.
+  return { js, sources: [entry] };
+}
+
+async function checkImportPolicy(entry: string, projectDir: string): Promise<string | null> {
+  const visited = new Set<string>();
+  const queue: string[] = [resolve(entry)];
+
+  while (queue.length > 0) {
+    const file = queue.shift()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+    if (!isInside(file, projectDir)) continue;
+
+    let source: string;
+    try {
+      source = await readFile(file, "utf-8");
+    } catch {
+      continue;
+    }
+
+    const importRx = /\bimport\s+(?:type\s+)?[\s\S]*?\bfrom\s*["']([^"']+)["']/g;
+    const dynamicRx = /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g;
+    const specs: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = importRx.exec(source)) !== null) if (m[1]) specs.push(m[1]);
+    while ((m = dynamicRx.exec(source)) !== null) if (m[1]) specs.push(m[1]);
+
+    const fileDir = dirname(file);
+    for (const spec of specs) {
+      if (spec.startsWith("./") || spec.startsWith("../") || isAbsolute(spec)) {
+        const resolved = resolve(fileDir, spec);
+        if (!isInside(resolved, projectDir)) {
+          return `resolve: import "${spec}" in ${relative(projectDir, file) || file} escapes the project directory`;
+        }
+        for (const c of walkerCandidates(resolved)) {
+          if (existsSync(c)) queue.push(c);
+        }
+      } else if (!ALLOWED_BARE.has(spec)) {
+        return `resolve: import "${spec}" is not in the allowlist. Only relative paths and @agentchan/renderer-{runtime,types} are permitted.`;
+      }
+    }
+  }
+  return null;
+}
+
+// TS-style imports write `.js` for a `.ts` source. Handle that plus index.* fallbacks.
+function walkerCandidates(resolved: string): string[] {
+  if (extname(resolved) === "") {
+    return [resolved + ".ts", resolved + ".js", join(resolved, "index.ts"), join(resolved, "index.js")];
+  }
+  const out = [resolved];
+  if (resolved.endsWith(".js")) out.push(resolved.slice(0, -3) + ".ts");
+  else if (resolved.endsWith(".mjs")) out.push(resolved.slice(0, -4) + ".mts");
+  return out;
+}
+
+// Runtime transpile result is invariant per runtimeEntry within a process.
+const transpiledRuntimeCache = new Map<string, string>();
+
+async function getTranspiledRuntime(runtimeEntry: string): Promise<string> {
+  const hit = transpiledRuntimeCache.get(runtimeEntry);
+  if (hit !== undefined) return hit;
+  if (!bun.Transpiler) throw new Error("Bun.Transpiler unavailable");
+  const source = await readFile(runtimeEntry, "utf-8");
+  const js = new bun.Transpiler({ loader: "ts" }).transformSync(source);
+  transpiledRuntimeCache.set(runtimeEntry, js);
+  return js;
+}
+
+// Build a prologue that wraps renderer-runtime in an IIFE and destructures
+// every `export function` name back into the top-level scope, so the renderer
+// body's (stripped) named imports still resolve. Destructure list is derived
+// dynamically from the transpiled runtime — no hand-maintained export list.
+function buildRuntimePrologue(runtimeJs: string): string {
+  const names = new Set<string>();
+  const fnRx = /\bexports\.(\w+)\s*=/g;
+  const bodyJs = runtimeJs.replace(/export\s+function\s+(\w+)/g, (_m, n: string) => {
+    names.add(n);
+    return `exports.${n} = function ${n}`;
+  });
+  // Any surviving `exports.foo = ...` from the regex above becomes a name.
+  let m: RegExpExecArray | null;
+  while ((m = fnRx.exec(bodyJs)) !== null) names.add(m[1]!);
+  const destructure = names.size > 0 ? `const { ${[...names].join(", ")} } = __rendererRuntime;\n` : "";
+  return `const __rendererRuntime = (() => {\n  const exports = {};\n${bodyJs}\n  return exports;\n})();\n${destructure}`;
+}
+
+/**
+ * Fallback for runtimes without Bun.build: transpile the flat renderer.ts
+ * directly, strip @agentchan/renderer-* imports, and prepend the runtime
+ * source so named helpers still resolve. Multi-file renderer/ is not supported.
+ */
+async function buildWithTranspiler(entry: string, opts: BuildRendererOptions): Promise<BuildResult> {
+  try {
+    if (!bun.Transpiler) return { error: "transpile: Bun.Transpiler unavailable" };
+    const source = await readFile(entry, "utf-8");
+    const transpiler = new bun.Transpiler({ loader: "ts" });
+    let body = transpiler.transformSync(source);
+
+    const importRx = /^\s*import[\s\S]*?from\s*["']([^"']+)["']/gm;
+    const forbidden: string[] = [];
+    const runtimeStmts: string[] = [];
+    body.replace(importRx, (match, spec: string) => {
+      if (ALLOWED_BARE.has(spec)) runtimeStmts.push(match);
+      else forbidden.push(spec);
+      return match;
+    });
+    if (forbidden.length > 0) {
+      return {
+        error:
+          `resolve: fallback transpiler cannot resolve imports: ${forbidden.join(", ")}. ` +
+          `Use a flat renderer.ts or run on a Bun runtime that supports Bun.build.`,
+      };
+    }
+    for (const stmt of runtimeStmts) body = body.replace(stmt, "");
+
+    const runtimeJs = await getTranspiledRuntime(opts.runtimeEntry);
+    return { js: buildRuntimePrologue(runtimeJs) + body, sources: [entry, opts.runtimeEntry] };
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return { error: `transpile: ${message}` };
+  }
+}
+
+function isInside(child: string, parent: string): boolean {
+  const rel = relative(parent, child);
+  return !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+export interface BundleCache {
+  get(slug: string): string | null;
+  set(slug: string, js: string, sources: string[]): void;
+  invalidate(slug: string): void;
+}
+
+interface CacheEntry {
+  js: string;
+  sigs: Map<string, number>;
+}
+
+// Bounded in practice by project count. Cache mtime tracks external-to-repo
+// mutations (e.g. edits to the shared runtime source in dev); in-project
+// writes are invalidated directly by the service layer.
+export function createBundleCache(): BundleCache {
+  const store = new Map<string, CacheEntry>();
+  return {
+    get(slug) {
+      const entry = store.get(slug);
+      if (!entry) return null;
+      for (const [path, sig] of entry.sigs) {
+        try {
+          if (statSync(path).mtimeMs !== sig) {
+            store.delete(slug);
+            return null;
+          }
+        } catch {
+          store.delete(slug);
+          return null;
+        }
+      }
+      return entry.js;
+    },
+    set(slug, js, sources) {
+      const sigs = new Map<string, number>();
+      for (const path of sources) {
+        try {
+          sigs.set(path, statSync(path).mtimeMs);
+        } catch {
+          // file vanished mid-build — skip
+        }
+      }
+      store.set(slug, { js, sigs });
+    },
+    invalidate(slug) {
+      store.delete(slug);
+    },
+  };
+}

--- a/packages/renderer-bundle/tsconfig.json
+++ b/packages/renderer-bundle/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/renderer-runtime/package.json
+++ b/packages/renderer-runtime/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@agentchan/renderer-runtime",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "dependencies": {
+    "@agentchan/renderer-types": "workspace:*"
+  }
+}

--- a/packages/renderer-runtime/src/index.ts
+++ b/packages/renderer-runtime/src/index.ts
@@ -1,0 +1,80 @@
+// Shared browser-side utilities for renderer.ts. No external dependencies —
+// this keeps the fallback linker (which can't resolve node_modules) simple.
+// Import from a renderer as: `import { escapeHtml } from "@agentchan/renderer-runtime"`.
+
+import type { ProjectFile, TextFile } from "@agentchan/renderer-types";
+
+const HTML_ESCAPES: Record<string, string> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/**
+ * Escape HTML special characters for safe insertion into text content or
+ * attribute values. Produces a short output — preserves `/` and unicode.
+ */
+export function escapeHtml(text: string): string {
+  return text.replace(/[&<>"']/g, (ch) => HTML_ESCAPES[ch] ?? ch);
+}
+
+/**
+ * Escape a string for use inside a `"..."` HTML attribute value.
+ * Alias of escapeHtml — provided for intent clarity at call sites.
+ */
+export function escapeAttr(text: string): string {
+  return escapeHtml(text);
+}
+
+/**
+ * Lowercase ASCII slug for use as CSS class / id fragments derived from a
+ * user-facing name. Non-ASCII characters are preserved to keep Korean names
+ * readable; whitespace collapses to `-`.
+ */
+export function slugifyToken(name: string): string {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w\-\uAC00-\uD7A3\u3040-\u30FF\u4E00-\u9FFF]/g, "");
+}
+
+/** Narrow a ProjectFile to TextFile (type-guard). */
+export function isTextFile(file: ProjectFile): file is TextFile {
+  return file.type === "text";
+}
+
+/**
+ * Convention: a file represents a character if its frontmatter defines a
+ * `display-name` field. Renderers that adopt this convention can use this
+ * guard instead of reimplementing the check.
+ */
+export function isCharacterFile(file: ProjectFile): file is TextFile {
+  return (
+    file.type === "text" &&
+    typeof file.frontmatter?.["display-name"] === "string"
+  );
+}
+
+/**
+ * Convention: a file represents the user's persona if `role: persona` is set
+ * in its frontmatter.
+ */
+export function isPersonaFile(file: ProjectFile): file is TextFile {
+  return file.type === "text" && file.frontmatter?.role === "persona";
+}
+
+/**
+ * Read a string field from a file's frontmatter, returning undefined when
+ * missing or of the wrong type. Saves the `typeof` dance at call sites.
+ */
+export function frontmatterString(
+  file: ProjectFile,
+  key: string,
+): string | undefined {
+  if (file.type !== "text" || !file.frontmatter) return undefined;
+  const value = file.frontmatter[key];
+  return typeof value === "string" ? value : undefined;
+}

--- a/packages/renderer-runtime/tsconfig.json
+++ b/packages/renderer-runtime/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/renderer-types/package.json
+++ b/packages/renderer-types/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@agentchan/renderer-types",
+  "version": "0.1.0",
+  "license": "MIT",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts"
+}

--- a/packages/renderer-types/src/index.ts
+++ b/packages/renderer-types/src/index.ts
@@ -1,0 +1,53 @@
+// Shared types for renderer.ts authors. No runtime values — this package is
+// consumed via `import type` only. The source of this file is also served
+// verbatim to the editor (via /api/system/renderer-types.ts) so that autocomplete
+// can be derived from the same declarations that renderers compile against.
+
+export interface TextFile {
+  type: "text";
+  path: string;
+  content: string;
+  frontmatter: Record<string, unknown> | null;
+  modifiedAt: number;
+}
+
+export interface DataFile {
+  type: "data";
+  path: string;
+  content: string;
+  data: unknown;
+  format: "yaml" | "json";
+  modifiedAt: number;
+}
+
+export interface BinaryFile {
+  type: "binary";
+  path: string;
+  modifiedAt: number;
+}
+
+export type ProjectFile = TextFile | DataFile | BinaryFile;
+
+export interface RenderContext {
+  files: ProjectFile[];
+  baseUrl: string;
+}
+
+// Token names map 1:1 to the app's `--color-*` CSS custom properties.
+export interface RendererThemeTokens {
+  void?: string;
+  base?: string;
+  surface?: string;
+  elevated?: string;
+  accent?: string;
+  fg?: string;
+  fg2?: string;
+  fg3?: string;
+  edge?: string;
+}
+
+export interface RendererTheme {
+  base: RendererThemeTokens;
+  dark?: Partial<RendererThemeTokens>;
+  prefersScheme?: "light" | "dark";
+}

--- a/packages/renderer-types/tsconfig.json
+++ b/packages/renderer-types/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- 단일 `renderer.ts` transpile 이 복잡한 템플릿에서 한계에 달해 (rpg-chat 4,152줄, sentinel 1,726줄), `renderer/index.ts + renderer/utils.ts` 식 모듈 분리와 시스템 제공 유틸 virtual module 을 지원하는 번들러로 교체.
- 타입(`RenderContext`, `ProjectFile`, `RendererTheme`)을 `@agentchan/renderer-types` SSOT 로 통합. 렌더러는 `import type` 만 해도 Bun.Transpiler 가 출력에서 제거 → exe 배포 호환.
- `@agentchan/renderer-runtime` 에 `escapeHtml`, `isCharacterFile`, `frontmatterString` 등 공통 유틸 노출. 기존 렌더러들의 중복 구현을 점진적으로 교체 가능.
- CodeMirror 자동완성을 하드코딩에서 d.ts 파서 기반 동적 생성으로 교체 — 타입 SSOT drift 제거.

## 주요 변경

### 신규 패키지
- `packages/renderer-types` — 런타임 값 0, 소스-퍼스트. 에디터에 정적 서빙되는 경로.
- `packages/renderer-runtime` — 외부 의존성 0, 단일 파일. fallback linker 단순화 목적.
- `packages/renderer-bundle` — `buildRenderer()` 공용 모듈. Bun.build 경로 + `checkImportPolicy` 프리플라이트 walker + Bun.Transpiler fallback + mtime 캐시.

### 통합
- `project.service.transpileRenderer` → `buildRenderer` 호출로 교체. 반환 타입을 `{ js } | { error } | null` 로 확장.
- `validate-renderer` 툴도 동일 번들러 사용. `AgentContext.rendererRuntimeEntry` 로 경로 주입.
- `/api/system/renderer-{types,runtime}.ts` 신규 라우트 — 서버 기동 시 1회 로드, 매 요청 디스크 read 제거.
- `paths.ts` 에 `RENDERER_RUNTIME_ENTRY`, `RENDERER_TYPES_ENTRY` 분기 (dev: monorepo src, compiled: `data/_system/*`).
- `build-exe.ts` 가 sidecar `data/_system/` 복사 추가.

### 에디터
- `entities/editor/rendererDts.ts` 신설 — d.ts/runtime 소스 fetch → top-level interface·export function 정규식 파싱 → CodeMirror `CompletionResult` 자동 생성.
- `FileEditor.tsx` 하드코딩 `rendererCompletions` 제거, TS 파일 오픈 시 `prefetchRendererTypes()` 호출.

### 정책
- 허용: 프로젝트 내부 상대 import, `@agentchan/renderer-{runtime,types}`.
- 거부: npm 패키지, `node:*`, URL 등. 프리플라이트에서 400 + `resolve: import "X" is not in the allowlist` 에러.

## Test plan

- [x] `bun install` — 391 installs / 456 packages 성공
- [x] `bunx tsc --noEmit` × 5 패키지 (webui, creative-agent, renderer-types/runtime/bundle) 통과
- [x] `bun run test` — 44/44 pass
- [x] `bun run lint` — pass
- [x] 템플릿 8종 렌더러 번들 (rpg-chat, sentinel, character-chat, novel, interactive-chat, memory-chat, impersonate-chat, empty) 모두 200
- [x] 분리형 \`renderer/index.ts\` + \`renderer/utils.ts\` + \`import { escapeHtml } from \"@agentchan/renderer-runtime\"\` 빌드 200, 번들에 runtime+utils+entry inline
- [x] 경계 위반 \`import { readFileSync } from \"node:fs\"\` → 400 + \`resolve: import \"node:fs\" is not in the allowlist...\`
- [x] \`/api/system/renderer-types.ts\`, \`/renderer-runtime.ts\` 200
- [ ] **exe 빌드 환경 검증 필요** — \`bun run build:exe\` 후 별도 폴더 실행 시 \`Bun.build\` 동작 여부, 동작 안 할 시 Bun.Transpiler fallback 경로 자동 분기 확인

## 후속 작업 (이 PR 스코프 밖)

- 기존 렌더러 `renderer/` 분할 파일럿 (rpg-chat 등) — 별도 PR
- `useOutput.ts` 의 `escapeHtml` 은 runtime 으로 교체 완료. 다른 레거시 렌더러들은 기존 인라인 구현 그대로 동작 (backward compat 유지).

🤖 Generated with [Claude Code](https://claude.com/claude-code)