### PR TITLE
fix(project): 스트리밍 중 pending UI 갱신으로 스크롤이 끌려내려가는 문제 수정

### DIFF
--- a/apps/webui/src/client/features/project/RenderedView.tsx
+++ b/apps/webui/src/client/features/project/RenderedView.tsx
@@ -128,14 +128,18 @@ export function RenderedView() {
     return () => clearTimeout(timer);
   }, [phase]);
 
+  // 스트리밍 중 pending UI가 매 rAF마다 anchor를 다시 잡으면서 스크롤을 끌어내리므로,
+  // 스트리밍이 끝난 직후 한 번만 바닥으로 이동시킨다. isStreaming이 true→false로 바뀌는
+  // 전이에서 effect가 재실행되며 최종 결과로 스크롤된다.
   useEffect(() => {
+    if (stream.isStreaming) return;
     const el = containerRef.current;
     if (!el) return;
     const anchor = el.querySelector("[data-chat-anchor]");
     if (anchor) {
       anchor.scrollIntoView({ behavior: "smooth" });
     }
-  }, [rendererView.html]);
+  }, [rendererView.html, stream.isStreaming]);
 
   useEffect(() => {
     const el = frontRef.current;


### PR DESCRIPTION
## Summary
- 렌더러의 pending UI가 rAF마다 갱신되며 `[data-chat-anchor]`를 다시 잡아 매번 `scrollIntoView`가 호출되던 동작 수정
- `stream.isStreaming`으로 게이트: 스트리밍 중에는 스크롤 보존, 종료 전이 시점에 한 번만 바닥으로 이동

## Test plan
- [x] `bunx tsc --noEmit` (apps/webui)
- [x] `bun run lint`
- [x] `bun run test`
- [x] agent-browser 시나리오 A: 스트리밍 중 scrollTop=200 유지
- [x] agent-browser 시나리오 B: 스트리밍 종료 전이 시점(+2s)에 11429/11594로 바닥 이동
- [x] 브라우저 콘솔 에러/경고 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)