### PR TITLE
refactor(project,editor): useProject / useEditMode의 useCallback 23개 제거

### DIFF
--- a/apps/webui/src/client/features/editor/useEditMode.ts
+++ b/apps/webui/src/client/features/editor/useEditMode.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
 import { useActiveStream } from "@/client/entities/stream/index.js";
@@ -88,51 +88,51 @@ export function useEditMode() {
     editorDispatch({ type: "CLEAR" });
   }, [slug, editorDispatch]);
 
-  const selectFile = useCallback((path: string) => {
+  const selectFile = (path: string) => {
     if (path === editor.selectedPath) return;
     if (editor.dirty) {
       setPendingPath(path);
       return;
     }
     editorDispatch({ type: "SELECT_FILE", path });
-  }, [editor.selectedPath, editor.dirty, editorDispatch]);
+  };
 
-  const saveCurrentFile = useCallback(async () => {
+  const saveCurrentFile = async () => {
     if (!slug || !editor.selectedPath || editor.localContent === null) return;
     await write(editor.selectedPath, editor.localContent);
     editorDispatch({ type: "MARK_CLEAN" });
-  }, [slug, editor.selectedPath, editor.localContent, write, editorDispatch]);
+  };
 
-  const handleDocChange = useCallback((content: string) => {
+  const handleDocChange = (content: string) => {
     editorDispatch({ type: "UPDATE_LOCAL_CONTENT", content });
-  }, [editorDispatch]);
+  };
 
   // Unsaved dialog handlers
-  const handleUnsavedSave = useCallback(async () => {
+  const handleUnsavedSave = async () => {
     await saveCurrentFile();
     if (pendingPath) {
       editorDispatch({ type: "SELECT_FILE", path: pendingPath });
       setPendingPath(null);
     }
-  }, [saveCurrentFile, pendingPath, editorDispatch]);
+  };
 
-  const handleUnsavedDiscard = useCallback(() => {
+  const handleUnsavedDiscard = () => {
     if (pendingPath) {
       editorDispatch({ type: "SELECT_FILE", path: pendingPath });
       setPendingPath(null);
     }
-  }, [pendingPath, editorDispatch]);
+  };
 
-  const handleUnsavedCancel = useCallback(() => {
+  const handleUnsavedCancel = () => {
     setPendingPath(null);
-  }, []);
+  };
 
   // Delete flow
-  const requestDeleteFile = useCallback((path: string) => {
+  const requestDeleteFile = (path: string) => {
     setDeleteConfirmPath(path);
-  }, []);
+  };
 
