### PR TITLE
refactor(project): SaveAsTemplateModal 수동 메모이제이션 제거

### DIFF
--- a/apps/webui/src/client/features/project/SaveAsTemplateModal.tsx
+++ b/apps/webui/src/client/features/project/SaveAsTemplateModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from "react";
+import { useState, useEffect } from "react";
 import {
   ChevronRight,
   ChevronDown,
@@ -245,11 +245,11 @@ export function SaveAsTemplateModal({ slug, onClose }: SaveAsTemplateModalProps)
     });
   }, [slug]);
 
-  const tree = useMemo(() => buildTree(fileEntries), [fileEntries]);
-  const filePathsMap = useMemo(() => buildFilePathsMap(tree), [tree]);
+  const tree = buildTree(fileEntries);
+  const filePathsMap = buildFilePathsMap(tree);
   const hasFiles = fileEntries.length > 0;
 
-  const toggleExclude = useCallback((node: TreeNode) => {
+  const toggleExclude = (node: TreeNode) => {
     setExcluded((prev) => {
       const next = new Set(prev);
       const paths = collectFilePaths(node);
@@ -261,18 +261,18 @@ export function SaveAsTemplateModal({ slug, onClose }: SaveAsTemplateModalProps)
       }
       return next;
     });
-  }, []);
+  };
 
-  const toggleCollapse = useCallback((path: string) => {
+  const toggleCollapse = (path: string) => {
     setCollapsed((prev) => {
       const next = new Set(prev);
       if (next.has(path)) next.delete(path);
       else next.add(path);
       return next;
     });
-  }, []);
+  };
 
-  const doSave = useCallback(async (overwrite: boolean) => {
+  const doSave = async (overwrite: boolean) => {
     if (!slug) return;
     const trimmedName = name.trim();
     if (!trimmedName) {
@@ -299,7 +299,7 @@ export function SaveAsTemplateModal({ slug, onClose }: SaveAsTemplateModalProps)
     } catch {
       setSaving(false);
     }
-  }, [slug, name, description, excluded, onClose]);
+  };
 
   return (
     <Dialog open={slug !== null} onOpenChange={(open) => { if (!open) onClose(); }} size={hasFiles ? "xl" : "md"}>


### PR DESCRIPTION
## Summary
- `apps/webui`는 React Compiler로 자동 메모이제이션이 적용되므로, `SaveAsTemplateModal.tsx`의 수동 `useMemo` / `useCallback` 래퍼를 제거했습니다.
- 제거 대상: `useMemo(buildTree)`, `useMemo(buildFilePathsMap)`, `useCallback(toggleExclude)`, `useCallback(toggleCollapse)`, `useCallback(doSave)`. 남는 import가 없어 `useMemo` / `useCallback` import도 함께 정리했습니다.
- 동작 변경 없음 — 순수 ergonomic 정리.

## Test plan
- [x] `cd apps/webui && bunx tsc --noEmit` 통과
- [x] `bun run lint` 통과
- [x] `bun run test` 통과