### PR TITLE
refactor(chat,settings): chat 보조 훅 + useTheme 수동 메모 제거

### DIFF
--- a/apps/webui/src/client/features/chat/useCommandPalette.ts
+++ b/apps/webui/src/client/features/chat/useCommandPalette.ts
@@ -1,4 +1,4 @@
-import { useCallback, useId, useMemo, useState } from "react";
+import { useId, useState } from "react";
 import { MIN_SCORE, scoreEntry, type SlashEntry } from "./commands.js";
 
 export function optionId(listboxId: string, entry: SlashEntry): string {
@@ -39,61 +39,57 @@ export function useCommandPalette({
   const query = text.startsWith("/") ? text.slice(1).toLowerCase() : "";
   const isOpen = text.startsWith("/") && !query.includes(" ");
 
-  const items = useMemo<SlashEntry[]>(() => {
-    if (!isOpen) return [];
-    return entries
-      .map((entry) => ({ entry, score: scoreEntry(entry, query) }))
-      .filter((x) => x.score >= MIN_SCORE)
-      .sort((a, b) => b.score - a.score)
-      .map((x) => x.entry);
-  }, [isOpen, entries, query]);
+  const items: SlashEntry[] = isOpen
+    ? entries
+        .map((entry) => ({ entry, score: scoreEntry(entry, query) }))
+        .filter((x) => x.score >= MIN_SCORE)
+        .sort((a, b) => b.score - a.score)
+        .map((x) => x.entry)
+    : [];
 
   const clampedIndex = Math.min(selectedIndex, Math.max(items.length - 1, 0));
   const activeOptionId = items[clampedIndex] ? optionId(listboxId, items[clampedIndex]) : undefined;
 
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent): boolean => {
-      if (!isOpen) return false;
+  const handleKeyDown = (e: React.KeyboardEvent): boolean => {
+    if (!isOpen) return false;
 
-      if (e.key === "Escape") {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      setText("");
+      setSelectedIndex(0);
+      return true;
+    }
+
+    // Empty-result state: consume nav keys so stray Enter doesn't submit.
+    if (items.length === 0) {
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Tab") {
         e.preventDefault();
-        setText("");
+        return true;
+      }
+      return false;
+    }
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((i) => (i + 1) % items.length);
+        return true;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex((i) => (i - 1 + items.length) % items.length);
+        return true;
+      case "Enter":
+      case "Tab": {
+        e.preventDefault();
+        const selected = items[clampedIndex];
+        if (selected) onSelect(selected);
         setSelectedIndex(0);
         return true;
       }
-
-      // Empty-result state: consume nav keys so stray Enter doesn't submit.
-      if (items.length === 0) {
-        if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Tab") {
-          e.preventDefault();
-          return true;
-        }
+      default:
         return false;
-      }
-
-      switch (e.key) {
-        case "ArrowDown":
-          e.preventDefault();
-          setSelectedIndex((i) => (i + 1) % items.length);
-          return true;
-        case "ArrowUp":
-          e.preventDefault();
-          setSelectedIndex((i) => (i - 1 + items.length) % items.length);
-          return true;
-        case "Enter":
-        case "Tab": {
-          e.preventDefault();
-          const selected = items[clampedIndex];
-          if (selected) onSelect(selected);
-          setSelectedIndex(0);
-          return true;
-        }
-        default:
-          return false;
-      }
-    },
-    [isOpen, items, clampedIndex, onSelect, setText],
-  );
+    }
+  };
 
   return {
     isOpen,

--- a/apps/webui/src/client/features/chat/useSentenceAnimation.ts
+++ b/apps/webui/src/client/features/chat/useSentenceAnimation.ts
@@ -1,4 +1,4 @@
-import { useMemo, useRef, useState, useEffect, useLayoutEffect } from "react";
+import { useRef, useState, useEffect, useLayoutEffect } from "react";
 import { segmentSentences } from "@/client/shared/sentenceSegmenter.js";
 
 export interface SentenceAnimationState {
@@ -19,17 +19,10 @@ export function useSentenceAnimation(
     new Set(),
   );
 
-  const { confirmed, pending } = useMemo(
-    () => segmentSentences(text),
-    [text],
-  );
+  const { confirmed, pending } = segmentSentences(text);
 
-  const confirmedSentences = useMemo(() => {
-    if (!isStreaming && pending) {
-      return [...confirmed, pending];
-    }
-    return confirmed;
-  }, [confirmed, pending, isStreaming]);
+  const confirmedSentences =
+    !isStreaming && pending ? [...confirmed, pending] : confirmed;
 
   useLayoutEffect(() => {
     const prevCount = animatedCountRef.current;

--- a/apps/webui/src/client/features/chat/useSlashCommands.ts
+++ b/apps/webui/src/client/features/chat/useSlashCommands.ts
@@ -1,4 +1,3 @@
-import { useCallback, useMemo } from "react";
 import { useConfigMutations } from "@/client/entities/config/index.js";
 import { useSkills } from "@/client/entities/skill/index.js";
 import {
@@ -23,91 +22,79 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
   const { create, compact } = useSession();
   const { send } = useStreaming();
 
-  const entries = useMemo(
-    () => buildSlashEntries(skills),
-    [skills],
-  );
+  const entries = buildSlashEntries(skills);
 
-  const executeLocalCommand = useCallback(
-    async (name: string, arg: string) => {
-      switch (name) {
-        case "new":
-          await create();
-          break;
-        case "compact":
-          await compact();
-          break;
-        case "edit":
-          uiDispatch({ type: "SET_VIEW_MODE", mode: ui.viewMode === "edit" ? "chat" : "edit" });
-          break;
-        case "readme":
-          uiDispatch({ type: "OPEN_README" });
-          break;
-        case "model": {
-          await updateConfig({ model: arg });
-          break;
-        }
-        case "provider": {
-          await updateConfig({ provider: arg });
-          break;
-        }
+  const executeLocalCommand = async (name: string, arg: string) => {
+    switch (name) {
+      case "new":
+        await create();
+        break;
+      case "compact":
+        await compact();
+        break;
+      case "edit":
+        uiDispatch({ type: "SET_VIEW_MODE", mode: ui.viewMode === "edit" ? "chat" : "edit" });
+        break;
+      case "readme":
+        uiDispatch({ type: "OPEN_README" });
+        break;
+      case "model": {
+        await updateConfig({ model: arg });
+        break;
       }
-      setText("");
-    },
-    [create, compact, updateConfig, uiDispatch, ui.viewMode, setText],
-  );
+      case "provider": {
+        await updateConfig({ provider: arg });
+        break;
+      }
+    }
+    setText("");
+  };
 
-  const selectCommand = useCallback(
-    (cmd: SlashEntry) => {
-      // Skill commands always allow free-form args; local commands ask
-      // explicitly via needsArg. Both cases just prefill the textbox.
-      const needsTextInsert = cmd.kind === "skill" || cmd.needsArg;
-      if (needsTextInsert) setText("/" + cmd.name + " ");
-      else void executeLocalCommand(cmd.name, "");
-    },
-    [executeLocalCommand, setText],
-  );
+  const selectCommand = (cmd: SlashEntry) => {
+    // Skill commands always allow free-form args; local commands ask
+    // explicitly via needsArg. Both cases just prefill the textbox.
+    const needsTextInsert = cmd.kind === "skill" || cmd.needsArg;
+    if (needsTextInsert) setText("/" + cmd.name + " ");
+    else void executeLocalCommand(cmd.name, "");
+  };
 
   const palette = useCommandPalette({ text, setText, entries, onSelect: selectCommand });
 
-  const tryExecuteCommand = useCallback(
-    (input: string): boolean => {
-      if (!input.startsWith("/")) return false;
+  const tryExecuteCommand = (input: string): boolean => {
+    if (!input.startsWith("/")) return false;
 
-      const withoutSlash = input.slice(1).trim();
-      const spaceIdx = withoutSlash.indexOf(" ");
-      const cmdName = spaceIdx >= 0 ? withoutSlash.slice(0, spaceIdx) : withoutSlash;
-      const arg = spaceIdx >= 0 ? withoutSlash.slice(spaceIdx + 1).trim() : "";
+    const withoutSlash = input.slice(1).trim();
+    const spaceIdx = withoutSlash.indexOf(" ");
+    const cmdName = spaceIdx >= 0 ? withoutSlash.slice(0, spaceIdx) : withoutSlash;
+    const arg = spaceIdx >= 0 ? withoutSlash.slice(spaceIdx + 1).trim() : "";
 
-      const local = LOCAL_COMMANDS.find((c) => c.name === cmdName);
-      if (local) {
-        if (local.needsArg && !arg) return false;
-        void executeLocalCommand(cmdName, arg);
-        return true;
-      }
+    const local = LOCAL_COMMANDS.find((c) => c.name === cmdName);
+    if (local) {
+      if (local.needsArg && !arg) return false;
+      void executeLocalCommand(cmdName, arg);
+      return true;
+    }
 
-      // Meta skill: auto-create meta session and send the command there.
-      // If already in a meta session, fall through to normal send.
-      const entry = entries.find(
-        (e): e is SkillSlashCommand => e.kind === "skill" && e.name === cmdName,
+    // Meta skill: auto-create meta session and send the command there.
+    // If already in a meta session, fall through to normal send.
+    const entry = entries.find(
+      (e): e is SkillSlashCommand => e.kind === "skill" && e.name === cmdName,
+    );
+    if (entry?.environment === "meta") {
+      const activeSession = sessions.find(
+        (s) => s.id === selection.openSessionId,
       );
-      if (entry?.environment === "meta") {
-        const activeSession = sessions.find(
-          (s) => s.id === selection.openSessionId,
-        );
-        if (activeSession?.mode === "meta") return false;
+      if (activeSession?.mode === "meta") return false;
 
-        setText("");
-        void create("meta").then((sess) => {
-          if (sess) void send(input, sess.id);
-        });
-        return true;
-      }
+      setText("");
+      void create("meta").then((sess) => {
+        if (sess) void send(input, sess.id);
+      });
+      return true;
+    }
 
-      return false; // skill commands fall through to send()
-    },
-    [executeLocalCommand, entries, sessions, selection.openSessionId, create, send, setText],
-  );
+    return false; // skill commands fall through to send()
+  };
 
   return { palette, selectCommand, tryExecuteCommand };
 }

--- a/apps/webui/src/client/features/settings/useTheme.ts
+++ b/apps/webui/src/client/features/settings/useTheme.ts
@@ -4,7 +4,6 @@ import {
   useState,
   useEffect,
   useCallback,
-  useMemo,
   type ReactNode,
 } from "react";
 import { createElement } from "react";
@@ -96,9 +95,9 @@ const darkIcon = createElement("svg", { width: 20, height: 20, viewBox: "0 0 24 
 
 export function useThemeOptions() {
   const { t } = useI18n();
-  return useMemo(() => [
+  return [
     { value: "system" as ThemePreference, label: t("globalSettings.themeSystem"), desc: t("globalSettings.themeSystemDesc"), icon: systemIcon },
     { value: "light" as ThemePreference, label: t("globalSettings.themeLight"), desc: t("globalSettings.themeLightDesc"), icon: lightIcon },
     { value: "dark" as ThemePreference, label: t("globalSettings.themeDark"), desc: t("globalSettings.themeDarkDesc"), icon: darkIcon },
-  ], [t]);
+  ];
 }


### PR DESCRIPTION
## 요약

React Compiler(`babel-plugin-react-compiler`)가 자동 메모이제이션을 처리하므로 불필요한 `useCallback` / `useMemo` 래퍼를 제거했습니다. 제거한 값은 모두 소비자의 `useEffect` / `useLayoutEffect` deps 외부에서만 쓰이는 것을 grep으로 확인했습니다.

## 변경

- **useSlashCommands.ts**: `entries` / `executeLocalCommand` / `selectCommand` / `tryExecuteCommand` 래퍼 제거. 반환되는 `selectCommand`, `tryExecuteCommand`는 BottomInput에서 이벤트 핸들러로만 쓰이고 effect deps에 없음.
- **useCommandPalette.ts**: `items` / `handleKeyDown` 래퍼 제거. `handleKeyDown`은 `onKeyDown`에만 연결되고 effect deps에 없음.
- **useSentenceAnimation.ts**: `segmentSentences()` 결과 분해와 `confirmedSentences` 파생 메모 제거. `useLayoutEffect` deps는 `confirmedSentences.length`라는 primitive만 사용하므로 배열 identity 변화에도 안전.
- **useTheme.ts**: `useThemeOptions`의 `useMemo` 제거. **`setPreference` useCallback은 Context value 구성원이라 의도적으로 유지.**

## 검증

- `bunx tsc --noEmit` (apps/webui) — 통과
- `bun run lint` — 통과
- `bun run test` — 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)