### PR TITLE
feat(providers): zai whitelist + GitHub Copilot subscription 연동

### DIFF
--- a/apps/webui/package.json
+++ b/apps/webui/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@agentchan/creative-agent": "workspace:*",
     "@agentchan/estimate-tokens": "workspace:*",
+    "@mariozechner/pi-ai": "^0.66.1",
     "@base-ui/react": "^1.3.0",
     "@codemirror/autocomplete": "^6.20.1",
     "@codemirror/commands": "^6.10.3",

--- a/apps/webui/src/client/entities/config/config.api.ts
+++ b/apps/webui/src/client/entities/config/config.api.ts
@@ -1,4 +1,4 @@
-import { json } from "@/client/shared/api.js";
+import { json, parseSSEStream, BASE } from "@/client/shared/api.js";
 import type { ProviderInfo, ThinkingLevel, CustomProviderDef } from "@agentchan/creative-agent";
 
 export interface ConfigResponse {
@@ -70,6 +70,73 @@ export function updateApiKey(provider: string, key: string): Promise<ApiKeyStatu
 export function deleteApiKey(provider: string): Promise<ApiKeyStatus> {
   return json(`/config/api-keys/${encodeURIComponent(provider)}`, {
     method: "DELETE",
+  });
+}
+
+// --- OAuth ---
+
+export interface OAuthStatus {
+  signedIn: boolean;
+  expiresAt?: number;
+  enterpriseUrl?: string;
+}
+
+export interface OAuthAuthInfo {
+  url: string;
+  instructions?: string;
+}
+
+export interface LoginOAuthCallbacks {
+  onAuth: (info: OAuthAuthInfo) => void;
+  onProgress?: (message: string) => void;
+  onDone: (status: OAuthStatus) => void | Promise<void>;
+  onError: (message: string) => void;
+  signal?: AbortSignal;
+}
+
+export function fetchOAuthStatus(provider: string): Promise<OAuthStatus> {
+  return json(`/config/oauth/${encodeURIComponent(provider)}`);
+}
+
+export function logoutOAuth(provider: string): Promise<OAuthStatus> {
+  return json(`/config/oauth/${encodeURIComponent(provider)}`, { method: "DELETE" });
+}
+
+export async function loginOAuthStream(
+  provider: string,
+  { onAuth, onProgress, onDone, onError, signal }: LoginOAuthCallbacks,
+): Promise<void> {
+  const res = await fetch(`${BASE}/config/oauth/${encodeURIComponent(provider)}/login`, {
+    method: "POST",
+    signal,
+  });
+  if (!res.ok || !res.body) {
+    onError(`HTTP ${res.status}`);
+    return;
+  }
+  await parseSSEStream(res.body, (event, data) => {
+    switch (event) {
+      case "auth":
+        try {
+          onAuth(JSON.parse(data) as OAuthAuthInfo);
+        } catch {
+          onError("Failed to parse auth event");
+        }
+        return;
+      case "progress":
+        onProgress?.(data);
+        return;
+      case "done":
+        try {
+          void onDone(JSON.parse(data) as OAuthStatus);
+        } catch {
+          void onDone({ signedIn: true });
+        }
+        return;
+      case "error":
+        onError(data);
+        return;
+    }
   });
 }
 

--- a/apps/webui/src/client/entities/config/index.ts
+++ b/apps/webui/src/client/entities/config/index.ts
@@ -7,5 +7,6 @@ export {
   fetchApiKeys, updateApiKey, deleteApiKey,
   fetchOnboardingStatus, completeOnboarding,
   saveCustomProvider, deleteCustomProvider,
+  fetchOAuthStatus, logoutOAuth, loginOAuthStream,
 } from "./config.api.js";
-export type { ApiKeyStatus } from "./config.api.js";
+export type { ApiKeyStatus, OAuthStatus, OAuthAuthInfo } from "./config.api.js";

--- a/apps/webui/src/client/features/settings/SettingsView.tsx
+++ b/apps/webui/src/client/features/settings/SettingsView.tsx
@@ -1,10 +1,10 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ArrowLeft, Globe } from "lucide-react";
 import { useUIState, useUIDispatch, type PageRoute } from "@/client/entities/ui/index.js";
