### PR TITLE
refactor(ResizeHandle): 불필요한 useCallback 제거

### DIFF
--- a/apps/webui/src/client/shared/ui/ResizeHandle.tsx
+++ b/apps/webui/src/client/shared/ui/ResizeHandle.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useEffect, useLayoutEffect } from "react";
+import { useRef, useEffect, useLayoutEffect } from "react";
 
 interface ResizeHandleProps {
   onResizeStart?: () => void;
@@ -16,7 +16,7 @@ export function ResizeHandle({ onResizeStart, onResize, onResizeEnd }: ResizeHan
 
   useEffect(() => () => cleanupRef.current?.(), []);
 
-  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+  const handleMouseDown = (e: React.MouseEvent) => {
     e.preventDefault();
     const startX = e.clientX;
 
@@ -40,7 +40,7 @@ export function ResizeHandle({ onResizeStart, onResize, onResizeEnd }: ResizeHan
     document.body.style.cursor = "col-resize";
     document.body.style.userSelect = "none";
     cleanupRef.current = cleanup;
-  }, []);
+  };
 
   return (
     <div


### PR DESCRIPTION
## 요약
- `apps/webui/src/client/shared/ui/ResizeHandle.tsx`의 `handleMouseDown`을 감싸던 `useCallback` 제거
- `babel-plugin-react-compiler`가 자동 메모이제이션하므로 수동 래핑 불필요
- `callbacksRef`가 `useLayoutEffect`로 매 렌더마다 최신 콜백을 동기화하므로 closure 이슈 없음
- 사용되지 않게 된 `useCallback` import도 함께 제거

## 배경
React Compiler 적용 이후 수동 메모이제이션을 제거하는 배치 작업 중 Unit 4.

## 검증
- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0
- [x] `bun run test` — 44 pass / 0 fail