### PR TITLE
refactor(chat): useSession의 수동 메모이제이션 제거

### DIFF
--- a/apps/webui/src/client/features/chat/useSession.ts
+++ b/apps/webui/src/client/features/chat/useSession.ts
@@ -31,67 +31,52 @@ export function useSession() {
     return session;
   }, [slug, mutations, sessionSelectionDispatch]);
 
-  const load = useCallback(
-    (id: string) => {
-      if (!slug) return;
-      // Flip selection immediately; `useSessionData(slug, id)` auto-fetches
-      // under the new key. Mirrors `useProject.selectProject`, which flips
-      // `activeProjectSlug` before the sessions-list fetch resolves —
-      // subscribers fall back to empty arrays for the single render gap.
+  const load = (id: string) => {
+    if (!slug) return;
+    // Flip selection immediately; `useSessionData(slug, id)` auto-fetches
+    // under the new key. Mirrors `useProject.selectProject`, which flips
+    // `activeProjectSlug` before the sessions-list fetch resolves —
+    // subscribers fall back to empty arrays for the single render gap.
+    sessionSelectionDispatch({
+      type: "SET_ACTIVE_SESSION",
+      projectSlug: slug,
+      sessionId: id,
+    });
+  };
+
+  const remove = async (id: string) => {
+    if (!slug) return;
+    await mutations.remove(id);
+    if (selection.openSessionId === id) {
       sessionSelectionDispatch({
         type: "SET_ACTIVE_SESSION",
         projectSlug: slug,
-        sessionId: id,
+        sessionId: null,
       });
-    },
-    [slug, sessionSelectionDispatch],
-  );
+    }
+  };
 
-  const remove = useCallback(
-    async (id: string) => {
-      if (!slug) return;
-      await mutations.remove(id);
-      if (selection.openSessionId === id) {
-        sessionSelectionDispatch({
-          type: "SET_ACTIVE_SESSION",
-          projectSlug: slug,
-          sessionId: null,
-        });
-      }
-    },
-    [slug, mutations, sessionSelectionDispatch, selection.openSessionId],
-  );
-
-  const refresh = useCallback(async () => {
+  const refresh = async () => {
     if (!slug) return;
     await mutate(qk.sessions(slug));
-  }, [slug, mutate]);
+  };
 
-  const switchBranch = useCallback(
-    async (nodeId: string) => {
-      if (!selection.openSessionId || !slug) return;
-      await mutations.switchBranch(selection.openSessionId, nodeId);
-    },
-    [selection.openSessionId, slug, mutations],
-  );
+  const switchBranch = async (nodeId: string) => {
+    if (!selection.openSessionId || !slug) return;
+    await mutations.switchBranch(selection.openSessionId, nodeId);
+  };
 
-  const deleteNode = useCallback(
-    async (nodeId: string) => {
-      if (!selection.openSessionId || !slug) return;
-      await mutations.removeNode(selection.openSessionId, nodeId);
-    },
-    [selection.openSessionId, slug, mutations],
-  );
+  const deleteNode = async (nodeId: string) => {
+    if (!selection.openSessionId || !slug) return;
+    await mutations.removeNode(selection.openSessionId, nodeId);
+  };
 
-  const setReplyTo = useCallback(
-    (nodeId: string | null) => {
-      if (!slug) return;
-      sessionSelectionDispatch({ type: "SET_REPLY_TO", projectSlug: slug, nodeId });
-    },
-    [slug, sessionSelectionDispatch],
-  );
+  const setReplyTo = (nodeId: string | null) => {
+    if (!slug) return;
+    sessionSelectionDispatch({ type: "SET_REPLY_TO", projectSlug: slug, nodeId });
+  };
 
-  const compact = useCallback(async () => {
+  const compact = async () => {
     if (!slug || !selection.openSessionId) return;
     const sessionId = selection.openSessionId;
     // Stream START locks the input while compact runs server-side.
@@ -111,7 +96,7 @@ export function useSession() {
         error: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [slug, selection.openSessionId, mutations, sessionSelectionDispatch, streamDispatch]);
+  };
 
   return {
     create,


### PR DESCRIPTION
## 개요

React Compiler(`babel-plugin-react-compiler`)가 `apps/webui`에 적용되어 있으므로, `useSession`의 수동 `useCallback` 중 effect deps 계약이 없는 것을 단순 함수 선언으로 전환한다. Unit 14 배치의 일부.

## KEEP / REMOVE 근거

### KEEP

- `create` — `BottomInput.tsx:81`의 `useEffect` deps에 직접 참여. Compiler 이후에도 **의미적 stability 계약**이 필요하므로 유지.

### REMOVE

검증 방법: `}, \[[^\]]*\bNAME\b[^\]]*\]` 패턴으로 apps/webui/src/client 전수 검색 후, 매치된 자리가 `useEffect`/`useLayoutEffect`의 deps인지 확인.

| 함수 | 사용처 | 판정 |
|---|---|---|
| `load` | `SessionTabs.tsx:34` onClick 핸들러 | REMOVE |
| `remove` | `SessionTabs.tsx:51` onClick 핸들러 | REMOVE |
| `refresh` | (사용처 없음 — 죽은 export에 가깝지만 본 유닛 범위 밖) | REMOVE |
| `switchBranch` | `AgentPanel.tsx:144,174` — 자식 prop | REMOVE |
| `deleteNode` | `AgentPanel.tsx:146,176` — 자식 prop | REMOVE |
| `setReplyTo` | `AgentPanel.tsx:145,163,175` — 자식 prop / onClick | REMOVE |
| `compact` | `useSlashCommands.ts:38,57` — 호출 + 다른 `useCallback` deps 참여 (effect deps 아님) | REMOVE |

`useCallback`의 `useCallback` deps 참여는 REMOVE 원칙에 해당 (Compiler가 호출자 측 메모이제이션도 자동 처리).

## 검증

- `cd apps/webui && bunx tsc --noEmit` — 통과
- `bun run lint` — 통과 (react-hooks/exhaustive-deps 경고 0)
- `bun run test` — 44/44 통과

## 변경 범위

- `apps/webui/src/client/features/chat/useSession.ts` — 7개 `useCallback` 제거, `useCallback` import는 `create`용으로 유지