### PR TITLE
refactor(editor): FileEditor/EditModePanel 수동 useCallback 제거

### DIFF
--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useRef } from "react";
 import { FileTree } from "./FileTree.js";
 import { FileEditor } from "./FileEditor.js";
 import { UnsavedDialog } from "./UnsavedDialog.js";
@@ -40,9 +40,9 @@ export function EditModePanel() {
   const [treeWidth, setTreeWidth] = useState(DEFAULT_TREE_WIDTH);
   const dragStartRef = useRef(0);
 
-  const handleTreeResize = useCallback((delta: number) => {
+  const handleTreeResize = (delta: number) => {
     setTreeWidth(Math.max(MIN_TREE_WIDTH, Math.min(MAX_TREE_WIDTH, dragStartRef.current + delta)));
-  }, []);
+  };
 
   return (
     <>

--- a/apps/webui/src/client/features/editor/FileEditor.tsx
+++ b/apps/webui/src/client/features/editor/FileEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { EditorView, keymap, highlightActiveLine, highlightActiveLineGutter } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
 import { defaultKeymap, indentWithTab, history, historyKeymap } from "@codemirror/commands";
@@ -250,9 +250,9 @@ export function FileEditor({ path, content, dirty, onDocChange, onSave }: FileEd
   useEffect(() => { onSaveRef.current = onSave; }, [onSave]);
   useEffect(() => { dirtyRef.current = dirty; }, [dirty]);
 
-  const handleSave = useCallback(async () => {
+  const handleSave = async () => {
     if (dirtyRef.current) await onSaveRef.current();
-  }, []);
+  };
 
   const language = path ? detectLanguage(path) : undefined;
 


### PR DESCRIPTION
## 요약

React Compiler(`babel-plugin-react-compiler`)가 자동 메모이제이션을 담당하므로, 이벤트 핸들러성 `useCallback` 래퍼 2건을 제거했다 (Unit 6).

- `FileEditor.tsx` — `handleSave` (Mod+s keymap 핸들러)
- `EditModePanel.tsx` — `handleTreeResize` (ResizeHandle `onResize` prop)

사용하지 않게 된 `useCallback` import도 함께 정리했다. `useEffect` deps 배열과 호출부 동작은 변경 없음.

## 테스트 계획

- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0
- [x] `bun run test` — 전부 통과 (44 tests)