-import { useConfigState, useConfigDispatch, updateConfig, fetchApiKeys, updateApiKey, deleteApiKey, saveCustomProvider, deleteCustomProvider, fetchProviders, FORMAT_OPTIONS } from "@/client/entities/config/index.js";
-import type { ApiKeyStatus, CustomApiFormat } from "@/client/entities/config/index.js";
+import { useConfigState, useConfigDispatch, updateConfig, fetchApiKeys, updateApiKey, deleteApiKey, saveCustomProvider, deleteCustomProvider, fetchProviders, FORMAT_OPTIONS, fetchOAuthStatus, logoutOAuth, loginOAuthStream } from "@/client/entities/config/index.js";
+import type { ApiKeyStatus, CustomApiFormat, OAuthStatus, OAuthAuthInfo } from "@/client/entities/config/index.js";
 import { useI18n, type LanguagePreference, type TranslationKey } from "@/client/i18n/index.js";
-import { Badge, Button, IconButton, Indicator, SectionHeader, TabBar, Select, FormField, OptionCardGrid, TextInput, ScrollArea } from "@/client/shared/ui/index.js";
+import { Badge, Button, Dialog, IconButton, Indicator, SectionHeader, TabBar, Select, FormField, OptionCardGrid, TextInput, ScrollArea } from "@/client/shared/ui/index.js";
 import {
   notificationPermission,
   requestNotificationPermission,
@@ -309,6 +309,10 @@ function ApiKeysTab() {
         <SectionHeader title={t("globalSettings.apiKeys")} description={t("globalSettings.apiKeysDescription")} />
         <div className="space-y-4">
           {config.providers.map((p) => {
+            if (p.oauth) {
+              return <OAuthProviderCard key={p.name} providerName={p.name} onChange={refreshProviders} />;
+            }
+
             const masked = keys[p.name] || "";
             const isConfigured = masked !== "";
             const isSaving = saving === p.name;
@@ -409,5 +413,207 @@ function ProviderForm({ form, updateForm, onSubmit, onCancel, t }: {
         </Button>
       </div>
     </div>
+  );
+}
+
+const PROVIDER_LABELS: Record<string, string> = {
+  "github-copilot": "GitHub Copilot",
+};
+
+function providerLabel(name: string): string {
+  return PROVIDER_LABELS[name] ?? name;
+}
+
+function formatExpires(expiresAt: number | undefined): string {
+  if (!expiresAt) return "";
+  const deltaMs = expiresAt - Date.now();
+  if (deltaMs <= 0) return "";
+  const minutes = Math.floor(deltaMs / 60_000);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remMin = minutes % 60;
+  return remMin > 0 ? `${hours}h ${remMin}m` : `${hours}h`;
+}
+
+function OAuthProviderCard({ providerName, onChange }: { providerName: string; onChange: () => Promise<void> }) {
+  const { t } = useI18n();
+  const [status, setStatus] = useState<OAuthStatus | null>(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const label = providerLabel(providerName);
+
+  useEffect(() => {
+    void fetchOAuthStatus(providerName).then(setStatus);
+  }, [providerName]);
+
+  const handleLogout = async () => {
+    setBusy(true);
+    try {
+      const next = await logoutOAuth(providerName);
+      setStatus(next);
+      await onChange();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleLoginDone = async (next: OAuthStatus) => {
+    setStatus(next);
+    await onChange();
+  };
+
+  const signedIn = status?.signedIn ?? false;
+  const expired = signedIn && status?.expiresAt !== undefined && status.expiresAt <= Date.now();
+  const relative = formatExpires(status?.expiresAt);
+
+  return (
+    <div className="p-4 rounded-xl border border-edge/8 bg-elevated/30 space-y-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2.5">
+          <span className="text-sm font-medium text-fg">{label}</span>
+          <Badge variant={signedIn && !expired ? "accent" : "muted"}>
+            <Indicator color={signedIn && !expired ? "accent" : "fg"} />
+            {signedIn ? (expired ? t("oauth.sessionExpired") : t("oauth.signedIn")) : t("oauth.notSignedIn")}
+          </Badge>
+        </div>
+        {signedIn && !expired && relative && (
+          <span className="text-xs text-fg-3 font-mono">
+            {t("oauth.expiresIn", { relative })}
+          </span>
+        )}
+      </div>
+      <div className="flex gap-2">
+        {!signedIn || expired ? (
+          <Button
+            variant="accent"
+            size="md"
+            onClick={() => setModalOpen(true)}
+            disabled={busy}
+          >
+            {t("oauth.signIn", { provider: label })}
+          </Button>
+        ) : (
+          <Button
+            variant="danger"
+            size="md"
+            onClick={() => void handleLogout()}
+            disabled={busy}
+          >
+            {t("oauth.signOut")}
+          </Button>
+        )}
+      </div>
+      {modalOpen && (
+        <DeviceCodeModal
+          providerName={providerName}
+          providerLabel={label}
+          onDone={handleLoginDone}
+          onClose={() => setModalOpen(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function DeviceCodeModal({
+  providerName,
+  providerLabel,
+  onDone,
+  onClose,
+}: {
+  providerName: string;
+  providerLabel: string;
+  onDone: (status: OAuthStatus) => void | Promise<void>;
+  onClose: () => void;
+}) {
+  const { t } = useI18n();
+  const [authInfo, setAuthInfo] = useState<OAuthAuthInfo | null>(null);
+  const [progress, setProgress] = useState<string>("");
+  const [error, setError] = useState<string>("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const onDoneRef = useRef(onDone);
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onDoneRef.current = onDone;
+    onCloseRef.current = onClose;
+  });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    void loginOAuthStream(providerName, {
+      signal: controller.signal,
+      onAuth: (info) => setAuthInfo(info),
+      onProgress: (msg) => setProgress(msg),
+      onDone: async (status) => {
+        try {
+          await onDoneRef.current(status);
+        } finally {
+          if (!controller.signal.aborted) onCloseRef.current();
+        }
+      },
+      onError: (msg) => {
+        if (controller.signal.aborted) return;
+        setError(msg);
+      },
+    }).catch((err: unknown) => {
+      if (controller.signal.aborted) return;
+      setError(err instanceof Error ? err.message : String(err));
+    });
+
+    return () => {
+      controller.abort();
+      abortRef.current = null;
+    };
+  }, [providerName]);
+
+  const handleCancel = () => {
+    abortRef.current?.abort();
+    onClose();
+  };
+
+  const handleOpenBrowser = () => {
+    if (authInfo?.url) {
+      window.open(authInfo.url, "_blank", "noopener");
+    }
+  };
+
+  return (
+    <Dialog open={true} onOpenChange={(next) => { if (!next) handleCancel(); }}>
+      <div className="p-6 space-y-4">
+        <h3 className="font-display text-base font-bold tracking-tight">
+          {t("oauth.modalTitle", { provider: providerLabel })}
+        </h3>
+        {error ? (
+          <div className="text-sm text-danger">{t("oauth.loginFailed", { message: error })}</div>
+        ) : authInfo ? (
+          <div className="space-y-3">
+            <div className="text-sm text-fg-2">
+              {t("oauth.deviceCodeInstructions", { url: authInfo.url })}
+            </div>
+            {authInfo.instructions && (
+              <div className="px-4 py-3 rounded-lg bg-elevated/40 border border-edge/8 text-lg font-mono tracking-widest text-center text-fg select-all">
+                {authInfo.instructions}
+              </div>
+            )}
+            <div className="text-xs text-fg-3">{progress || t("oauth.waiting")}</div>
+          </div>
+        ) : (
+          <div className="text-sm text-fg-3">{t("oauth.signingIn")}</div>
+        )}
+        <div className="flex gap-2 justify-end">
+          {authInfo && !error && (
+            <Button variant="ghost" size="md" onClick={handleOpenBrowser}>
+              {t("oauth.openBrowser")}
+            </Button>
+          )}
+          <Button variant="danger" size="md" onClick={handleCancel}>
+            {t("oauth.cancel")}
+          </Button>
+        </div>
+      </div>
+    </Dialog>
   );
 }

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -172,6 +172,23 @@ export const translations = {
   "globalSettings.activeProvider": "Active Provider & Model",
   "globalSettings.activeProviderDesc": "Select which provider and model to use for conversations",
 
+  // OAuth providers (e.g. GitHub Copilot)
+  "oauth.signIn": "Sign in with {{provider}}",
+  "oauth.signedIn": "Signed in",
+  "oauth.notSignedIn": "Not signed in",
+  "oauth.signOut": "Sign out",
+  "oauth.signingIn": "Signing in...",
+  "oauth.expiresIn": "Expires in {{relative}}",
+  "oauth.sessionExpired": "Session expired",
+  "oauth.modalTitle": "Authorize {{provider}}",
+  "oauth.deviceCodeInstructions": "Open {{url}} and enter the code below.",
+  "oauth.openBrowser": "Open browser",
+  "oauth.copyCode": "Copy",
+  "oauth.waiting": "Waiting for authorization...",
+  "oauth.enablingModels": "Enabling models...",
+  "oauth.loginFailed": "Login failed: {{message}}",
+  "oauth.cancel": "Cancel",
+
   // Custom Providers
   "customApi.providers": "Custom Providers",
   "customApi.providersDesc": "Add custom API providers with your own endpoints.",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -174,6 +174,23 @@ export const translations: Record<TranslationKey, string> = {
   "globalSettings.activeProvider": "활성 프로바이더 및 모델",
   "globalSettings.activeProviderDesc": "대화에 사용할 프로바이더와 모델을 선택하세요",
 
+  // OAuth 프로바이더 (예: GitHub Copilot)
+  "oauth.signIn": "{{provider}}로 로그인",
+  "oauth.signedIn": "로그인됨",
+  "oauth.notSignedIn": "로그인되지 않음",
+  "oauth.signOut": "로그아웃",
+  "oauth.signingIn": "로그인 중...",
+  "oauth.expiresIn": "{{relative}} 후 만료",
+  "oauth.sessionExpired": "세션 만료됨",
+  "oauth.modalTitle": "{{provider}} 인증",
+  "oauth.deviceCodeInstructions": "{{url}}을 열고 아래 코드를 입력하세요.",
+  "oauth.openBrowser": "브라우저에서 열기",
+  "oauth.copyCode": "복사",
+  "oauth.waiting": "인증 대기 중...",
+  "oauth.enablingModels": "모델 활성화 중...",
+  "oauth.loginFailed": "로그인 실패: {{message}}",
+  "oauth.cancel": "취소",
+
   // Custom Providers
   "customApi.providers": "커스텀 프로바이더",
   "customApi.providersDesc": "자체 엔드포인트로 커스텀 API 프로바이더를 추가합니다.",

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -49,22 +49,28 @@ const agentContext = createAgentContext({
   resolveAgentConfig: (): ResolvedAgentConfig => {
     const cfg = configService.getConfig();
     const providerInfo = configService.findProvider(cfg.provider);
+    const apiKey = configService.getApiKey(cfg.provider) ?? "";
+    const oauthBaseUrl = configService.getResolvedBaseUrl(cfg.provider, apiKey);
     return {
       provider: cfg.provider,
       model: cfg.model,
-      apiKey: configService.getApiKey(cfg.provider) ?? "",
+      apiKey,
       temperature: cfg.temperature,
       maxTokens: cfg.maxTokens,
       contextWindow: cfg.contextWindow,
       thinkingLevel: cfg.thinkingLevel,
       ...(providerInfo?.custom
         ? { baseUrl: providerInfo.custom.url, apiFormat: providerInfo.custom.format }
-        : {}),
+        : oauthBaseUrl
+          ? { baseUrl: oauthBaseUrl }
+          : {}),
     };
   },
 });
 const conversationService = createConversationService(agentContext);
-const agentService = createAgentService(agentContext);
+const agentService = createAgentService(agentContext, async () => {
+  await configService.ensureOAuthToken(configService.getConfig().provider);
+});
 
 // ===== 3. Bootstrap =====
 await templateRepo.ensureDir();

--- a/apps/webui/src/server/repositories/settings.repo.ts
+++ b/apps/webui/src/server/repositories/settings.repo.ts
@@ -1,5 +1,6 @@
 import { Database } from "bun:sqlite";
 import { join } from "node:path";
+import type { OAuthCredentials } from "@mariozechner/pi-ai/oauth";
 
 function maskKey(key: string): string {
   if (!key) return "";
@@ -14,6 +15,9 @@ export function createSettingsRepo(dataDir: string) {
   );
   db.run(
     "CREATE TABLE IF NOT EXISTS app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+  );
+  db.run(
+    "CREATE TABLE IF NOT EXISTS oauth_credentials (provider TEXT PRIMARY KEY, credentials TEXT NOT NULL)",
   );
 
   return {
@@ -63,6 +67,29 @@ export function createSettingsRepo(dataDir: string) {
 
     deleteAppSetting(key: string): void {
       db.run("DELETE FROM app_settings WHERE key = ?", [key]);
+    },
+
+    getOAuthCredentials(provider: string): OAuthCredentials | null {
+      const row = db.query("SELECT credentials FROM oauth_credentials WHERE provider = ?").get(provider) as
+        | { credentials: string }
+        | null;
+      if (!row) return null;
+      try {
+        return JSON.parse(row.credentials) as OAuthCredentials;
+      } catch {
+        return null;
+      }
+    },
+
+    setOAuthCredentials(provider: string, credentials: OAuthCredentials): void {
+      db.run(
+        "INSERT INTO oauth_credentials (provider, credentials) VALUES (?, ?) ON CONFLICT(provider) DO UPDATE SET credentials = excluded.credentials",
+        [provider, JSON.stringify(credentials)],
+      );
+    },
+
+    deleteOAuthCredentials(provider: string): void {
+      db.run("DELETE FROM oauth_credentials WHERE provider = ?", [provider]);
     },
   };
 }

--- a/apps/webui/src/server/routes/config.routes.ts
+++ b/apps/webui/src/server/routes/config.routes.ts
@@ -1,4 +1,5 @@
 import { Hono } from "hono";
+import { streamSSE } from "hono/streaming";
 import type { AppEnv, ServerConfig, CustomProviderDef } from "../types.js";
 
 export function createConfigRoutes() {
@@ -45,6 +46,43 @@ export function createConfigRoutes() {
 
   app.delete("/api-keys/:provider", (c) => {
     return c.json(c.get("configService").deleteApiKey(c.req.param("provider")));
+  });
+
+  // --- OAuth ---
+
+  app.get("/oauth/:provider", (c) => {
+    const provider = c.req.param("provider");
+    return c.json(c.get("configService").getOAuthStatus(provider));
+  });
+
+  app.post("/oauth/:provider/login", (c) => {
+    const provider = c.req.param("provider");
+    const signal = c.req.raw.signal;
+    return streamSSE(c, async (stream) => {
+      try {
+        await c.get("configService").startOAuthLogin(provider, {
+          onAuth: (info) => {
+            void stream.writeSSE({ event: "auth", data: JSON.stringify(info) });
+          },
+          onPrompt: () => Promise.resolve(""),
+          onProgress: (message: string) => {
+            void stream.writeSSE({ event: "progress", data: message });
+          },
+          signal,
+        });
+        const status = c.get("configService").getOAuthStatus(provider);
+        await stream.writeSSE({ event: "done", data: JSON.stringify(status) });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        await stream.writeSSE({ event: "error", data: message });
+      }
+    });
+  });
+
+  app.delete("/oauth/:provider", (c) => {
+    const provider = c.req.param("provider");
+    c.get("configService").logoutOAuth(provider);
+    return c.json(c.get("configService").getOAuthStatus(provider));
   });
 
   // --- Onboarding ---

--- a/apps/webui/src/server/services/agent.service.ts
+++ b/apps/webui/src/server/services/agent.service.ts
@@ -12,8 +12,15 @@ import {
  * SSE adapter — translates SessionEvent into the wire format the frontend
  * already expects. Event name strings here are the client contract; see
  * useChatStream for the consumer.
+ *
+ * `prepareRun` is called before each prompt/regenerate. OAuth providers use it
+ * to refresh expired tokens into the DB so the sync `resolveAgentConfig` reads
+ * fresh credentials.
  */
-export function createAgentService(ctx: AgentContext) {
+export function createAgentService(
+  ctx: AgentContext,
+  prepareRun: () => Promise<void> = async () => {},
+) {
   return {
     async sendMessage(
       stream: SSEStreamingApi,
@@ -23,6 +30,7 @@ export function createAgentService(ctx: AgentContext) {
       text: string,
       signal?: AbortSignal,
     ) {
+      await prepareRun();
       const queue = createSerialWriter(stream);
       try {
         await runPrompt(
@@ -43,6 +51,7 @@ export function createAgentService(ctx: AgentContext) {
       userNodeId: string,
       signal?: AbortSignal,
     ) {
+      await prepareRun();
       const queue = createSerialWriter(stream);
       try {
         await runRegenerate(

--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -1,8 +1,24 @@
 import { getProviders, getModels } from "@agentchan/creative-agent";
+import {
+  getOAuthApiKey,
+  getOAuthProvider,
+  getGitHubCopilotBaseUrl,
+  type OAuthLoginCallbacks,
+} from "@mariozechner/pi-ai/oauth";
 import type { ServerConfig, ProviderInfo, CustomProviderDef } from "../types.js";
 import type { SettingsRepo } from "../repositories/settings.repo.js";
 
-const BUILTIN_PROVIDERS = new Set(["google", "google-vertex", "openai", "anthropic", "vercel-ai-gateway"]);
+const BUILTIN_PROVIDERS = new Set([
+  "google",
+  "google-vertex",
+  "openai",
+  "anthropic",
+  "vercel-ai-gateway",
+  "zai",
+  "github-copilot",
+]);
+
+const OAUTH_PROVIDERS = new Set(["github-copilot"]);
 
 const ALLOWED_MODELS = new Set([
   // Anthropic
@@ -33,9 +49,50 @@ const ALLOWED_MODELS = new Set([
   "google/gemini-3.1-flash-lite-preview",
   "deepseek/deepseek-v3.2",
   "xai/grok-4.1-fast-non-reasoning",
+  // Z.ai
+  "glm-5",
+  "glm-5.1",
 ]);
 
 const DEFAULT_PROVIDER = "google";
+
+const COPILOT_HEADERS: Record<string, string> = {
+  "User-Agent": "GitHubCopilotChat/0.35.0",
+  "Editor-Version": "vscode/1.107.0",
+  "Editor-Plugin-Version": "copilot-chat/0.35.0",
+  "Copilot-Integration-Id": "vscode-chat",
+};
+
+async function enableAllCopilotModels(token: string): Promise<void> {
+  const baseUrl = getGitHubCopilotBaseUrl(token);
+  const models = getModels("github-copilot");
+  await Promise.all(
+    models.map(async (m) => {
+      try {
+        await fetch(`${baseUrl}/models/${m.id}/policy`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+            ...COPILOT_HEADERS,
+            "openai-intent": "chat-policy",
+            "x-interaction-type": "chat-policy",
+          },
+          body: JSON.stringify({ state: "enabled" }),
+        });
+      } catch {
+        // Ignore per-model enable failures; user can still chat with models
+        // GitHub already activated.
+      }
+    }),
+  );
+}
+
+export type OAuthStatus = {
+  signedIn: boolean;
+  expiresAt?: number;
+  enterpriseUrl?: string;
+};
 
 export function createConfigService(settingsRepo: SettingsRepo) {
   // --- Custom providers persistence ---
@@ -50,10 +107,22 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     settingsRepo.setAppSetting("custom-providers", JSON.stringify(providers));
   }
 
+  function hasOAuthCredentials(provider: string): boolean {
+    return settingsRepo.getOAuthCredentials(provider) != null;
+  }
+
   function buildProviderList(): ProviderInfo[] {
     const builtIn: ProviderInfo[] = getProviders()
       .filter((name) => BUILTIN_PROVIDERS.has(name))
       .map((name) => {
+        // OAuth provider (e.g. github-copilot): model list comes from pi-ai as-is,
+        // but hidden until user signs in so selecting it can't silently fail.
+        if (OAUTH_PROVIDERS.has(name)) {
+          const models = hasOAuthCredentials(name)
+            ? getModels(name).map((m) => ({ id: m.id, name: m.name, reasoning: m.reasoning }))
+            : [];
+          return { name, defaultModel: models[0]?.id ?? "", models, oauth: true };
+        }
         const models = getModels(name)
           .filter((m) => ALLOWED_MODELS.has(m.id))
           .map((m) => ({
@@ -127,6 +196,10 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     if (providerInfo?.custom) {
       // Custom providers: accept any saved model, fallback to default
       model = savedModel ?? (providerInfo?.defaultModel ?? "");
+    } else if (OAUTH_PROVIDERS.has(provider)) {
+      // OAuth providers: pi-ai is source of truth for model list, not ALLOWED_MODELS
+      const known = new Set(providerInfo?.models.map((m) => m.id) ?? []);
+      model = savedModel && known.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
     } else {
       model = savedModel && ALLOWED_MODELS.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
     }
@@ -236,6 +309,9 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     // --- API Keys ---
 
     getApiKey(provider: string): string | null {
+      if (OAUTH_PROVIDERS.has(provider)) {
+        return settingsRepo.getOAuthCredentials(provider)?.access ?? null;
+      }
       return settingsRepo.getApiKey(provider);
     },
 
@@ -251,6 +327,73 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     deleteApiKey(provider: string): Record<string, string> {
       settingsRepo.deleteApiKey(provider);
       return settingsRepo.getAllApiKeys();
+    },
+
+    // --- OAuth ---
+
+    isOAuthProvider(provider: string): boolean {
+      return OAUTH_PROVIDERS.has(provider);
+    },
+
+    getOAuthStatus(provider: string): OAuthStatus {
+      const creds = settingsRepo.getOAuthCredentials(provider);
+      if (!creds) return { signedIn: false };
+      return {
+        signedIn: true,
+        expiresAt: creds.expires,
+        enterpriseUrl: typeof creds.enterpriseUrl === "string" ? creds.enterpriseUrl : undefined,
+      };
+    },
+
+    async startOAuthLogin(provider: string, callbacks: OAuthLoginCallbacks): Promise<void> {
+      const oauthProvider = getOAuthProvider(provider);
+      if (!oauthProvider) {
+        throw new Error(`Unknown OAuth provider: ${provider}`);
+      }
+      const creds = await oauthProvider.login(callbacks);
+      settingsRepo.setOAuthCredentials(provider, creds);
+      invalidateProviderCache();
+      if (provider === "github-copilot") {
+        callbacks.onProgress?.("enabling models");
+        await enableAllCopilotModels(creds.access);
+      }
+    },
+
+    logoutOAuth(provider: string): void {
+      settingsRepo.deleteOAuthCredentials(provider);
+      invalidateProviderCache();
+      if (currentConfig.provider === provider) {
+        currentConfig.provider = DEFAULT_PROVIDER;
+        const providerInfo = getProviderList().find((p) => p.name === DEFAULT_PROVIDER);
+        currentConfig.model = providerInfo?.defaultModel ?? "";
+        settingsRepo.setAppSetting("config.provider", currentConfig.provider);
+        settingsRepo.setAppSetting("config.model", currentConfig.model);
+      }
+    },
+
+    /**
+     * Refresh OAuth token if needed and persist updated credentials.
+     * No-op for non-OAuth providers. Called before agent prompts so the sync
+     * `resolveAgentConfig` can read a fresh access token straight from the DB.
+     */
+    async ensureOAuthToken(provider: string): Promise<void> {
+      if (!OAUTH_PROVIDERS.has(provider)) return;
+      const creds = settingsRepo.getOAuthCredentials(provider);
+      if (!creds) return;
+      const result = await getOAuthApiKey(provider, { [provider]: creds });
+      if (!result) return;
+      // pi-ai returns the same reference when the token was still valid, and a
+      // new object when it was refreshed — so identity compare is enough here.
+      if (result.newCredentials !== creds) {
+        settingsRepo.setOAuthCredentials(provider, result.newCredentials);
+      }
+    },
+
+    getResolvedBaseUrl(provider: string, apiKey: string | null): string | undefined {
+      if (provider === "github-copilot" && apiKey) {
+        return getGitHubCopilotBaseUrl(apiKey);
+      }
+      return undefined;
     },
 
     isOnboardingCompleted(): boolean {

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@lezer/highlight": "^1.2.3",
+        "@mariozechner/pi-ai": "^0.66.1",
         "command-score": "^0.1.2",
         "hono": "^4.12.12",
         "idiomorph": "^0.7.4",

--- a/packages/creative-agent/src/config-types.ts
+++ b/packages/creative-agent/src/config-types.ts
@@ -18,6 +18,8 @@ export interface ProviderInfo {
   defaultModel: string;
   models: ModelInfo[];
   custom?: { url: string; format: CustomApiFormat };
+  /** Provider uses OAuth subscription (login flow) instead of API key input. */
+  oauth?: boolean;
 }
 
 export interface CustomProviderDef {


### PR DESCRIPTION
## Summary
- `BUILTIN_PROVIDERS` 화이트리스트에 **zai** 추가 (`glm-5`, `glm-5.1` 노출).
- **GitHub Copilot** subscription 연동 도입 — OAuth device code flow 기반. pi-ai(`@mariozechner/pi-ai/oauth`)가 제공하는 로그인/토큰 갱신 유틸을 webui가 storage + UI + SSE 엔드포인트로 감싸 통합.
- 로그인 성공 후 모든 Copilot 모델에 대해 policy enable을 병렬로 호출, 사용자가 즉시 모든 모델을 사용할 수 있도록 함.
- `settings.db`에 `oauth_credentials` 테이블 신설, `ProviderInfo`에 `oauth?: boolean` 플래그 추가로 서버/클라이언트 간 단일 진실을 유지.

## 주요 설계 결정
- **Sync `resolveAgentConfig` 유지**: pi-agent-core의 설정 해상 함수는 sync 시그니처 유지를 위해, `agent.service`의 `sendMessage`/`regenerate` 진입 시점에 `ensureOAuthToken()`을 pre-call하여 DB에 최신 토큰을 기록하는 방식으로 설계. 외부 패키지 시그니처 변경 없음.
- **동적 `baseUrl` 주입**: Copilot의 경우 token에 포함된 `proxy-ep`에서 base URL을 추출해 `ResolvedAgentConfig.baseUrl`에 주입. 기존 custom provider와 동일한 override 경로 재사용.
- **`ProviderInfo.oauth` 플래그**: 클라이언트에서 provider 이름 하드코딩 대신 서버 응답 플래그를 기반으로 UI 분기 — 향후 Anthropic Pro/Gemini CLI 등 다른 OAuth provider 추가 시 서버 쪽만 수정하면 됨.
- **로그인 전에는 모델 숨김**: 미로그인 시 Copilot의 `models: []`로 응답하여 프로바이더 선택은 가능하지만 모델 선택은 블록됨. silent failure 방지.

## 변경 파일
- 서버
  - `apps/webui/src/server/repositories/settings.repo.ts` — `oauth_credentials` 테이블 + CRUD, `OAuthCredentials` 타입
  - `apps/webui/src/server/services/config.service.ts` — BUILTIN/ALLOWED 확장, OAuth 메서드(`getOAuthStatus`, `startOAuthLogin`, `logoutOAuth`, `ensureOAuthToken`, `getResolvedBaseUrl`), Copilot 모델 policy 활성화 루프
  - `apps/webui/src/server/routes/config.routes.ts` — `GET`/`POST(SSE)`/`DELETE /oauth/:provider`
  - `apps/webui/src/server/services/agent.service.ts` — `prepareRun` 콜백 주입 지점
  - `apps/webui/src/server/index.ts` — `resolveAgentConfig`에 OAuth baseUrl 주입, `agentService`에 `ensureOAuthToken` 연결
- 클라이언트
  - `apps/webui/src/client/entities/config/config.api.ts` — `OAuthStatus`/`OAuthAuthInfo` 타입 + `fetchOAuthStatus`/`logoutOAuth`/`loginOAuthStream` (SSE 파서 재사용)
  - `apps/webui/src/client/features/settings/SettingsView.tsx` — `OAuthProviderCard` + `DeviceCodeModal`
  - `apps/webui/src/client/i18n/en.ts`, `ko.ts` — `oauth.*` 키 15개 추가
- 공통 타입
  - `packages/creative-agent/src/config-types.ts` — `ProviderInfo.oauth?: boolean`
- 의존성
  - `apps/webui/package.json`, `bun.lock` — `@mariozechner/pi-ai` 직접 dependency 추가 (subpath export `/oauth` 사용)

## Test plan
- [x] `cd apps/webui && bunx tsc --noEmit` 통과
- [x] `cd packages/creative-agent && bunx tsc --noEmit` 통과
- [x] `bun run lint` 통과
- [x] `bun run test` 통과 (44/44)
- [x] Settings → API 키 탭에서 Provider 드롭다운에 `zai`, `github-copilot` 노출
- [x] zai 선택 시 모델 드롭다운에 `glm-5`, `glm-5.1` 표시, 다른 provider는 기존 목록 유지
- [x] Copilot 카드 "Not signed in" 상태 + "Login with GitHub Copilot" 버튼 렌더
- [x] 로그인 버튼 클릭 시 device code 모달 표시 (verification URL + user code)
- [x] 취소 시 모달 닫힘 + 서버 SSE polling 정상 중단
- [x] `settings.db`에 `oauth_credentials (provider TEXT PRIMARY KEY, credentials TEXT NOT NULL)` 스키마 생성 확인
- [ ] (수동) 실제 GitHub 계정으로 로그인 → Copilot 모델 채팅 end-to-end 테스트

## 범위 밖
- GitHub Enterprise 도메인 입력 UI (pi-ai의 `enterpriseUrl` 필드는 schema에 보존, UI는 후속)
- 다른 OAuth provider(Anthropic Claude Pro, Gemini CLI 등) — 인프라는 일반화되어 있어 향후 UI + model allowlist만 추가하면 됨
- 멀티 탭 동시 토큰 refresh의 race 방지(proper-lockfile) — 단일 사용자 환경에서 리스크 낮음

🤖 Generated with [Claude Code](https://claude.com/claude-code)