### PR TITLE
refactor(appshell): resolvedTheme useMemo 제거

### DIFF
--- a/apps/webui/src/client/app/AppShell.tsx
+++ b/apps/webui/src/client/app/AppShell.tsx
@@ -1,4 +1,4 @@
-import { Suspense, lazy, useEffect, useMemo } from "react";
+import { Suspense, lazy, useEffect } from "react";
 import { Menu } from "lucide-react";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
@@ -73,10 +73,10 @@ export function AppShell() {
     ui.currentPage.page === "main" &&
     ui.viewMode === "chat";
 
-  const resolvedTheme = useMemo(() => {
-    if (!themeActive || !rendererView.theme) return null;
-    return resolveThemeVars(rendererView.theme, userScheme);
-  }, [themeActive, rendererView.theme, userScheme]);
+  const resolvedTheme =
+    themeActive && rendererView.theme
+      ? resolveThemeVars(rendererView.theme, userScheme)
+      : null;
 
   const rootStyle = resolvedTheme?.vars;
   // data-theme는 prefersScheme가 명시된 경우에만 scope-local override.


### PR DESCRIPTION
## 요약

- `apps/webui/src/client/app/AppShell.tsx`의 `resolvedTheme` 수동 `useMemo` 제거.
- React Compiler(`babel-plugin-react-compiler`)가 자동 메모이제이션하므로 수동 훅 불필요.
- `themeActive && rendererView.theme` 조건을 보존해 원래의 short-circuit 동작 유지.
- 사용처가 없어진 `useMemo` import도 제거.

## REMOVE 근거

- `resolvedTheme`은 DOM `style` / `data-theme`에만 쓰이는 파생값.
- `useEffect`/`useLayoutEffect` deps 배열에 포함되지 않음 → 참조 동일성 계약 없음.
- REMOVE 원칙 ("파생 상태 계산은 컴파일러가 처리") 적용 대상.

## 검증

- [x] `cd apps/webui && bunx tsc --noEmit` 통과
- [x] `bun run lint` 통과 (에러/경고 0)
- [x] `bun run test` 통과 (44 pass, 0 fail)