### PR TITLE
refactor(chat): AgentPanel useMemo 제거 (Unit 7)

### DIFF
--- a/apps/webui/src/client/features/chat/AgentPanel.tsx
+++ b/apps/webui/src/client/features/chat/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { CornerUpLeft } from "lucide-react";
 import { Popover } from "@base-ui/react/popover";
 import { useActiveStream } from "@/client/entities/stream/index.js";
@@ -101,11 +101,8 @@ export function AgentPanel() {
   );
   const nodes = sessionData?.nodes ?? EMPTY_NODES;
   const activePath = sessionData?.activePath ?? EMPTY_PATH;
-  const nodeMap = useMemo(() => {
-    const m = new Map<string, TreeNode>();
-    for (const n of nodes) m.set(n.id, n);
-    return m;
-  }, [nodes]);
+  const nodeMap = new Map<string, TreeNode>();
+  for (const n of nodes) nodeMap.set(n.id, n);
 
   const { t } = useI18n();
   const { switchBranch, setReplyTo, deleteNode } = useSession();
@@ -122,10 +119,7 @@ export function AgentPanel() {
     return parent?.children ?? [node.id];
   };
 
-  const groups = useMemo(
-    () => groupActivePath(activePath, nodeMap),
-    [activePath, nodeMap],
-  );
+  const groups = groupActivePath(activePath, nodeMap);
 
   if (!selection.openSessionId) {
     return (


### PR DESCRIPTION
## 요약

React Compiler 도입 후 불필요해진 수동 메모이제이션 제거 배치의 Unit 7.

- `features/chat/AgentPanel.tsx`의 `nodeMap` useMemo 제거 (nodes → Map 변환)
- 동 파일의 `groups` useMemo 제거 (`groupActivePath(activePath, nodeMap)` 파생 상태)
- 불필요해진 `useMemo` import 정리

두 값 모두 파생 상태/자식 prop으로만 쓰이므로 React Compiler가 자동 메모이제이션한다.

## 테스트

- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0
- [x] `bun run test` — 44 pass, 0 fail