### PR TITLE
perf(webui): 프로젝트 전환을 View Transitions API로 이관

### DIFF
--- a/apps/webui/src/client/App.tsx
+++ b/apps/webui/src/client/App.tsx
@@ -3,6 +3,7 @@ import { useProjectDispatch, fetchProjects } from "@/client/entities/project/ind
 import { useSessionDispatch, fetchConversations } from "@/client/entities/session/index.js";
 import { useConfigDispatch, fetchConfig, fetchProviders } from "@/client/entities/config/index.js";
 import { useSkillDispatch, fetchSkills } from "@/client/entities/skill/index.js";
+import { loadRenderOutput } from "@/client/features/project/index.js";
 import { localStore } from "@/client/shared/storage.js";
 
 import { AppShell } from "@/client/app/index.js";
@@ -35,10 +36,14 @@ export function App() {
       const defaultProject = (lastSlug && projects.find((p) => p.slug === lastSlug)) ?? projects[0];
       if (defaultProject) {
         projectDispatch({ type: "SET_ACTIVE_PROJECT", slug: defaultProject.slug });
-        const [conversations, skills] = await Promise.all([
+        // Renderer도 여기서 함께 로드 — 없으면 RenderedView effect가 선점해서
+        // selectProject 경로와 double-fetch가 될 수 있다.
+        const [conversations, skills, output] = await Promise.all([
           fetchConversations(defaultProject.slug),
           fetchSkills(defaultProject.slug),
+          loadRenderOutput(defaultProject.slug),
         ]);
+        projectDispatch({ type: "SET_RENDER_OUTPUT", html: output.html, theme: output.theme });
         sessionDispatch({ type: "SET_CONVERSATIONS", conversations });
         skillDispatch({ type: "SET_SKILLS", skills });
       }

--- a/apps/webui/src/client/app/AppShell.tsx
+++ b/apps/webui/src/client/app/AppShell.tsx
@@ -84,7 +84,7 @@ export function AppShell() {
 
   return (
     <div
-      className="flex h-full bg-void text-fg font-body transition-colors duration-300"
+      className="flex h-full bg-void text-fg font-body"
       style={rootStyle}
       data-theme={dataThemeOverride}
     >

--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -13,7 +13,10 @@ export function Sidebar() {
   const { t } = useI18n();
 
   return (
-    <div className="flex flex-col w-72 h-full bg-base border-r border-edge/6 transition-colors duration-300">
+    <div
+      className="flex flex-col w-72 h-full bg-base border-r border-edge/6"
+      style={{ viewTransitionName: "sidebar" }}
+    >
       {/* Header */}
       <div className="px-5 pt-5 pb-4 flex items-start justify-between">
         <div>

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -196,7 +196,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   }
 
   return (
-    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4 transition-colors duration-300">
+    <div className="relative z-20 border-t border-edge/6 bg-base/80 backdrop-blur-sm p-3 pb-4">
       {inputContent}
     </div>
   );

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -49,7 +49,7 @@ export function EditModePanel() {
       {/* Tree panel */}
       <div
         style={{ width: treeWidth }}
-        className="flex-shrink-0 border-r border-edge/6 bg-base/40 transition-colors duration-300"
+        className="flex-shrink-0 border-r border-edge/6 bg-base/40"
       >
         <FileTree
           entries={treeEntries}
@@ -72,7 +72,7 @@ export function EditModePanel() {
       />
 
       {/* Editor panel */}
-      <div className="flex-1 flex flex-col min-w-0 bg-surface/30 transition-colors duration-300">
+      <div className="flex-1 flex flex-col min-w-0 bg-surface/30">
         <FileEditor
           path={selectedPath}
           content={fileContent}

--- a/apps/webui/src/client/features/project/RenderedView.tsx
+++ b/apps/webui/src/client/features/project/RenderedView.tsx
@@ -1,15 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { Idiomorph } from "idiomorph";
 import { useOutput } from "./useOutput.js";
 import { useProjectState } from "@/client/entities/project/index.js";
 import { useActiveStream } from "@/client/entities/session/index.js";
 import { useRendererActionDispatch } from "@/client/entities/renderer-action/index.js";
 import { ScrollArea } from "@/client/shared/ui/index.js";
-
-type TransitionPhase = "idle" | "capture" | "fading";
-
-// Must stay in sync with the Tailwind `duration-300` class on the back layer.
-const FADE_DURATION_MS = 300;
 
 export function RenderedView() {
   const project = useProjectState();
@@ -18,46 +13,22 @@ export function RenderedView() {
   const actionDispatch = useRendererActionDispatch();
   const containerRef = useRef<HTMLDivElement>(null);
   const frontRef = useRef<HTMLDivElement>(null);
-  const backRef = useRef<HTMLDivElement>(null);
-  const prevSlugRef = useRef<string | null>(project.activeProjectSlug);
-  const cleanupTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const [phase, setPhase] = useState<TransitionPhase>("idle");
 
-  // Snapshot the current renderer DOM into the back layer so it can cross-fade
-  // out while the new project's renderer loads. Must stay declared above the
-  // morph effect below so snapshot runs before morph overwrites `frontEl`.
-  // Clearing any in-flight cleanup timer here prevents a rapid A→B→C switch
-  // from letting B's fading cleanup clobber C's fresh snapshot.
+  // 스트리밍이 방금 끝난 순간에만 renderer 재실행 — 초기 로드와 프로젝트 전환은
+  // 각각 App.tsx, selectProject가 담당한다.
+  const prevStreamingRef = useRef(stream.isStreaming);
   useEffect(() => {
-    const newSlug = project.activeProjectSlug;
-    if (prevSlugRef.current !== null && prevSlugRef.current !== newSlug) {
-      const frontEl = frontRef.current;
-      const backEl = backRef.current;
-      const viewport = containerRef.current;
-      if (frontEl && backEl && frontEl.innerHTML) {
-        if (cleanupTimerRef.current !== null) {
-          clearTimeout(cleanupTimerRef.current);
-          cleanupTimerRef.current = null;
-        }
-        backEl.innerHTML = frontEl.innerHTML;
-        const scrollTop = viewport?.scrollTop ?? 0;
-        backEl.style.transform =
-          scrollTop > 0 ? `translateY(-${scrollTop}px)` : "";
-        // eslint-disable-next-line react-hooks/set-state-in-effect -- snapshot DOM과 phase가 같은 커밋에 묶여야 overlay가 먼저 paint됨
-        setPhase("capture");
-      }
-    }
-    prevSlugRef.current = newSlug;
-    void refresh();
-  }, [project.activeProjectSlug, refresh]);
-
-  useEffect(() => {
-    if (!stream.isStreaming && project.activeProjectSlug) {
+    const wasStreaming = prevStreamingRef.current;
+    prevStreamingRef.current = stream.isStreaming;
+    if (wasStreaming && !stream.isStreaming && project.activeProjectSlug) {
       void refresh();
     }
   }, [stream.isStreaming, project.activeProjectSlug, refresh]);
 
-  useEffect(() => {
+  // useLayoutEffect로 paint 전에 morph를 끝내야 View Transition의 "after"
+  // 스냅샷이 새 HTML을 포함하게 된다. useEffect면 flushSync 이후 async로 돌아
+  // VT 캡처보다 뒤에 실행될 수 있다.
+  useLayoutEffect(() => {
     const el = frontRef.current;
     if (!el) return;
     if (!project.renderedHtml) return;
@@ -66,37 +37,6 @@ export function RenderedView() {
       ignoreActiveValue: true,
     });
   }, [project.renderedHtml]);
-
-  // Two rAFs: the first lets the `capture` className paint, the second lets
-  // the browser register the fading transition class before opacity flips —
-  // otherwise capture→fading is coalesced and the transition is skipped.
-  useEffect(() => {
-    if (phase !== "capture") return;
-    if (!project.renderedHtml) return;
-    let raf2 = 0;
-    const raf1 = requestAnimationFrame(() => {
-      raf2 = requestAnimationFrame(() => setPhase("fading"));
-    });
-    return () => {
-      cancelAnimationFrame(raf1);
-      cancelAnimationFrame(raf2);
-    };
-  }, [phase, project.renderedHtml]);
-
-  useEffect(() => {
-    if (phase !== "fading") return;
-    const timer = setTimeout(() => {
-      const backEl = backRef.current;
-      if (backEl) {
-        backEl.innerHTML = "";
-        backEl.style.transform = "";
-      }
-      cleanupTimerRef.current = null;
-      setPhase("idle");
-    }, FADE_DURATION_MS);
-    cleanupTimerRef.current = timer;
-    return () => clearTimeout(timer);
-  }, [phase]);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -130,23 +70,11 @@ export function RenderedView() {
     return () => el.removeEventListener("click", handleClick);
   }, [actionDispatch]);
 
-  const backOpacityClass =
-    phase === "capture"
-      ? "opacity-100 transition-none"
-      : phase === "fading"
-        ? "opacity-0 transition-opacity duration-300 ease-out motion-reduce:duration-0"
-        : "opacity-0 transition-none";
-
   return (
     <div className="relative flex-1 flex flex-col min-h-0">
       <ScrollArea ref={containerRef} className="flex-1">
         <div ref={frontRef} className="h-full min-h-full" />
       </ScrollArea>
-      <div
-        ref={backRef}
-        aria-hidden
-        className={`pointer-events-none absolute inset-0 overflow-hidden ${backOpacityClass}`}
-      />
     </div>
   );
 }

--- a/apps/webui/src/client/features/project/index.ts
+++ b/apps/webui/src/client/features/project/index.ts
@@ -1,5 +1,5 @@
 export { ProjectTabs } from "./ProjectTabs.js";
 export { useProject } from "./useProject.js";
 export { RenderedView } from "./RenderedView.js";
-export { useOutput } from "./useOutput.js";
+export { useOutput, loadRenderOutput } from "./useOutput.js";
 export { ProjectReadmeModal } from "./ProjectReadmeModal.js";

--- a/apps/webui/src/client/features/project/useOutput.ts
+++ b/apps/webui/src/client/features/project/useOutput.ts
@@ -27,10 +27,15 @@ const NOT_FOUND_HTML = `<div style="color: var(--color-fg-4); font-size: 14px; f
   <p style="margin-top: 8px; font-size: 12px; opacity: 0.7;">Create a renderer.ts file in the project folder to render output.</p>
 </div>`;
 
+export interface RenderOutput {
+  html: string;
+  theme: RendererTheme | null;
+}
+
 async function executeRenderer(
   jsCode: string,
   context: RenderContext,
-): Promise<{ html: string; theme: RendererTheme | null }> {
+): Promise<RenderOutput> {
   const blob = new Blob([jsCode], { type: "application/javascript" });
   const url = URL.createObjectURL(blob);
   try {
@@ -46,6 +51,27 @@ async function executeRenderer(
   }
 }
 
+// 렌더러 fetch → transpile → execute를 한 번에 수행.
+export async function loadRenderOutput(slug: string): Promise<RenderOutput> {
+  try {
+    const [rendererResult, filesResult] = await Promise.all([
+      fetchTranspiledRenderer(slug),
+      fetchWorkspaceFiles(slug),
+    ]);
+    const context: RenderContext = {
+      files: filesResult.files,
+      baseUrl: `/api/projects/${encodeURIComponent(slug)}`,
+    };
+    return await executeRenderer(rendererResult.js, context);
+  } catch (e: unknown) {
+    if (e instanceof Error && e.message.includes("404")) {
+      return { html: NOT_FOUND_HTML, theme: null };
+    }
+    const message = e instanceof Error ? e.message : String(e);
+    return { html: errorHtml(message), theme: null };
+  }
+}
+
 export function useOutput() {
   const projectState = useProjectState();
   const projectDispatch = useProjectDispatch();
@@ -53,28 +79,8 @@ export function useOutput() {
   const refresh = useCallback(async () => {
     const slug = projectState.activeProjectSlug;
     if (!slug) return;
-
-    try {
-      const [rendererResult, filesResult] = await Promise.all([
-        fetchTranspiledRenderer(slug),
-        fetchWorkspaceFiles(slug),
-      ]);
-
-      const context: RenderContext = {
-        files: filesResult.files,
-        baseUrl: `/api/projects/${encodeURIComponent(slug)}`,
-      };
-
-      const { html, theme } = await executeRenderer(rendererResult.js, context);
-      projectDispatch({ type: "SET_RENDER_OUTPUT", html, theme });
-    } catch (e: unknown) {
-      if (e instanceof Error && e.message.includes("404")) {
-        projectDispatch({ type: "SET_RENDER_OUTPUT", html: NOT_FOUND_HTML, theme: null });
-      } else {
-        const message = e instanceof Error ? e.message : String(e);
-        projectDispatch({ type: "SET_RENDER_OUTPUT", html: errorHtml(message), theme: null });
-      }
-    }
+    const { html, theme } = await loadRenderOutput(slug);
+    projectDispatch({ type: "SET_RENDER_OUTPUT", html, theme });
   }, [projectState.activeProjectSlug, projectDispatch]);
 
   return { refresh };

--- a/apps/webui/src/client/features/project/useProject.ts
+++ b/apps/webui/src/client/features/project/useProject.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { flushSync } from "react-dom";
 import {
   useProjectState,
   useProjectDispatch,
@@ -17,6 +18,8 @@ import {
 } from "@/client/entities/session/index.js";
 import { useSkillDispatch, fetchSkills } from "@/client/entities/skill/index.js";
 import { localStore } from "@/client/shared/storage.js";
+import { withViewTransition } from "@/client/shared/viewTransition.js";
+import { loadRenderOutput } from "./useOutput.js";
 
 export function useProject() {
   const projectState = useProjectState();
@@ -40,15 +43,36 @@ export function useProject() {
 
       localStore.lastProject.write(slug);
       const rememberedSessionId = projectState.projectActiveSession.get(slug);
-      projectDispatch({ type: "SET_ACTIVE_PROJECT", slug, currentConversationId: sessionState.activeConversationId });
-      // SWITCH_PROJECT replaces the active view but preserves streams Map so
-      // background streams on other projects keep running and can notify on completion.
-      sessionDispatch({ type: "SWITCH_PROJECT", projectSlug: slug, conversations: [] });
-      skillDispatch({ type: "CLEAR" });
-      const [conversations, skills] = await Promise.all([
-        fetchConversations(slug),
-        fetchSkills(slug),
-      ]);
+      const currentConversationId = sessionState.activeConversationId;
+
+      // 모든 fetch를 VT 바깥에서 병렬 시작 — 렌더러 로드가 VT1 진행 중에 완료되면
+      // VT2가 대기 없이 이어 시작되어 체감 지연이 최소화된다.
+      const conversationsPromise = fetchConversations(slug);
+      const skillsPromise = fetchSkills(slug);
+      const outputPromise = loadRenderOutput(slug);
+
+      // VT1: chrome swap (slug/sidebar/empty html). sync callback이라 VT overlay가
+      // 덮이는 시간은 ~16ms → 클릭 즉시 crossfade가 시작돼 "멈춘 느낌" 사라진다.
+      await withViewTransition(() => {
+        flushSync(() => {
+          projectDispatch({ type: "SET_ACTIVE_PROJECT", slug, currentConversationId });
+          // SWITCH_PROJECT replaces the active view but preserves streams Map so
+          // background streams on other projects keep running and can notify on completion.
+          sessionDispatch({ type: "SWITCH_PROJECT", projectSlug: slug, conversations: [] });
+          skillDispatch({ type: "CLEAR" });
+        });
+      });
+
+      // VT2: renderer 도착 시 theme+html 교체. output이 VT1 중에 이미 준비됐다면
+      // 즉시 시작, 아니면 여기서 잠시 대기.
+      const output = await outputPromise;
+      await withViewTransition(() => {
+        flushSync(() => {
+          projectDispatch({ type: "SET_RENDER_OUTPUT", html: output.html, theme: output.theme });
+        });
+      });
+
+      const [conversations, skills] = await Promise.all([conversationsPromise, skillsPromise]);
       sessionDispatch({ type: "SET_CONVERSATIONS", conversations });
       skillDispatch({ type: "SET_SKILLS", skills });
       // Restore the previously active session if it still exists

--- a/apps/webui/src/client/features/settings/useTheme.ts
+++ b/apps/webui/src/client/features/settings/useTheme.ts
@@ -10,6 +10,7 @@ import {
 import { createElement } from "react";
 import { useI18n } from "@/client/i18n/index.js";
 import { localStore } from "@/client/shared/storage.js";
+import { withViewTransition } from "@/client/shared/viewTransition.js";
 
 export type ThemePreference = "system" | "light" | "dark";
 export type ResolvedTheme = "light" | "dark";
@@ -47,11 +48,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveTheme(localStore.theme.read()));
 
   const setPreference = useCallback((pref: ThemePreference) => {
-    setPreferenceState(pref);
-    localStore.theme.write(pref);
     const r = resolveTheme(pref);
-    setResolved(r);
-    applyTheme(r);
+    void withViewTransition(() => {
+      setPreferenceState(pref);
+      localStore.theme.write(pref);
+      setResolved(r);
+      applyTheme(r);
+    });
   }, []);
 
   // Apply theme to DOM whenever resolved theme changes

--- a/apps/webui/src/client/main.css
+++ b/apps/webui/src/client/main.css
@@ -140,3 +140,27 @@ select option {
   box-shadow: 0 0 0 1px var(--color-accent),
               0 0 24px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
+
+/* ── View Transitions ──────────────────────────
+   Match the app's 300ms ease-out (UA default is 250ms linear). */
+
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 300ms;
+  animation-timing-function: ease-out;
+}
+
+/* Sidebar는 view-transition-name: sidebar로 root에서 분리 — 프로젝트 전환 시
+   old(A active)/new(B active) 버튼이 crossfade 구간에서 반투명으로 겹쳐 보이는
+   현상을 막는다. 1ms로 사실상 즉시 교체. */
+::view-transition-old(sidebar),
+::view-transition-new(sidebar) {
+  animation-duration: 1ms;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  ::view-transition-old(root),
+  ::view-transition-new(root) {
+    animation-duration: 1ms;
+  }
+}

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -60,7 +60,7 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
           </Suspense>
         ) : (
           // Chat mode: Rendered View
-          <div className={`flex-1 flex flex-col min-w-0 transition-colors duration-300 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
+          <div className={`flex-1 flex flex-col min-w-0 ${agentPanelOpen ? "" : "border-r border-edge/6"}`}>
             {project.activeProjectSlug ? (
               <RenderedView />
             ) : (
@@ -85,13 +85,13 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
         {agentPanelOpen ? (
           <div
             style={{ width: panelWidth }}
-            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 transition-colors duration-300 hidden lg:flex"
+            className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 hidden lg:flex"
           >
             <AgentPanel />
             {isEdit && <BottomInput variant="embedded" />}
           </div>
         ) : (
-          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20 transition-colors duration-300">
+          <div className="hidden lg:flex flex-shrink-0 w-8 flex-col items-center border-l border-edge/6 bg-base/20">
             <EditModeToggle />
             <div className="flex-1" />
             <button

--- a/apps/webui/src/client/shared/viewTransition.ts
+++ b/apps/webui/src/client/shared/viewTransition.ts
@@ -1,0 +1,8 @@
+// Chromium/Safari만 지원. 미지원 브라우저(Firefox 등)는 즉시 실행.
+// `.finished`를 기다려 연속 호출 시 뒤엣 놈이 앞의 애니메이션을 스킵시키지 않게 한다.
+export function withViewTransition(update: () => void | Promise<void>): Promise<void> {
+  if (typeof document.startViewTransition === "function") {
+    return document.startViewTransition(update).finished;
+  }
+  return Promise.resolve(update());
+}


### PR DESCRIPTION
## Summary
- `document.startViewTransition` 기반 GPU crossfade로 프로젝트 전환·테마 토글 이관. 수동 DOM 복제 cross-fade(`RenderedView`의 backRef + phase state machine)와 하위 요소마다 뿌려져 있던 `transition-colors duration-300` 스톰 제거
- 테마가 다른 프로젝트 간 전환이 간헐적으로 버벅이던 증상 해결. VT를 2단계로 쪼개 클릭 즉시 chrome(slug/sidebar) crossfade → 렌더러 도착 시 theme+html crossfade로 체감 지연 최소화
- Sidebar에 `view-transition-name: sidebar` + 1ms duration을 주어 전환 중 이전/새 active 버튼이 반투명으로 겹쳐 보이는 현상 제거
- `withViewTransition` 유틸을 `shared/viewTransition.ts`로 분리, `selectProject`와 `setPreference`(light/dark 토글) 양쪽에서 재사용
- 초기 로드 책임을 `App.tsx`로 이동해 `RenderedView`의 slug 변경 effect와 `selectProject`의 `loadRenderOutput` 호출이 중복 fetch되던 문제 제거

## Test plan
- [ ] 서로 다른 테마를 가진 프로젝트 간 전환 시 300ms crossfade가 부드럽게 재생되는지
- [ ] 클릭 직후 Sidebar active 버튼이 즉시 바뀌어 "멈춘 느낌"이 없는지
- [ ] A → B → C 빠른 연속 전환 시 상태 꼬임이나 visual glitch 없는지
- [ ] Settings → Appearance의 light/dark 토글이 crossfade로 전환되는지
- [ ] Firefox 등 VT 미지원 브라우저에서 즉시 전환 fallback 동작하는지
- [ ] 스트리밍 완료 후 렌더러 자동 refresh가 정상 동작하는지 (stream-edge 감지로 축소됨)
- [ ] 앱 첫 로드 시 저장된 프로젝트가 renderer HTML과 함께 즉시 표시되는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)