### PR TITLE
refactor(templates): TemplatesPage의 불필요한 useCallback/useMemo 제거

### DIFF
--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef, useMemo } from "react";
+import { useState, useEffect, useRef } from "react";
 import { ArrowLeft, BookOpen, GripVertical } from "lucide-react";
 import { useSWRConfig } from "swr";
 import {
@@ -133,19 +133,17 @@ export function TemplatesPage() {
 
   // Show cached README when available, otherwise synthesize a doc from the
   // template meta so the hero/cover still render while the body fetches.
-  const displayDoc: ReadmeDoc | null = useMemo(() => {
-    if (!selectedTemplate) return null;
-    if (readme) return readme;
-    return {
-      frontmatter: {
-        name: selectedTemplate.name,
-        description: selectedTemplate.description,
-      },
-      body: "",
-    };
-  }, [selectedTemplate, readme]);
+  const displayDoc: ReadmeDoc | null = selectedTemplate
+    ? readme ?? {
+        frontmatter: {
+          name: selectedTemplate.name,
+          description: selectedTemplate.description,
+        },
+        body: "",
+      }
+    : null;
 
-  const handleCreate = useCallback(async () => {
+  const handleCreate = async () => {
     if (!selectedSlug || creating) return;
     const name = nameInput.trim();
     if (!name) {
@@ -159,24 +157,21 @@ export function TemplatesPage() {
     } finally {
       setCreating(false);
     }
-  }, [selectedSlug, creating, nameInput, createProject, uiDispatch]);
+  };
 
-  const handleKeyNav = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (!templates || templates.length === 0) return;
-      if (e.key === "ArrowDown" || e.key === "ArrowUp") {
-        e.preventDefault();
-        const cur = selectedIndex < 0 ? 0 : selectedIndex;
-        const next =
-          e.key === "ArrowDown"
-            ? Math.min(cur + 1, templates.length - 1)
-            : Math.max(cur - 1, 0);
-        const nextTemplate = templates[next];
-        if (nextTemplate) setSelectedSlug(nextTemplate.slug);
-      }
-    },
-    [templates, selectedIndex],
-  );
+  const handleKeyNav = (e: React.KeyboardEvent) => {
+    if (!templates || templates.length === 0) return;
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      const cur = selectedIndex < 0 ? 0 : selectedIndex;
+      const next =
+        e.key === "ArrowDown"
+          ? Math.min(cur + 1, templates.length - 1)
+          : Math.max(cur - 1, 0);
+      const nextTemplate = templates[next];
+      if (nextTemplate) setSelectedSlug(nextTemplate.slug);
+    }
+  };
 
   const sensors = useSensors(
     // Require a small drag distance so that clicks on the handle (to focus it)
@@ -185,38 +180,35 @@ export function TemplatesPage() {
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
   );
 
-  const handleDragEnd = useCallback(
-    async (event: DragEndEvent) => {
-      const { active, over } = event;
-      if (!over || active.id === over.id) return;
-      if (!templates) return;
-      const from = templates.findIndex((x) => x.slug === active.id);
-      const to = templates.findIndex((x) => x.slug === over.id);
-      if (from < 0 || to < 0) return;
-      const next = arrayMove(templates, from, to);
-      try {
-        await mutate<TemplateMeta[]>(
-          qk.templates(),
-          async () => {
-            await saveTemplateOrder(next.map((x) => x.slug));
-            return next;
-          },
-          {
-            optimisticData: next,
-            rollbackOnError: true,
-            revalidate: false,
-            populateCache: true,
-          },
-        );
-      } catch (err) {
-        console.error("[templates] reorder failed", err);
-        alert(t("templates.reorderFailed"));
-      }
-    },
-    [templates, mutate, t],
-  );
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    if (!templates) return;
+    const from = templates.findIndex((x) => x.slug === active.id);
+    const to = templates.findIndex((x) => x.slug === over.id);
+    if (from < 0 || to < 0) return;
+    const next = arrayMove(templates, from, to);
+    try {
+      await mutate<TemplateMeta[]>(
+        qk.templates(),
+        async () => {
+          await saveTemplateOrder(next.map((x) => x.slug));
+          return next;
+        },
+        {
+          optimisticData: next,
+          rollbackOnError: true,
+          revalidate: false,
+          populateCache: true,
+        },
+      );
+    } catch (err) {
+      console.error("[templates] reorder failed", err);
+      alert(t("templates.reorderFailed"));
+    }
+  };
 
-  const templateIds = useMemo(() => templates?.map((tpl) => tpl.slug) ?? [], [templates]);
+  const templateIds = templates?.map((tpl) => tpl.slug) ?? [];
 
   return (
     <div


### PR DESCRIPTION
## 요약
- React Compiler(`babel-plugin-react-compiler`)가 자동 메모이제이션을 처리하므로 `TemplatesPage.tsx`의 수동 래퍼를 해제
- 제거 대상: `displayDoc`(파생 상태), `handleCreate`/`handleKeyNav`/`handleDragEnd`(이벤트 핸들러 — @dnd-kit은 reference equality 요구 안 함), `templateIds`(`templates.map` 단순 파생)
- 쓸데없게 된 `useCallback`/`useMemo` import도 정리

## 검증
- [x] `cd apps/webui && bunx tsc --noEmit` — 에러 0
- [x] `bun run lint` — 에러/경고 0 (react-hooks/exhaustive-deps 포함)
- [x] `bun run test` — 44 pass / 0 fail

## 비고
`handleCreate`는 내부 비동기 흐름이 있지만 버튼 `onClick`으로만 소비되므로 REMOVE 안전. 다른 `useEffect`에서 이 핸들러들을 deps에 넣는 경우는 없음을 확인했다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)