### PR TITLE
refactor(editor): FileTree 수동 메모이제이션 제거

### DIFF
--- a/apps/webui/src/client/features/editor/FileTree.tsx
+++ b/apps/webui/src/client/features/editor/FileTree.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback, useEffect, useRef } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   ChevronRight,
   ChevronDown,
@@ -43,47 +43,47 @@ export function FileTree({
   onSelect, onDelete, onDeleteDir, onReveal, onRename, onCreateFile, onCreateDir,
 }: FileTreeProps) {
   const { t } = useI18n();
-  const tree = useMemo(() => buildTree(entries), [entries]);
+  const tree = buildTree(entries);
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [inlineEdit, setInlineEdit] = useState<InlineEdit>(null);
 
-  const toggle = useCallback((path: string) => {
+  const toggle = (path: string) => {
     setCollapsed((prev) => {
       const next = new Set(prev);
       if (next.has(path)) next.delete(path);
       else next.add(path);
       return next;
     });
-  }, []);
+  };
 
-  const expandFolder = useCallback((path: string) => {
+  const expandFolder = (path: string) => {
     setCollapsed((prev) => {
       if (!prev.has(path)) return prev;
       const next = new Set(prev);
       next.delete(path);
       return next;
     });
-  }, []);
+  };
 
-  const startNewFile = useCallback((parentPath: string | null) => {
+  const startNewFile = (parentPath: string | null) => {
     if (parentPath) expandFolder(parentPath);
     setInlineEdit({ mode: "new-file", parentPath });
-  }, [expandFolder]);
+  };
 
-  const startNewDir = useCallback((parentPath: string | null) => {
+  const startNewDir = (parentPath: string | null) => {
     if (parentPath) expandFolder(parentPath);
     setInlineEdit({ mode: "new-dir", parentPath });
-  }, [expandFolder]);
+  };
 
-  const startRename = useCallback((path: string, currentName: string) => {
+  const startRename = (path: string, currentName: string) => {
     setInlineEdit({ mode: "rename", path, currentName });
-  }, []);
+  };
 
-  const cancelInline = useCallback(() => {
+  const cancelInline = () => {
     setInlineEdit(null);
-  }, []);
+  };
 
-  const commitInline = useCallback((value: string) => {
+  const commitInline = (value: string) => {
     if (!inlineEdit) return;
     const name = value.trim();
     if (!name || name.includes("/") || name.includes("\\")) {
@@ -101,7 +101,7 @@ export function FileTree({
       }
     }
     setInlineEdit(null);
-  }, [inlineEdit, onCreateFile, onCreateDir, onRename]);
+  };
 
   const rootInline = inlineEdit && inlineEdit.mode !== "rename" && inlineEdit.parentPath === null;
 


### PR DESCRIPTION
## Summary
- React Compiler(`babel-plugin-react-compiler`)가 자동 메모이제이션을 적용하므로 `apps/webui/src/client/features/editor/FileTree.tsx`의 수동 메모화를 제거합니다.
- 제거: `useMemo` 1개(`tree = buildTree(entries)`) + `useCallback` 7개(`toggle`, `expandFolder`, `startNewFile`, `startNewDir`, `startRename`, `cancelInline`, `commitInline`).
- 미사용 import(`useMemo`, `useCallback`) 정리.

## Test plan
- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0 (react-hooks/exhaustive-deps 포함)
- [x] `bun run test` — 전체 통과 (44 pass / 0 fail)