### PR TITLE
feat(renderer): 프로젝트 전환 cross-fade + 테마 transition 300ms

### DIFF
--- a/apps/webui/src/client/app/AppShell.tsx
+++ b/apps/webui/src/client/app/AppShell.tsx
@@ -84,7 +84,7 @@ export function AppShell() {
 
   return (
     <div
-      className="flex h-full bg-void text-fg font-body transition-colors duration-200"
+      className="flex h-full bg-void text-fg font-body transition-colors duration-300"
       style={rootStyle}
       data-theme={dataThemeOverride}
     >

--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -13,7 +13,7 @@ export function Sidebar() {
   const { t } = useI18n();
 
   return (
-    <div className="flex flex-col w-72 h-full bg-base border-r border-edge/6 transition-colors duration-200">
+    <div className="flex flex-col w-72 h-full bg-base border-r border-edge/6 transition-colors duration-300">
       {/* Header */}
       <div className="px-5 pt-5 pb-4 flex items-start justify-between">
         <div>

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -196,7 +196,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   }
 
   return (
-    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4 transition-colors duration-200">
+    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4 transition-colors duration-300">
       {inputContent}
     </div>
   );

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -49,7 +49,7 @@ export function EditModePanel() {
       {/* Tree panel */}
       <div
         style={{ width: treeWidth }}
-        className="flex-shrink-0 border-r border-edge/6 bg-base/40 transition-colors duration-200"
+        className="flex-shrink-0 border-r border-edge/6 bg-base/40 transition-colors duration-300"
       >
         <FileTree
           entries={treeEntries}
@@ -72,7 +72,7 @@ export function EditModePanel() {
       />
 
       {/* Editor panel */}
-      <div className="flex-1 flex flex-col min-w-0 bg-surface/30 transition-colors duration-200">
+      <div className="flex-1 flex flex-col min-w-0 bg-surface/30 transition-colors duration-300">
         <FileEditor
           path={selectedPath}
           content={fileContent}

--- a/apps/webui/src/client/features/project/RenderedView.tsx
+++ b/apps/webui/src/client/features/project/RenderedView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Idiomorph } from "idiomorph";
 import { useOutput } from "./useOutput.js";
 import { useProjectState } from "@/client/entities/project/index.js";
@@ -6,37 +6,98 @@ import { useActiveStream } from "@/client/entities/session/index.js";
 import { useRendererActionDispatch } from "@/client/entities/renderer-action/index.js";
 import { ScrollArea } from "@/client/shared/ui/index.js";
 
+type TransitionPhase = "idle" | "capture" | "fading";
+
+// Must stay in sync with the Tailwind `duration-300` class on the back layer.
+const FADE_DURATION_MS = 300;
+
 export function RenderedView() {
   const project = useProjectState();
   const stream = useActiveStream();
   const { refresh } = useOutput();
   const actionDispatch = useRendererActionDispatch();
   const containerRef = useRef<HTMLDivElement>(null);
-  const contentRef = useRef<HTMLDivElement>(null);
+  const frontRef = useRef<HTMLDivElement>(null);
+  const backRef = useRef<HTMLDivElement>(null);
+  const prevSlugRef = useRef<string | null>(project.activeProjectSlug);
+  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [phase, setPhase] = useState<TransitionPhase>("idle");
 
-  // Refresh when project changes
+  // Snapshot the current renderer DOM into the back layer so it can cross-fade
+  // out while the new project's renderer loads. Must stay declared above the
+  // morph effect below so snapshot runs before morph overwrites `frontEl`.
+  // Clearing any in-flight cleanup timer here prevents a rapid A→B→C switch
+  // from letting B's fading cleanup clobber C's fresh snapshot.
   useEffect(() => {
+    const newSlug = project.activeProjectSlug;
+    if (prevSlugRef.current !== null && prevSlugRef.current !== newSlug) {
+      const frontEl = frontRef.current;
+      const backEl = backRef.current;
+      const viewport = containerRef.current;
+      if (frontEl && backEl && frontEl.innerHTML) {
+        if (cleanupTimerRef.current !== null) {
+          clearTimeout(cleanupTimerRef.current);
+          cleanupTimerRef.current = null;
+        }
+        backEl.innerHTML = frontEl.innerHTML;
+        const scrollTop = viewport?.scrollTop ?? 0;
+        backEl.style.transform =
+          scrollTop > 0 ? `translateY(-${scrollTop}px)` : "";
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- snapshot DOM과 phase가 같은 커밋에 묶여야 overlay가 먼저 paint됨
+        setPhase("capture");
+      }
+    }
+    prevSlugRef.current = newSlug;
     void refresh();
   }, [project.activeProjectSlug, refresh]);
 
-  // Refresh when streaming completes (agent may have written files)
   useEffect(() => {
     if (!stream.isStreaming && project.activeProjectSlug) {
       void refresh();
     }
   }, [stream.isStreaming, project.activeProjectSlug, refresh]);
 
-  // Morph DOM when rendered HTML changes
   useEffect(() => {
-    const el = contentRef.current;
+    const el = frontRef.current;
     if (!el) return;
+    if (!project.renderedHtml) return;
     Idiomorph.morph(el, project.renderedHtml, {
       morphStyle: "innerHTML",
       ignoreActiveValue: true,
     });
   }, [project.renderedHtml]);
 
-  // Auto-scroll to bottom when rendered content has a chat anchor
+  // Two rAFs: the first lets the `capture` className paint, the second lets
+  // the browser register the fading transition class before opacity flips —
+  // otherwise capture→fading is coalesced and the transition is skipped.
+  useEffect(() => {
+    if (phase !== "capture") return;
+    if (!project.renderedHtml) return;
+    let raf2 = 0;
+    const raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => setPhase("fading"));
+    });
+    return () => {
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  }, [phase, project.renderedHtml]);
+
+  useEffect(() => {
+    if (phase !== "fading") return;
+    const timer = setTimeout(() => {
+      const backEl = backRef.current;
+      if (backEl) {
+        backEl.innerHTML = "";
+        backEl.style.transform = "";
+      }
+      cleanupTimerRef.current = null;
+      setPhase("idle");
+    }, FADE_DURATION_MS);
+    cleanupTimerRef.current = timer;
+    return () => clearTimeout(timer);
+  }, [phase]);
+
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
@@ -46,9 +107,8 @@ export function RenderedView() {
     }
   }, [project.renderedHtml]);
 
-  // Event delegation for renderer actions (data-action="send" | "fill")
   useEffect(() => {
-    const el = contentRef.current;
+    const el = frontRef.current;
     if (!el) return;
     const handleClick = (e: MouseEvent) => {
       const target = (e.target as HTMLElement).closest<HTMLElement>(
@@ -70,9 +130,23 @@ export function RenderedView() {
     return () => el.removeEventListener("click", handleClick);
   }, [actionDispatch]);
 
+  const backOpacityClass =
+    phase === "capture"
+      ? "opacity-100 transition-none"
+      : phase === "fading"
+        ? "opacity-0 transition-opacity duration-300 ease-out motion-reduce:duration-0"
+        : "opacity-0 transition-none";
+
   return (
-    <ScrollArea ref={containerRef} className="flex-1">
-      <div ref={contentRef} className="h-full min-h-full" />
-    </ScrollArea>
+    <div className="relative flex-1 flex flex-col min-h-0">
+      <ScrollArea ref={containerRef} className="flex-1">
+        <div ref={frontRef} className="h-full min-h-full" />
+      </ScrollArea>
+      <div
+        ref={backRef}
+        aria-hidden
+        className={`pointer-events-none absolute inset-0 overflow-hidden ${backOpacityClass}`}
+      />
+    </div>
   );
 }

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -60,7 +60,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
           </Suspense>
         ) : (
           // Chat mode: Rendered View
-          <div className={`flex-1 flex flex-col min-w-0 transition-colors duration-200 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
+          <div className={`flex-1 flex flex-col min-w-0 transition-colors duration-300 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
             {project.activeProjectSlug ? (
               <RenderedView />
             ) : (
@@ -85,13 +85,13 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
         {agentPanelOpen ? (
           <div
             style={{ width: panelWidth }}
-            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 transition-colors duration-200 hidden lg:flex"
+            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 transition-colors duration-300 hidden lg:flex"
           >
             <AgentPanel />
             {isEdit && <BottomInput variant="embedded" />}
           </div>
         ) : (
-          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20 transition-colors duration-200">
+          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20 transition-colors duration-300">
             <EditModeToggle />
             <div className="flex-1" />
             <button


### PR DESCRIPTION
## Summary
- 프로젝트 전환 시 렌더러 영역이 뚝 끊기는 느낌을 줄이기 위해, RenderedView에 front/back 2-layer 구조와 phase FSM(idle → capture → fading → idle)을 도입해 이전 렌더러 DOM snapshot을 overlay한 채 300ms opacity cross-fade를 수행한다.
- 외곽 컴포넌트들의 `transition-colors duration-200`을 `duration-300`으로 통일해 테마 색상 전환과 렌더러 cross-fade가 같은 타이밍에 움직이도록 맞췄다.
- 빠른 연속 전환(A→B→C) 시 이전 fade의 cleanup timer가 다음 snapshot을 덮어쓰지 않도록 `cleanupTimerRef`로 clear한다.

## 구현 포인트
- **2-layer 구조**: `RenderedView`가 `<ScrollArea>`(front) + `<div>`(back overlay, absolute inset-0)로 분리. back은 `pointer-events-none`에 `overflow-hidden`.
- **Phase FSM**: `capture`(snapshot 주입 + `transition-none` opacity-100) → rAF×2 후 `fading`(opacity-0 + `transition-opacity duration-300`) → 300ms 후 `idle` cleanup.
- **Scroll offset 보정**: snapshot 시점의 viewport `scrollTop`만큼 back layer에 `translateY(-scrollTop)`을 적용해 "직전까지 보이던 프레임"을 그대로 overlay.
- **같은 프로젝트 내 refresh**는 `prevSlugRef.current !== newSlug` 가드로 cross-fade 스킵 (기존 Idiomorph 부분 업데이트 유지).
- `FADE_DURATION_MS = 300`은 Tailwind `duration-300` 클래스와 동기화 주석을 남김.

## 수정 파일
- `apps/webui/src/client/features/project/RenderedView.tsx` — 핵심 로직
- `apps/webui/src/client/app/AppShell.tsx`, `Sidebar.tsx`, `features/chat/BottomInput.tsx`, `features/editor/EditModePanel.tsx`, `pages/ProjectPage.tsx` — `transition-colors` duration을 300으로 통일

## Test plan
- [x] `bunx tsc --noEmit` (apps/webui)
- [x] `bun run lint`
- [x] `bun run test` (creative-agent 44 tests pass)
- [x] 브라우저 수동 검증: Test RPG ↔ Test Empty 전환 시 MutationObserver로 back layer className 전이를 측정 — `opacity-0` → `opacity-100 transition-none` (capture, +3ms) → `opacity-0 transition-opacity duration-300` (fading, +81ms) → innerHTML clear (+313ms) → `opacity-0 transition-none` (idle, +314ms). 설계대로 동작.
- [ ] 같은 프로젝트 내 스트리밍 완료 후 refresh 시 cross-fade가 발생하지 않고 Idiomorph 부분 업데이트만 일어나는지 육안 확인 (코드 조건으로는 보장됨)
- [ ] `prefers-reduced-motion: reduce` 환경에서 back layer가 즉시 사라지는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)