### PR TITLE
refactor(ProjectPage): useCallback 제거 (React Compiler)

### DIFF
--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, Suspense, lazy } from "react";
+import { useState, useRef, Suspense, lazy } from "react";
 import { ChevronsLeft } from "lucide-react";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
 import { useUIState, useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
@@ -33,12 +33,12 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
 
   const isEdit = ui.viewMode === "edit";
 
-  const handlePanelResize = useCallback((delta: number) => {
+  const handlePanelResize = (delta: number) => {
     const container = containerRef.current;
     if (!container) return;
     const maxWidth = container.getBoundingClientRect().width * MAX_PANEL_RATIO;
     setPanelWidth(Math.max(MIN_PANEL_WIDTH, Math.min(maxWidth, dragStartRef.current - delta)));
-  }, []);
+  };
 
   return (
     <>


### PR DESCRIPTION
## 요약
- `apps/webui`는 `babel-plugin-react-compiler`로 자동 메모이제이션이 적용되므로, `ProjectPage`의 `handlePanelResize`를 감쌌던 `useCallback`을 제거
- `ResizeHandle.onResize` prop으로 전달되는 자식 핸들러는 Compiler가 자동으로 참조 안정성을 유지하므로 수동 메모이제이션 근거 없음
- 쓸모 없어진 `useCallback` import도 함께 정리

## 검증
- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0
- [x] `bun run test` — 44 pass, 0 fail