### PR TITLE
refactor(chat): useStreaming regenerate useCallback 제거

### DIFF
--- a/apps/webui/src/client/features/chat/useStreaming.ts
+++ b/apps/webui/src/client/features/chat/useStreaming.ts
@@ -291,37 +291,34 @@ export function useStreaming() {
     [streamDispatch, makeCallbacks],
   );
 
-  const regenerate = useCallback(
-    async (userNodeId: string) => {
-      const p = projectSelectionRef.current;
-      const sel = sessionSelectionStateRef.current;
-      const streams = streamStateRef.current;
-      if (!p.activeProjectSlug) return;
-      const projectSlug = p.activeProjectSlug;
-      const selection = selectSessionSelection(sel, projectSlug);
-      if (!selection.openSessionId) return;
+  const regenerate = async (userNodeId: string) => {
+    const p = projectSelectionRef.current;
+    const sel = sessionSelectionStateRef.current;
+    const streams = streamStateRef.current;
+    if (!p.activeProjectSlug) return;
+    const projectSlug = p.activeProjectSlug;
+    const selection = selectSessionSelection(sel, projectSlug);
+    if (!selection.openSessionId) return;
 
-      const slot = selectStreamSlot(streams, projectSlug);
-      if (slot.isStreaming) return;
+    const slot = selectStreamSlot(streams, projectSlug);
+    if (slot.isStreaming) return;
 
-      streamDispatch({ type: "START", projectSlug });
+    streamDispatch({ type: "START", projectSlug });
 
-      const controller = new AbortController();
-      registerAbortController(projectSlug, controller);
-      try {
-        await regenerateResponse(
-          projectSlug,
-          selection.openSessionId,
-          userNodeId,
-          makeCallbacks(projectSlug, selection.openSessionId, null),
-          controller.signal,
-        );
-      } finally {
-        clearAbortController(projectSlug, controller);
-      }
-    },
-    [streamDispatch, makeCallbacks],
-  );
+    const controller = new AbortController();
+    registerAbortController(projectSlug, controller);
+    try {
+      await regenerateResponse(
+        projectSlug,
+        selection.openSessionId,
+        userNodeId,
+        makeCallbacks(projectSlug, selection.openSessionId, null),
+        controller.signal,
+      );
+    } finally {
+      clearAbortController(projectSlug, controller);
+    }
+  };
 
   return { send, regenerate, isStreaming: activeSlot.isStreaming };
 }


### PR DESCRIPTION
## 요약

React Compiler(`babel-plugin-react-compiler`)가 `apps/webui`에 적용되어 있으므로, 수동 메모이제이션 중 정당한 근거(effect deps 계약 등)가 없는 것을 제거하는 배치 작업(Unit 13).

`features/chat/useStreaming.ts`의 세 `useCallback`을 검증하고, 소비자 effect deps에 쓰이지 않는 `regenerate`만 REMOVE.

## 변경 사항

- `regenerate`: useCallback 래퍼 제거 (일반 함수로 변환)

## KEEP/REMOVE 근거

| 대상 | 결정 | 근거 |
|---|---|---|
| `send` (L228) | KEEP | `BottomInput.tsx:81`의 `useEffect` deps에 사용됨 (task spec 확정) |
| `makeCallbacks` (L101) | KEEP | `send`의 dep 체인 — `send`가 KEEP이면 안정적 ref 필요 |
| `regenerate` (L294) | **REMOVE** | 소비처는 `AgentPanel.tsx:147, 177` 두 곳뿐이며 모두 자식 prop(`onRegenerate`, `regenerate={...}`)로 전달. effect deps에 쓰이는 곳 없음 → Compiler가 자동 메모이제이션 처리 |

### `regenerate` 소비처 grep 결과

- `AgentPanel.tsx:112` — `const { regenerate } = useStreaming()` (구조분해)
- `AgentPanel.tsx:147` — `onRegenerate: regenerate` (actions 객체의 자식 prop)
- `AgentPanel.tsx:177` — `regenerate={regenerate}` (MessageActionsProvider의 자식 prop)
- effect deps 패턴(`}, [... regenerate ...]`) 매치 0건

## 검증

- [x] `cd apps/webui && bunx tsc --noEmit` — 에러 0
- [x] `bun run lint` — 에러/경고 0 (react-hooks/exhaustive-deps 포함)
- [x] `bun run test` — 44 pass / 0 fail

## Test plan

- [ ] 메시지 regenerate(재시도) 버튼 동작 확인
- [ ] 스트리밍 중 regenerate 무시(slot.isStreaming guard) 확인
- [ ] 활성 세션이 없거나 프로젝트 미선택 상태에서 no-op 확인