### PR TITLE
refactor(webui): onboarding/oauth useMemo 제거

### DIFF
--- a/apps/webui/src/client/features/oauth/DeviceCodeModal.tsx
+++ b/apps/webui/src/client/features/oauth/DeviceCodeModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Dialog, Button } from "@/client/shared/ui/index.js";
 import { useClipboard } from "@/client/shared/useClipboard.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -22,12 +22,10 @@ export function DeviceCodeModal({
   const abortRef = useRef<AbortController | null>(null);
   const { copied, copy } = useClipboard();
 
-  const deviceCode = useMemo(() => {
-    const raw = authInfo?.instructions?.trim();
-    if (!raw) return null;
-    const match = raw.match(/:\s*(\S.*)$/);
-    return (match?.[1] ?? raw).trim();
-  }, [authInfo?.instructions]);
+  const rawInstructions = authInfo?.instructions?.trim();
+  const deviceCode = rawInstructions
+    ? (rawInstructions.match(/:\s*(\S.*)$/)?.[1] ?? rawInstructions).trim()
+    : null;
 
   // loginOAuth identity rotates each render — capture in a ref so the streaming
   // useEffect doesn't restart and abort its own in-flight poll.

--- a/apps/webui/src/client/features/onboarding/OnboardingWizard.tsx
+++ b/apps/webui/src/client/features/onboarding/OnboardingWizard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import { useI18n } from "@/client/i18n/index.js";
 import { Dialog, Button, Badge, Indicator, Select } from "@/client/shared/ui/index.js";
@@ -264,14 +264,13 @@ function TemplatePickerStep({
 }) {
   const { t } = useI18n();
   const { data: allTemplates, isLoading } = useTemplates();
-  const templates = useMemo<TemplateMeta[] | null>(() => {
-    if (isLoading) return null;
-    if (!allTemplates) return [];
-    const bySlug = new Map(allTemplates.map((tpl) => [tpl.slug, tpl]));
-    return FEATURED_SLUGS.map((slug) => bySlug.get(slug)).filter(
-      (tpl): tpl is TemplateMeta => tpl !== undefined,
-    );
-  }, [allTemplates, isLoading]);
+  const templates: TemplateMeta[] | null = isLoading
+    ? null
+    : allTemplates
+      ? FEATURED_SLUGS.map((slug) =>
+          allTemplates.find((tpl) => tpl.slug === slug),
+        ).filter((tpl): tpl is TemplateMeta => tpl !== undefined)
+      : [];
 
   return (
     <div className="w-full max-w-2xl animate-fade">


### PR DESCRIPTION
## 요약

React Compiler가 자동 메모이제이션을 담당하므로 불필요한 수동 `useMemo`를 제거합니다. (Unit 11 — features/onboarding + oauth)

## 변경 내용

- `features/onboarding/OnboardingWizard.tsx`
  - `TemplatePickerStep`의 `templates` `useMemo` 제거 — `isLoading` / `allTemplates` 기반 파생값을 인라인 삼항 표현식으로 단순화
  - `FEATURED_SLUGS`가 2개뿐이라 Map 빌드 대신 `find`로 선형 검색 (가독성 개선)
  - 사용하지 않게 된 `useMemo` import 제거
- `features/oauth/DeviceCodeModal.tsx`
  - `deviceCode` `useMemo` 제거 — instructions 정규식 파싱을 인라인화
  - 사용하지 않게 된 `useMemo` import 제거

## 검증

- [x] `cd apps/webui && bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run test`