### PR TITLE
refactor(editor): client-first 동기 모델로 회귀 — SWR 읽기 경로 제거

### DIFF
--- a/apps/webui/src/client/entities/editor/EditorContext.tsx
+++ b/apps/webui/src/client/entities/editor/EditorContext.tsx
@@ -9,21 +9,31 @@ import type { EditorState, EditorAction } from "./editor.types.js";
 
 const initialState: EditorState = {
   selectedPath: null,
+  originalContent: null,
   buffer: null,
 };
 
 function editorReducer(state: EditorState, action: EditorAction): EditorState {
   switch (action.type) {
     case "SELECT_FILE":
-      return { selectedPath: action.path, buffer: null };
+      return {
+        selectedPath: action.path,
+        originalContent: action.content,
+        buffer: action.content,
+      };
     case "UPDATE_BUFFER":
       return { ...state, buffer: action.content };
-    case "DISCARD_BUFFER":
-      // Only drop the shadow if it still matches what was saved — preserves
-      // keystrokes the user made during the save round-trip.
-      return state.buffer === action.ifEquals ? { ...state, buffer: null } : state;
+    case "FILE_SAVED":
+      // Buffer is intentionally preserved so edits made during the write
+      // round-trip survive; dirty re-derives against the new baseline.
+      if (state.originalContent === action.savedContent) return state;
+      return { ...state, originalContent: action.savedContent };
+    case "EXTERNAL_REFRESH":
+      // Drop if selection moved during the refresh fetch.
+      if (state.selectedPath !== action.path) return state;
+      return { ...state, originalContent: action.content, buffer: action.content };
     case "DESELECT_FILE":
-      return { selectedPath: null, buffer: null };
+      return { selectedPath: null, originalContent: null, buffer: null };
     case "RENAME_SELECTED":
       return { ...state, selectedPath: action.newPath };
     case "CLEAR":

--- a/apps/webui/src/client/entities/editor/editor.types.ts
+++ b/apps/webui/src/client/entities/editor/editor.types.ts
@@ -12,20 +12,22 @@ export interface TreeEntry {
 }
 
 /**
- * Single source of truth for file content is the SWR cache (`useFileContent`).
- * `buffer` is a client-only shadow that only exists while the user is editing;
- * `dirty` is derived (`buffer !== null && buffer !== serverContent`) rather
- * than stored — that way there is no sync effect to go out of step with.
+ * Invariant: `selectedPath` set ⇔ `originalContent` and `buffer` set.
+ * SELECT_FILE carries the content payload, so there is no transient
+ * "selected but empty" state that sync effects would otherwise need to
+ * paper over. `dirty` is derived (`buffer !== originalContent`).
  */
 export interface EditorState {
   selectedPath: string | null;
+  originalContent: string | null;
   buffer: string | null;
 }
 
 export type EditorAction =
-  | { type: "SELECT_FILE"; path: string }
+  | { type: "SELECT_FILE"; path: string; content: string }
   | { type: "UPDATE_BUFFER"; content: string }
-  | { type: "DISCARD_BUFFER"; ifEquals: string }
+  | { type: "FILE_SAVED"; savedContent: string }
+  | { type: "EXTERNAL_REFRESH"; path: string; content: string }
   | { type: "DESELECT_FILE" }
   | { type: "RENAME_SELECTED"; newPath: string }
   | { type: "CLEAR" };

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -3,4 +3,4 @@ export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile,
 export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
 export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";
-export { useProjectTree, useFileContent, useEditorMutations } from "./useEditor.js";
+export { useProjectTree, useEditorMutations } from "./useEditor.js";

--- a/apps/webui/src/client/entities/editor/useEditor.ts
+++ b/apps/webui/src/client/entities/editor/useEditor.ts
@@ -14,63 +14,46 @@ export function useProjectTree(slug: string | null) {
   return useSWR<{ entries: TreeEntry[] }>(slug ? qk.projectTree(slug) : null);
 }
 
-export function useFileContent(slug: string | null, path: string | null) {
-  return useSWR<{ content: string }>(slug && path ? qk.projectFile(slug, path) : null);
-}
-
 /**
- * Editor mutations. `write` seeds the file cache so the editor doesn't
- * round-trip after save. Tree-shape changes (delete/rename/createDir)
- * invalidate the tree key and selectively migrate file content cache.
+ * File content is owned by the editor reducer, not SWR. Mutations here
+ * kick off a tree revalidation (fire-and-forget) so the caller isn't
+ * blocked on the GET round-trip before its own follow-up dispatch.
  */
 export function useEditorMutations(slug: string | null) {
   const { mutate } = useSWRConfig();
 
+  const refreshTree = () => {
+    if (slug) void mutate(qk.projectTree(slug));
+  };
+
   const write = async (path: string, content: string) => {
     if (!slug) throw new Error("write: slug required");
     await apiWrite(slug, path, content);
-    await mutate(qk.projectFile(slug, path), { content }, { revalidate: false });
-    // Tree's modifiedAt for this entry shifts — keep the list in sync.
-    await mutate(qk.projectTree(slug));
+    refreshTree();
   };
 
   const removeFile = async (path: string) => {
     if (!slug) throw new Error("removeFile: slug required");
     await apiDeleteFile(slug, path);
-    await mutate(qk.projectTree(slug));
-    await mutate(qk.projectFile(slug, path), undefined, { revalidate: false });
+    refreshTree();
   };
 
   const removeDir = async (path: string) => {
     if (!slug) throw new Error("removeDir: slug required");
     await apiDeleteDir(slug, path);
-    await mutate(qk.projectTree(slug));
-    // Evict any cached files under this directory prefix.
-    await mutate(
-      (k) =>
-        Array.isArray(k) &&
-        k[0] === "projectFile" &&
-        k[1] === slug &&
-        typeof k[2] === "string" &&
-        k[2].startsWith(path + "/"),
-      undefined,
-      { revalidate: false },
-    );
+    refreshTree();
   };
 
   const rename = async (from: string, to: string) => {
     if (!slug) throw new Error("rename: slug required");
     await apiRename(slug, from, to);
-    await mutate(qk.projectTree(slug));
-    // Move the file content cache to the new key (if loaded).
-    await mutate(qk.projectFile(slug, from), undefined, { revalidate: false });
-    await mutate(qk.projectFile(slug, to));
+    refreshTree();
   };
 
   const createDir = async (path: string) => {
     if (!slug) throw new Error("createDir: slug required");
     await apiCreateDir(slug, path);
-    await mutate(qk.projectTree(slug));
+    refreshTree();
   };
 
   const reveal = async (path: string) => {

--- a/apps/webui/src/client/features/editor/useEditMode.ts
+++ b/apps/webui/src/client/features/editor/useEditMode.ts
@@ -7,8 +7,8 @@ import {
   useEditorState,
   useEditorDispatch,
   useProjectTree,
-  useFileContent,
   useEditorMutations,
+  readProjectFile,
 } from "@/client/entities/editor/index.js";
 import { qk } from "@/client/shared/queryKeys.js";
 import { useLatestRef } from "@/client/shared/useLatestRef.js";
@@ -29,10 +29,6 @@ export function useEditMode() {
   const { data: treeData } = useProjectTree(isEdit ? slug : null);
   const treeEntries = treeData?.entries ?? [];
 
-  // File content for the active selection. SWR keys by [slug, path] so
-  // switching files is a free cache hit when one's been opened before.
-  const { data: fileData } = useFileContent(slug, editor.selectedPath);
-
   const {
     write,
     removeFile: deleteFile,
@@ -42,29 +38,24 @@ export function useEditMode() {
     reveal,
   } = useEditorMutations(slug);
 
-  // Derived: SWR cache is ground truth. A buffer only exists while editing.
-  // dirty is parity against the server baseline — never stored, so it can't
-  // drift against the SWR cache.
-  const serverContent = fileData?.content;
   const dirty =
-    editor.buffer !== null && serverContent !== undefined && editor.buffer !== serverContent;
-  const fileContent = editor.buffer ?? serverContent ?? null;
+    editor.buffer !== null && editor.buffer !== editor.originalContent;
+  const fileContent = editor.buffer;
 
-  // Refs so the streaming-finished effect and async delete/rename handlers see
-  // latest selectedPath/dirty without re-subscribing or stale-closure risk.
   const wasStreaming = useRef(false);
   const selectedPathRef = useLatestRef(editor.selectedPath);
   const dirtyRef = useLatestRef(dirty);
 
-  // Pending navigation while unsaved dialog is shown
-  const [pendingPath, setPendingPath] = useState<string | null>(null);
+  // Last-write-wins: if a newer selection supersedes an in-flight fetch,
+  // drop the stale payload rather than flashing old content into the new slot.
+  const pendingSelectionRef = useRef<string | null>(null);
 
-  // Pending delete confirmation
+  const [pendingPath, setPendingPath] = useState<string | null>(null);
   const [deleteConfirmPath, setDeleteConfirmPath] = useState<string | null>(null);
   const [deleteConfirmDir, setDeleteConfirmDir] = useState<string | null>(null);
 
-  // Refetch tree + active file when an agent stream finishes (it may have
-  // edited files behind our back).
+  // Refetch tree + active file when an agent stream finishes — it may have
+  // edited files behind our back.
   useEffect(() => {
     if (stream.isStreaming) {
       wasStreaming.current = true;
@@ -74,15 +65,29 @@ export function useEditMode() {
     wasStreaming.current = false;
     if (!isEdit || !slug) return;
     void mutate(qk.projectTree(slug));
-    if (selectedPathRef.current && !dirtyRef.current) {
-      void mutate(qk.projectFile(slug, selectedPathRef.current));
-    }
-  }, [stream.isStreaming, isEdit, slug, mutate, selectedPathRef, dirtyRef]);
+    const path = selectedPathRef.current;
+    if (!path || dirtyRef.current) return;
+    void (async () => {
+      const { content } = await readProjectFile(slug, path);
+      editorDispatch({ type: "EXTERNAL_REFRESH", path, content });
+    })();
+  }, [stream.isStreaming, isEdit, slug, mutate, selectedPathRef, dirtyRef, editorDispatch]);
 
-  // Clear editor on project switch (don't carry stale selection across projects).
   useEffect(() => {
+    // Cross-project contamination guard: an in-flight fetch from the
+    // previous project would otherwise dispatch SELECT_FILE into the new
+    // project's state if its path happens to match the guard lane.
+    pendingSelectionRef.current = null;
     editorDispatch({ type: "CLEAR" });
   }, [slug, editorDispatch]);
+
+  const fetchAndSelect = async (path: string) => {
+    if (!slug) return;
+    pendingSelectionRef.current = path;
+    const { content } = await readProjectFile(slug, path);
+    if (pendingSelectionRef.current !== path) return;
+    editorDispatch({ type: "SELECT_FILE", path, content });
+  };
 
   const selectFile = (path: string) => {
     if (path === editor.selectedPath) return;
@@ -90,43 +95,40 @@ export function useEditMode() {
       setPendingPath(path);
       return;
     }
-    editorDispatch({ type: "SELECT_FILE", path });
+    void fetchAndSelect(path);
   };
 
   const saveCurrentFile = async () => {
     if (!slug || !editor.selectedPath || editor.buffer === null) return;
     const saved = editor.buffer;
     await write(editor.selectedPath, saved);
-    // Conditional drop: if the user typed more during the await, keep their
-    // buffer — dirty will re-derive against the new serverContent.
-    editorDispatch({ type: "DISCARD_BUFFER", ifEquals: saved });
+    editorDispatch({ type: "FILE_SAVED", savedContent: saved });
   };
 
   const handleDocChange = (content: string) => {
     editorDispatch({ type: "UPDATE_BUFFER", content });
   };
 
-  // Unsaved dialog handlers
-  const handleUnsavedSave = async () => {
-    await saveCurrentFile();
-    if (pendingPath) {
-      editorDispatch({ type: "SELECT_FILE", path: pendingPath });
-      setPendingPath(null);
-    }
+  const navigatePending = async () => {
+    if (!pendingPath) return;
+    const target = pendingPath;
+    setPendingPath(null);
+    await fetchAndSelect(target);
   };
 
-  const handleUnsavedDiscard = () => {
-    if (pendingPath) {
-      editorDispatch({ type: "SELECT_FILE", path: pendingPath });
-      setPendingPath(null);
-    }
+  const handleUnsavedSave = async () => {
+    await saveCurrentFile();
+    await navigatePending();
+  };
+
+  const handleUnsavedDiscard = async () => {
+    await navigatePending();
   };
 
   const handleUnsavedCancel = () => {
     setPendingPath(null);
   };
 
-  // Delete flow
   const requestDeleteFile = (path: string) => {
     setDeleteConfirmPath(path);
   };
@@ -136,6 +138,11 @@ export function useEditMode() {
     try {
       await deleteFile(deleteConfirmPath);
       if (selectedPathRef.current === deleteConfirmPath) {
+        // Prevent a late fetchAndSelect response from resurrecting the
+        // just-deleted path via SELECT_FILE.
+        if (pendingSelectionRef.current === deleteConfirmPath) {
+          pendingSelectionRef.current = null;
+        }
         editorDispatch({ type: "DESELECT_FILE" });
       }
     } finally {
@@ -147,7 +154,6 @@ export function useEditMode() {
     setDeleteConfirmPath(null);
   };
 
-  // Folder delete flow
   const requestDeleteDir = (path: string) => {
     setDeleteConfirmDir(path);
   };
@@ -156,10 +162,16 @@ export function useEditMode() {
     if (!slug || !deleteConfirmDir) return;
     try {
       await deleteDir(deleteConfirmDir);
-      if (selectedPathRef.current && (
-        selectedPathRef.current === deleteConfirmDir ||
-        selectedPathRef.current.startsWith(deleteConfirmDir + "/")
-      )) {
+      const selected = selectedPathRef.current;
+      const affected = !!selected && (
+        selected === deleteConfirmDir ||
+        selected.startsWith(deleteConfirmDir + "/")
+      );
+      if (affected) {
+        const pending = pendingSelectionRef.current;
+        if (pending && (pending === deleteConfirmDir || pending.startsWith(deleteConfirmDir + "/"))) {
+          pendingSelectionRef.current = null;
+        }
         editorDispatch({ type: "DESELECT_FILE" });
       }
     } finally {
@@ -171,14 +183,21 @@ export function useEditMode() {
     setDeleteConfirmDir(null);
   };
 
-  // Rename
   const renameEntry = async (oldPath: string, newName: string) => {
     if (!slug) return;
     const parentPath = oldPath.includes("/") ? oldPath.substring(0, oldPath.lastIndexOf("/")) : null;
     const newPath = parentPath ? `${parentPath}/${newName}` : newName;
     await rename(oldPath, newPath);
 
-    // Update selectedPath if the renamed item is the open file or a parent folder.
+    // Translate any in-flight selection fetch to the renamed path so its
+    // response isn't dropped-or-worse, dispatched under the stale path.
+    const pending = pendingSelectionRef.current;
+    if (pending === oldPath) {
+      pendingSelectionRef.current = newPath;
+    } else if (pending && pending.startsWith(oldPath + "/")) {
+      pendingSelectionRef.current = newPath + pending.slice(oldPath.length);
+    }
+
     const selected = selectedPathRef.current;
     if (selected) {
       if (selected === oldPath) {
@@ -189,12 +208,14 @@ export function useEditMode() {
     }
   };
 
-  // Create file / dir
   const createFileInDir = async (dirPath: string | null, fileName: string) => {
     if (!slug) return;
     const filePath = dirPath ? `${dirPath}/${fileName}` : fileName;
     await write(filePath, "");
-    editorDispatch({ type: "SELECT_FILE", path: filePath });
+    // Known-empty; skip the read round-trip. Claim the guard lane so any
+    // in-flight fetchAndSelect that resolves after this point is dropped.
+    pendingSelectionRef.current = filePath;
+    editorDispatch({ type: "SELECT_FILE", path: filePath, content: "" });
   };
 
   const createDirInDir = async (parentPath: string | null, dirName: string) => {
@@ -216,26 +237,20 @@ export function useEditMode() {
     selectFile,
     saveCurrentFile,
     handleDocChange,
-    // Unsaved dialog
     unsavedDialogOpen: pendingPath !== null,
     handleUnsavedSave,
     handleUnsavedDiscard,
     handleUnsavedCancel,
-    // Delete dialog
     deleteConfirmPath,
     requestDeleteFile,
     confirmDeleteFile,
     cancelDeleteFile,
-    // Reveal in explorer
     revealFile,
-    // Folder delete dialog
     deleteConfirmDir,
     requestDeleteDir,
     confirmDeleteDir,
     cancelDeleteDir,
-    // Rename
     renameEntry,
-    // Create
     createFileInDir,
     createDirInDir,
   };

--- a/apps/webui/src/client/shared/queryKeys.ts
+++ b/apps/webui/src/client/shared/queryKeys.ts
@@ -31,7 +31,6 @@ export const qk = {
 
   // --- Editor (file system) ---
   projectTree:     (slug: string)              => ["projectTree", slug] as const,
-  projectFile:     (slug: string, path: string) => ["projectFile", slug, path] as const,
 
   // --- Templates ---
   templates:       ()                          => ["templates"] as const,
@@ -46,8 +45,8 @@ export type QueryKey = readonly [string, ...unknown[]];
 /**
  * Predicate for `mutate()` that matches every cache entry tagged with a
  * given project slug. Entity convention: slug lives at `key[1]` for
- * per-project keys (`sessions`, `session`, `skills`, `projectTree`,
- * `projectFile`, etc.), so wiping a project is a single predicate eviction.
+ * per-project keys (`sessions`, `session`, `skills`, `projectTree`, etc.),
+ * so wiping a project is a single predicate eviction.
  */
 export const matchesSlug =
   (slug: string) =>

--- a/apps/webui/src/client/shared/swr.tsx
+++ b/apps/webui/src/client/shared/swr.tsx
@@ -33,7 +33,6 @@ function buildRoute(entity: string, args: unknown[]): string {
     case "onboarding":      return "/config/onboarding";
     // editor
     case "projectTree":     return `/projects/${enc(args[0])}/tree`;
-    case "projectFile":     return `/projects/${enc(args[0])}/file?path=${enc(args[1])}`;
     // templates
     case "templates":       return "/templates";
     case "templateReadme":  return `/templates/${enc(args[0])}/readme`;


### PR DESCRIPTION
## Summary

9d840215의 SWR 이주 이후 에디터에 반복된 회귀 버그들의 근본 원인을 제거합니다. SWR은 읽기 전용 + 서버-진실 엔티티에 맞는 모델인데, 에디터 콘텐츠는 **양방향**(CodeMirror doc이 또 다른 진실) + **이종 파일**(텍스트/이미지)이라 SWR의 단일 fetcher·단일 `keepPreviousData` 정책과 구조적으로 어긋납니다. 그 간극을 메우려고 쌓인 파생 state + useEffect 브리지가 다음 회귀들의 공통 원인이었습니다:

- 처음 연 파일이 자동으로 dirty 표시 (`UPDATE_LOCAL_CONTENT`가 `dirty: true` 무조건 dispatch)
- `keepPreviousData: true`로 이미지 → md 전환 시 이전 이미지 바이너리의 UTF-8 디코딩 쓰레기가 잠시 노출
- `keepPreviousData: false`로 바꾸니 빈 프레임 flicker 재발
- 외부 content sync useEffect가 keystroke마다 O(n) serialize

브리지를 제거하고 **에디터 콘텐츠를 `EditorState`가 직접 소유**하는 client-first 동기 pre-fetch 모델로 되돌립니다. `selectFile`이 `readProjectFile`을 await한 뒤 atomic `SELECT_FILE { path, content }`을 dispatch — path와 content가 **같은 프레임**에 교체되므로 flicker / wrong encoding / dirty mis-flag가 구조적으로 소멸합니다.

## 주요 변경

### entities/editor/
- `EditorState`에 `originalContent` 추가. `buffer`는 편집용 live doc, `dirty = buffer !== originalContent` 파생
- reducer actions: `SELECT_FILE { path, content }`, `FILE_SAVED { savedContent }` (baseline shift + no-op guard), `EXTERNAL_REFRESH { path, content }` (stale selection guard)
- 구 `DISCARD_BUFFER` 제거
- `useFileContent` 훅 삭제. `useEditorMutations`는 tree revalidation을 **fire-and-forget** (`void mutate`) — save→다음 파일 open 경로의 직렬 대기 제거

### features/editor/useEditMode.ts
- `fetchAndSelect` 헬퍼: `pendingSelectionRef`로 last-write-wins 가드. 빠른 연속 클릭 시 stale fetch 응답이 새 선택을 덮어쓰지 못함
- Post-stream refresh를 `readProjectFile` + `EXTERNAL_REFRESH` dispatch로 교체
- `navigatePending` 헬퍼로 save/discard 플로우 공통화
- **Race guard 동기화**: delete/slug-switch/rename 전이 시 `pendingSelectionRef`를 초기화하거나 재매핑. in-flight fetch 응답이 transition 이후의 state를 오염시키는 3가지 race 방어 (삭제된 파일 부활, 프로젝트 간 오염, rename된 파일 revert)

### shared/
- `qk.projectFile` 키 제거 (zero references)
- `buildRoute`의 `projectFile` case 제거

## 영향 범위

- Editor 모듈만. Projects/Sessions/Config/Templates 등 다른 SWR 엔티티는 변경 없음
- `useProjectTree`는 그대로 SWR 유지 (트리는 읽기 중심 리스트로 SWR 모델과 잘 맞음)

## 테스트 계획

- [x] \`bunx tsc --noEmit\` (apps/webui)
- [x] \`bun run lint\`
- [x] \`bun run test\` — 44 pass
- [x] 브라우저 수동 검증:
  - 이미지(wary.jpg) → 마크다운(alana.md) atomic 전환, UTF-8 쓰레기 flicker 없음
  - 타이핑 시 focus 유지, dirty dot 표시
  - Ctrl+Z undo 정상, undo 시 dirty 해제
  - 편집 중 다른 파일 클릭 → unsaved dialog → 버리기 → 네비게이션, 원본 파일 edits 버려짐 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)