-  const confirmDeleteFile = useCallback(async () => {
+  const confirmDeleteFile = async () => {
     if (!slug || !deleteConfirmPath) return;
     try {
       await deleteFile(deleteConfirmPath);
@@ -142,18 +142,18 @@ export function useEditMode() {
     } finally {
       setDeleteConfirmPath(null);
     }
-  }, [slug, deleteConfirmPath, deleteFile, editorDispatch]);
+  };
 
-  const cancelDeleteFile = useCallback(() => {
+  const cancelDeleteFile = () => {
     setDeleteConfirmPath(null);
-  }, []);
+  };
 
   // Folder delete flow
-  const requestDeleteDir = useCallback((path: string) => {
+  const requestDeleteDir = (path: string) => {
     setDeleteConfirmDir(path);
-  }, []);
+  };
 
-  const confirmDeleteDir = useCallback(async () => {
+  const confirmDeleteDir = async () => {
     if (!slug || !deleteConfirmDir) return;
     try {
       await deleteDir(deleteConfirmDir);
@@ -166,14 +166,14 @@ export function useEditMode() {
     } finally {
       setDeleteConfirmDir(null);
     }
-  }, [slug, deleteConfirmDir, deleteDir, editorDispatch]);
+  };
 
-  const cancelDeleteDir = useCallback(() => {
+  const cancelDeleteDir = () => {
     setDeleteConfirmDir(null);
-  }, []);
+  };
 
   // Rename
-  const renameEntry = useCallback(async (oldPath: string, newName: string) => {
+  const renameEntry = async (oldPath: string, newName: string) => {
     if (!slug) return;
     const parentPath = oldPath.includes("/") ? oldPath.substring(0, oldPath.lastIndexOf("/")) : null;
     const newPath = parentPath ? `${parentPath}/${newName}` : newName;
@@ -188,26 +188,26 @@ export function useEditMode() {
         editorDispatch({ type: "RENAME_SELECTED", newPath: newPath + selected.slice(oldPath.length) });
       }
     }
-  }, [slug, rename, editorDispatch]);
+  };
 
   // Create file / dir
-  const createFileInDir = useCallback(async (dirPath: string | null, fileName: string) => {
+  const createFileInDir = async (dirPath: string | null, fileName: string) => {
     if (!slug) return;
     const filePath = dirPath ? `${dirPath}/${fileName}` : fileName;
     await write(filePath, "");
     editorDispatch({ type: "SELECT_FILE", path: filePath });
-  }, [slug, write, editorDispatch]);
+  };
 
-  const createDirInDir = useCallback(async (parentPath: string | null, dirName: string) => {
+  const createDirInDir = async (parentPath: string | null, dirName: string) => {
     if (!slug) return;
     const dirPath = parentPath ? `${parentPath}/${dirName}` : dirName;
     await createDir(dirPath);
-  }, [slug, createDir]);
+  };
 
-  const revealFile = useCallback((path: string) => {
+  const revealFile = (path: string) => {
     if (!slug) return;
     void reveal(path);
-  }, [slug, reveal]);
+  };
 
   return {
     treeEntries,

--- a/apps/webui/src/client/features/project/useProject.ts
+++ b/apps/webui/src/client/features/project/useProject.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useSWRConfig } from "swr";
 import {
   useProjectSelectionState,
@@ -43,122 +43,95 @@ export function useProject() {
   const sessionSelectionRef = useRef(sessionSelectionState);
   useEffect(() => { sessionSelectionRef.current = sessionSelectionState; });
 
-  const activateProject = useCallback(
-    async (slug: string): Promise<Session[]> => {
-      projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug });
-      // Must fire synchronously with slug change: if RenderedView is off-screen
-      // (Templates/Settings) during a project switch, its slug-keyed effect
-      // won't run on return, so the previous project's HTML would briefly
-      // flash. Theme is kept to avoid a two-step palette flicker.
-      rendererViewDispatch({ type: "CLEAR_HTML" });
-      // Single GET: SWR's fetcher runs, result seeds the cache atomically.
-      // Calling `fetchSessions` separately risked a duplicate fetch when
-      // `useSessions(slug)` mounted outside the dedupe window.
-      const sessions = await mutate<Session[]>(qk.sessions(slug));
-      return sessions ?? [];
-    },
-    [projectSelectionDispatch, rendererViewDispatch, mutate],
-  );
+  const activateProject = async (slug: string): Promise<Session[]> => {
+    projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug });
+    // Must fire synchronously with slug change: if RenderedView is off-screen
+    // (Templates/Settings) during a project switch, its slug-keyed effect
+    // won't run on return, so the previous project's HTML would briefly
+    // flash. Theme is kept to avoid a two-step palette flicker.
+    rendererViewDispatch({ type: "CLEAR_HTML" });
+    // Single GET: SWR's fetcher runs, result seeds the cache atomically.
+    // Calling `fetchSessions` separately risked a duplicate fetch when
+    // `useSessions(slug)` mounted outside the dedupe window.
+    const sessions = await mutate<Session[]>(qk.sessions(slug));
+    return sessions ?? [];
+  };
 
