### PR TITLE
refactor(project): ProjectTabs useCallback 제거 (Unit 9)

### DIFF
--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -1,4 +1,4 @@
-import { useReducer, useRef, useEffect, useCallback, useState } from "react";
+import { useReducer, useRef, useEffect, useState } from "react";
 import { Check, Plus, Settings, X } from "lucide-react";
 import { ContextMenu } from "@base-ui/react/context-menu";
 import { Menu } from "@base-ui/react/menu";
@@ -83,7 +83,7 @@ export function ProjectTabs() {
     if (isEditing) editInputRef.current?.focus();
   }, [isEditing]);
 
-  const handleCreate = useCallback(async () => {
+  const handleCreate = async () => {
     if (mode.type !== "creating") return;
     if (submittingRef.current) return;
     const name = mode.value.trim();
@@ -99,9 +99,9 @@ export function ProjectTabs() {
     } finally {
       submittingRef.current = false;
     }
-  }, [mode, createProject]);
+  };
 
-  const handleDuplicate = useCallback(async () => {
+  const handleDuplicate = async () => {
     if (mode.type !== "duplicating") return;
     if (submittingRef.current) return;
     const name = mode.value.trim();
@@ -117,7 +117,7 @@ export function ProjectTabs() {
     } finally {
       submittingRef.current = false;
     }
-  }, [mode, duplicateProject]);
+  };
 
   const handleRename = async (slug: string) => {
     if (mode.type !== "editing") return;
@@ -148,15 +148,12 @@ export function ProjectTabs() {
   const [settingsSlug, setSettingsSlug] = useState<string | null>(null);
   const [saveAsTemplateSlug, setSaveAsTemplateSlug] = useState<string | null>(null);
 
-  const handleOpenSettings = useCallback(
-    (slug: string) => {
-      if (activeProjectSlug !== slug) {
-        void selectProject(slug);
-      }
-      setSettingsSlug(slug);
-    },
-    [activeProjectSlug, selectProject],
-  );
+  const handleOpenSettings = (slug: string) => {
+    if (activeProjectSlug !== slug) {
+      void selectProject(slug);
+    }
+    setSettingsSlug(slug);
+  };
 
   return (
     <div className="px-2 py-1 space-y-0.5">


### PR DESCRIPTION
## 요약

React Compiler 적용 이후 불필요해진 `ProjectTabs.tsx`의 수동 메모이제이션을 제거 (Unit 9).

## 변경 내용

- `handleCreate` — `useCallback` 래핑 제거, 일반 `async` 함수로 변환
- `handleDuplicate` — `useCallback` 래핑 제거, 일반 `async` 함수로 변환
- `handleOpenSettings` — `useCallback` 래핑 제거, 일반 함수로 변환
- 사용처 없어진 `useCallback` import 제거

## 근거

`apps/webui`는 `babel-plugin-react-compiler`로 자동 메모이제이션이 적용됨. 자식 prop/이벤트 핸들러 안정화는 컴파일러가 담당하므로 수동 `useCallback`은 불필요 (CLAUDE.md의 React Compiler 가이드 참조).

## 검증

- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 에러 0
- [x] `bun run lint` — 에러/경고 0
- [x] `bun run test` — 전부 통과 (44 pass)