-  const selectProject = useCallback(
-    async (slug: string) => {
-      // No-op if already active. Otherwise SET_ACTIVE_PROJECT would re-fire
-      // and clear renderedHtml, but the slug-keyed useEffect in RenderedView
-      // wouldn't re-run (primitive equality), leaving the renderer blank.
-      if (projectSelection.activeProjectSlug === slug) return;
+  const selectProject = async (slug: string) => {
+    // No-op if already active. Otherwise SET_ACTIVE_PROJECT would re-fire
+    // and clear renderedHtml, but the slug-keyed useEffect in RenderedView
+    // wouldn't re-run (primitive equality), leaving the renderer blank.
+    if (projectSelection.activeProjectSlug === slug) return;
 
-      localStore.lastProject.write(slug);
-      const rememberedSessionId = selectSessionSelection(
-        sessionSelectionRef.current,
-        slug,
-      ).openSessionId;
+    localStore.lastProject.write(slug);
+    const rememberedSessionId = selectSessionSelection(
+      sessionSelectionRef.current,
+      slug,
+    ).openSessionId;
 
-      // Sessions list + remembered detail fetch in parallel. The detail
-      // fetch is speculative (we don't yet know the remembered id is valid);
-      // if the session was deleted server-side, SWR's 404 leaves the
-      // cache untouched and we skip the dispatch below.
-      const [sessions] = await Promise.all([
-        activateProject(slug),
-        rememberedSessionId
-          ? mutate(qk.session(slug, rememberedSessionId))
-          : Promise.resolve(null),
-      ]);
+    // Sessions list + remembered detail fetch in parallel. The detail
+    // fetch is speculative (we don't yet know the remembered id is valid);
+    // if the session was deleted server-side, SWR's 404 leaves the
+    // cache untouched and we skip the dispatch below.
+    const [sessions] = await Promise.all([
+      activateProject(slug),
+      rememberedSessionId
+        ? mutate(qk.session(slug, rememberedSessionId))
+        : Promise.resolve(null),
+    ]);
 
-      if (rememberedSessionId && sessions.some((s) => s.id === rememberedSessionId)) {
-        sessionSelectionDispatch({
-          type: "SET_ACTIVE_SESSION",
-          projectSlug: slug,
-          sessionId: rememberedSessionId,
-        });
+    if (rememberedSessionId && sessions.some((s) => s.id === rememberedSessionId)) {
+      sessionSelectionDispatch({
+        type: "SET_ACTIVE_SESSION",
+        projectSlug: slug,
+        sessionId: rememberedSessionId,
+      });
+    }
+  };
+
+  const createProject = async (name: string, fromTemplate?: string) => {
+    const project = await createProjectMutation(name, fromTemplate);
+    projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug: project.slug });
+    rendererViewDispatch({ type: "CLEAR_HTML" });
+    return project;
+  };
+
+  const duplicateProject = async (sourceSlug: string, name: string) => {
+    const project = await duplicateProjectMutation(sourceSlug, name);
+    await activateProject(project.slug);
+    return project;
+  };
+
+  const renameProject = async (slug: string, name: string) => {
+    return updateProjectMutation(slug, { name });
+  };
+
+  const deleteProject = async (slug: string) => {
+    // Abort any in-flight stream so pi-agent-core cancels the LLM request
+    // and drop the stream+selection slots so stale completion events can't
+    // resurrect them.
+    abortProjectStream(slug);
+    streamDispatch({ type: "CLOSE", projectSlug: slug });
+    sessionSelectionDispatch({ type: "CLEAR", projectSlug: slug });
+
+    await deleteProjectMutation(slug);
+
+    if (projectSelection.activeProjectSlug === slug) {
+      const fallback = projects.find((p) => p.slug !== slug);
+      if (fallback) {
+        localStore.lastProject.write(fallback.slug);
+        await activateProject(fallback.slug);
+      } else {
+        projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug: null });
+        rendererViewDispatch({ type: "CLEAR" });
       }
-    },
-    [projectSelection.activeProjectSlug, activateProject, sessionSelectionDispatch, mutate],
-  );
+    }
+  };
 
-  const createProject = useCallback(
-    async (name: string, fromTemplate?: string) => {
-      const project = await createProjectMutation(name, fromTemplate);
-      projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug: project.slug });
-      rendererViewDispatch({ type: "CLEAR_HTML" });
-      return project;
-    },
-    [createProjectMutation, projectSelectionDispatch, rendererViewDispatch],
-  );
-
-  const duplicateProject = useCallback(
-    async (sourceSlug: string, name: string) => {
-      const project = await duplicateProjectMutation(sourceSlug, name);
-      await activateProject(project.slug);
-      return project;
-    },
-    [duplicateProjectMutation, activateProject],
-  );
-
-  const renameProject = useCallback(
-    async (slug: string, name: string) => {
-      return updateProjectMutation(slug, { name });
-    },
-    [updateProjectMutation],
-  );
-
-  const deleteProject = useCallback(
-    async (slug: string) => {
-      // Abort any in-flight stream so pi-agent-core cancels the LLM request
-      // and drop the stream+selection slots so stale completion events can't
-      // resurrect them.
-      abortProjectStream(slug);
-      streamDispatch({ type: "CLOSE", projectSlug: slug });
-      sessionSelectionDispatch({ type: "CLEAR", projectSlug: slug });
-
-      await deleteProjectMutation(slug);
-
-      if (projectSelection.activeProjectSlug === slug) {
-        const fallback = projects.find((p) => p.slug !== slug);
-        if (fallback) {
-          localStore.lastProject.write(fallback.slug);
-          await activateProject(fallback.slug);
-        } else {
-          projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug: null });
-          rendererViewDispatch({ type: "CLEAR" });
-        }
-      }
-    },
-    [
-      projectSelection.activeProjectSlug,
-      projects,
-      deleteProjectMutation,
-      streamDispatch,
-      sessionSelectionDispatch,
-      projectSelectionDispatch,
-      rendererViewDispatch,
-      activateProject,
-    ],
-  );
-
-  const loadProjects = useCallback(async () => {
+  const loadProjects = async () => {
     const next = await mutate(qk.projects());
     return next ?? projects;
-  }, [mutate, projects]);
+  };
 
   return {
     loadProjects,


### PR DESCRIPTION
## Summary
- React Compiler가 자동 메모이제이션을 담당하므로 `useProject.ts`와 `useEditMode.ts`의 수동 `useCallback` 23개를 모두 일반 함수 선언으로 변환
- 두 훅 모두 `useCallback` import 제거

## 검증 — REMOVE 근거

두 훅의 반환 멤버 + 내부 콜백 전부에 대해 `Grep`으로 `useEffect` / `useLayoutEffect` deps 배열에 포함되는 경우를 전수 조사. 모두 **사용처 없음** (소비처는 `useCallback` deps 또는 이벤트 핸들러뿐).

### useProject.ts (7개 REMOVE)
| 이름 | 소비처 검증 |
|------|------------|
| `activateProject` | 내부 호출만 (duplicate/delete/select). effect dep 없음 |
| `selectProject` | Sidebar 등에서 이벤트 핸들러 |
| `createProject` | `ProjectTabs.handleCreate` / `TemplatesPage.handleCreate`의 `useCallback` dep |
| `duplicateProject` | `ProjectTabs.handleDuplicate`의 `useCallback` dep |
| `renameProject` | 이벤트 핸들러 |
| `deleteProject` | 이벤트 핸들러 |
| `loadProjects` | 이벤트 핸들러 |

### useEditMode.ts (16개 REMOVE)
`selectFile`, `saveCurrentFile`, `handleDocChange`, `handleUnsavedSave/Discard/Cancel`, `requestDeleteFile/Dir`, `confirmDeleteFile/Dir`, `cancelDeleteFile/Dir`, `renameEntry`, `createFileInDir`, `createDirInDir`, `revealFile` — 모두 `EditModePanel` 등에서 prop/이벤트 핸들러로만 소비, effect dep 사용처 없음 확인.

## 체인 결정
- **useProject**: `activateProject`는 `duplicateProject`/`deleteProject`/`selectProject`의 내부 의존이었음. 셋 모두 REMOVE이므로 `activateProject`도 REMOVE (체인 안정성 불필요)
- **useEditMode**: `saveCurrentFile`은 `handleUnsavedSave`의 내부 의존이었음. 둘 다 REMOVE이므로 함께 REMOVE 가능

## 보존
- `useRef`(sessionSelectionRef, wasStreaming, selectedPathRef, dirtyRef)와 `useEffect`(ref 동기화, streaming-finished refetch, 외부 content sync, project switch clear)는 그대로 유지

## Test plan
- [x] `bunx tsc --noEmit` (apps/webui) — 타입 에러 0
- [x] `bun run lint` — 경고/에러 0 (react-hooks/exhaustive-deps 통과)
- [x] `bun run test` — 44 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)