### PR TITLE
perf(editor): CodeMirror로 buffer 승격해 keystroke당 리렌더 제거

### DIFF
--- a/apps/webui/src/client/entities/editor/EditorContext.tsx
+++ b/apps/webui/src/client/entities/editor/EditorContext.tsx
@@ -10,7 +10,7 @@ import type { EditorState, EditorAction } from "./editor.types.js";
 const initialState: EditorState = {
   selectedPath: null,
   originalContent: null,
-  buffer: null,
+  dirty: false,
 };
 
 function editorReducer(state: EditorState, action: EditorAction): EditorState {
@@ -19,21 +19,20 @@ function editorReducer(state: EditorState, action: EditorAction): EditorState {
       return {
         selectedPath: action.path,
         originalContent: action.content,
-        buffer: action.content,
+        dirty: false,
       };
-    case "UPDATE_BUFFER":
-      return { ...state, buffer: action.content };
+    case "MARK_DIRTY":
+      // Idempotent — returning the same reference makes useReducer bail out,
+      // so repeat fires from CodeMirror's updateListener don't propagate.
+      return state.dirty ? state : { ...state, dirty: true };
     case "FILE_SAVED":
-      // Buffer is intentionally preserved so edits made during the write
-      // round-trip survive; dirty re-derives against the new baseline.
-      if (state.originalContent === action.savedContent) return state;
-      return { ...state, originalContent: action.savedContent };
+      return { ...state, originalContent: action.savedContent, dirty: false };
     case "EXTERNAL_REFRESH":
       // Drop if selection moved during the refresh fetch.
       if (state.selectedPath !== action.path) return state;
-      return { ...state, originalContent: action.content, buffer: action.content };
+      return { ...state, originalContent: action.content, dirty: false };
     case "DESELECT_FILE":
-      return { selectedPath: null, originalContent: null, buffer: null };
+      return initialState;
     case "RENAME_SELECTED":
       return { ...state, selectedPath: action.newPath };
     case "CLEAR":

--- a/apps/webui/src/client/entities/editor/editor.types.ts
+++ b/apps/webui/src/client/entities/editor/editor.types.ts
@@ -12,22 +12,31 @@ export interface TreeEntry {
 }
 
 /**
- * Invariant: `selectedPath` set ⇔ `originalContent` and `buffer` set.
- * SELECT_FILE carries the content payload, so there is no transient
- * "selected but empty" state that sync effects would otherwise need to
- * paper over. `dirty` is derived (`buffer !== originalContent`).
+ * CodeMirror owns the live buffer; React tracks only the baseline
+ * (`originalContent`) and a sticky `dirty` flag. `dirty` flips to true on the
+ * first user edit of a session and stays true until SELECT_FILE / FILE_SAVED
+ * / EXTERNAL_REFRESH / DESELECT_FILE clears it — round-trips back to baseline
+ * don't clear it, keeping keystroke comparisons out of the hot path.
  */
 export interface EditorState {
   selectedPath: string | null;
   originalContent: string | null;
-  buffer: string | null;
+  dirty: boolean;
 }
 
 export type EditorAction =
   | { type: "SELECT_FILE"; path: string; content: string }
-  | { type: "UPDATE_BUFFER"; content: string }
+  | { type: "MARK_DIRTY" }
   | { type: "FILE_SAVED"; savedContent: string }
   | { type: "EXTERNAL_REFRESH"; path: string; content: string }
   | { type: "DESELECT_FILE" }
   | { type: "RENAME_SELECTED"; newPath: string }
   | { type: "CLEAR" };
+
+/**
+ * Imperative handle exposed by FileEditor. `getContent` returns the live
+ * CodeMirror doc; returns null before mount or after unmount.
+ */
+export interface EditorAPI {
+  getContent: () => string | null;
+}

--- a/apps/webui/src/client/entities/editor/index.ts
+++ b/apps/webui/src/client/entities/editor/index.ts
@@ -1,6 +1,6 @@
 export { EditorProvider, useEditorState, useEditorDispatch } from "./EditorContext.js";
 export { fetchProjectTree, readProjectFile, writeProjectFile, deleteProjectFile, revealProjectFile, deleteProjectDir, renameProjectEntry, createProjectDir } from "./editor.api.js";
-export type { TreeEntry, EditorState, EditorAction } from "./editor.types.js";
+export type { TreeEntry, EditorState, EditorAction, EditorAPI } from "./editor.types.js";
 export { IMAGE_EXTS, isImagePath } from "./editor.types.js";
 export { buildTree, FileIcon, type TreeNode } from "./file-tree.utils.js";
 export { useProjectTree, useEditorMutations } from "./useEditor.js";

--- a/apps/webui/src/client/features/editor/EditModePanel.tsx
+++ b/apps/webui/src/client/features/editor/EditModePanel.tsx
@@ -4,6 +4,7 @@ import { FileEditor } from "./FileEditor.js";
 import { UnsavedDialog } from "./UnsavedDialog.js";
 import { DeleteConfirmDialog } from "./DeleteConfirmDialog.js";
 import { ResizeHandle } from "@/client/shared/ui/ResizeHandle.js";
+import type { EditorAPI } from "@/client/entities/editor/index.js";
 import { useEditMode } from "./useEditMode.js";
 
 const DEFAULT_TREE_WIDTH = 200;
@@ -11,14 +12,15 @@ const MIN_TREE_WIDTH = 140;
 const MAX_TREE_WIDTH = 400;
 
 export function EditModePanel() {
+  const editorApiRef = useRef<EditorAPI | null>(null);
   const {
     treeEntries,
     selectedPath,
-    fileContent,
+    baseline,
     dirty,
     selectFile,
     saveCurrentFile,
-    handleDocChange,
+    markDirty,
     unsavedDialogOpen,
     handleUnsavedSave,
     handleUnsavedDiscard,
@@ -35,7 +37,7 @@ export function EditModePanel() {
     renameEntry,
     createFileInDir,
     createDirInDir,
-  } = useEditMode();
+  } = useEditMode(editorApiRef);
 
   const [treeWidth, setTreeWidth] = useState(DEFAULT_TREE_WIDTH);
   const dragStartRef = useRef(0);
@@ -74,10 +76,11 @@ export function EditModePanel() {
       {/* Editor panel */}
       <div className="flex-1 flex flex-col min-w-0 bg-surface/30 transition-colors duration-300">
         <FileEditor
+          editorRef={editorApiRef}
           path={selectedPath}
-          content={fileContent}
+          baseline={baseline}
           dirty={dirty}
-          onDocChange={handleDocChange}
+          onMarkDirty={markDirty}
           onSave={saveCurrentFile}
         />
       </div>

--- a/apps/webui/src/client/features/editor/FileEditor.tsx
+++ b/apps/webui/src/client/features/editor/FileEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { EditorView, keymap, highlightActiveLine, highlightActiveLineGutter } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
 import { defaultKeymap, indentWithTab, history, historyKeymap } from "@codemirror/commands";
@@ -24,9 +24,11 @@ import {
 } from "@codemirror/autocomplete";
 import { useI18n } from "@/client/i18n/index.js";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
-import { isImagePath } from "@/client/entities/editor/index.js";
+import { isImagePath, type EditorAPI } from "@/client/entities/editor/index.js";
 import { estimateTokens, formatTokens } from "@/client/shared/pricing.utils.js";
 import { useLatestRef } from "@/client/shared/useLatestRef.js";
+
+const TOKEN_DEBOUNCE_MS = 300;
 
 // --- Obsidian Teal theme (from former TextEditor) ---
 
@@ -231,30 +233,36 @@ function rendererCompletions(context: CompletionContext): CompletionResult | nul
 
 interface FileEditorProps {
   path: string | null;
-  content: string | null;
+  baseline: string | null;
   dirty: boolean;
-  onDocChange: (content: string) => void;
+  onMarkDirty: () => void;
   onSave: () => Promise<void>;
+  editorRef: RefObject<EditorAPI | null>;
 }
 
-export function FileEditor({ path, content, dirty, onDocChange, onSave }: FileEditorProps) {
+export function FileEditor({ path, baseline, dirty, onMarkDirty, onSave, editorRef }: FileEditorProps) {
   const { t } = useI18n();
   const project = useProjectSelectionState();
   const containerRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
-  const onDocChangeRef = useLatestRef(onDocChange);
+  const onMarkDirtyRef = useLatestRef(onMarkDirty);
   const onSaveRef = useLatestRef(onSave);
   const dirtyRef = useLatestRef(dirty);
+  // True while the sync effect applies a programmatic doc swap — keeps the
+  // updateListener from mis-attributing it as a user edit.
+  const suppressDirtyRef = useRef(false);
+  const tokenTimerRef = useRef<number | null>(null);
   const [tokenCount, setTokenCount] = useState<number | null>(null);
 
   const language = path ? detectLanguage(path) : undefined;
-  const hasContent = content !== null;
+  const hasBaseline = baseline !== null;
 
-  // Create / destroy EditorView when path changes or content first loads.
-  // hasContent toggles the effect on null→value transition so the view is built
-  // once content arrives; subsequent value→value edits don't re-run (would destroy focus/history).
+  // Create / destroy EditorView when path changes or baseline first loads.
+  // hasBaseline toggles the effect on null→value transition so the view is built
+  // once content arrives; subsequent baseline changes (external refresh, save)
+  // flow through the sync effect below and don't tear down the view.
   useEffect(() => {
-    if (!containerRef.current || !path || content === null || isImagePath(path)) return;
+    if (!containerRef.current || !path || baseline === null || isImagePath(path)) return;
 
     const saveKeymap = keymap.of([{
       key: "Mod-s",
@@ -265,18 +273,28 @@ export function FileEditor({ path, content, dirty, onDocChange, onSave }: FileEd
     }]);
 
     const updateListener = EditorView.updateListener.of((update) => {
-      if (update.docChanged) {
-        const text = update.state.doc.toString();
-        onDocChangeRef.current(text);
-        setTokenCount(estimateTokens(text));
+      if (!update.docChanged) return;
+
+      if (!suppressDirtyRef.current && !dirtyRef.current) {
+        onMarkDirtyRef.current();
       }
+
+      // Debounce the token estimate — estimateTokens is O(n) per char and
+      // was dominating keystroke cost. Only recompute once typing settles.
+      if (tokenTimerRef.current !== null) {
+        clearTimeout(tokenTimerRef.current);
+      }
+      tokenTimerRef.current = window.setTimeout(() => {
+        const v = viewRef.current;
+        if (v) setTokenCount(estimateTokens(v.state.doc.toString()));
+        tokenTimerRef.current = null;
+      }, TOKEN_DEBOUNCE_MS);
     });
 
-    // eslint-disable-next-line react-hooks/set-state-in-effect -- 에디터 생성 시 초기 토큰 수 설정
-    setTokenCount(estimateTokens(content));
+    setTokenCount(estimateTokens(baseline));
 
     const state = EditorState.create({
-      doc: content,
+      doc: baseline,
       extensions: [
         saveKeymap,
         keymap.of([
@@ -310,27 +328,44 @@ export function FileEditor({ path, content, dirty, onDocChange, onSave }: FileEd
 
     const view = new EditorView({ state, parent: containerRef.current });
     viewRef.current = view;
+    editorRef.current = {
+      getContent: () => viewRef.current?.state.doc.toString() ?? null,
+    };
 
     return () => {
+      if (tokenTimerRef.current !== null) {
+        clearTimeout(tokenTimerRef.current);
+        tokenTimerRef.current = null;
+      }
       view.destroy();
       viewRef.current = null;
+      editorRef.current = null;
     };
-  }, [path, language, hasContent]); // eslint-disable-line react-hooks/exhaustive-deps -- content used only for initial doc; save/docChange via refs
+  }, [path, language, hasBaseline]); // eslint-disable-line react-hooks/exhaustive-deps -- baseline used only for initial doc; save/markDirty via refs
 
-  // Sync external content changes (e.g. agent wrote to this file).
-  // dirtyRef guard goes before `doc.toString()` because this effect fires on
-  // every keystroke (content prop is a fresh string); skipping the O(n)
-  // serialize when we know the update originated from the user's own typing.
+  // Sync baseline → CodeMirror doc. With buffer lifted out of React, baseline
+  // only changes on SELECT_FILE / FILE_SAVED / EXTERNAL_REFRESH, so this effect
+  // stays off the keystroke path entirely.
   useEffect(() => {
     const view = viewRef.current;
-    if (!view || content === null || dirtyRef.current) return;
+    if (!view || baseline === null) return;
     const currentDoc = view.state.doc.toString();
-    if (currentDoc !== content) {
+    if (currentDoc === baseline) return;
+
+    suppressDirtyRef.current = true;
+    try {
       view.dispatch({
-        changes: { from: 0, to: view.state.doc.length, insert: content },
+        changes: { from: 0, to: view.state.doc.length, insert: baseline },
       });
+      if (tokenTimerRef.current !== null) {
+        clearTimeout(tokenTimerRef.current);
+        tokenTimerRef.current = null;
+      }
+      setTokenCount(estimateTokens(baseline));
+    } finally {
+      suppressDirtyRef.current = false;
     }
-  }, [content, dirtyRef]);
+  }, [baseline]);
 
   // No file selected
   if (!path) {

--- a/apps/webui/src/client/features/editor/useEditMode.ts
+++ b/apps/webui/src/client/features/editor/useEditMode.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type RefObject } from "react";
 import { useSWRConfig } from "swr";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
 import { useActiveStream } from "@/client/entities/stream/index.js";
@@ -9,11 +9,12 @@ import {
   useProjectTree,
   useEditorMutations,
   readProjectFile,
+  type EditorAPI,
 } from "@/client/entities/editor/index.js";
 import { qk } from "@/client/shared/queryKeys.js";
 import { useLatestRef } from "@/client/shared/useLatestRef.js";
 
-export function useEditMode() {
+export function useEditMode(editorApiRef: RefObject<EditorAPI | null>) {
   const ui = useUIState();
   const project = useProjectSelectionState();
   const stream = useActiveStream();
@@ -38,9 +39,8 @@ export function useEditMode() {
     reveal,
   } = useEditorMutations(slug);
 
-  const dirty =
-    editor.buffer !== null && editor.buffer !== editor.originalContent;
-  const fileContent = editor.buffer;
+  const dirty = editor.dirty;
+  const baseline = editor.originalContent;
 
   const wasStreaming = useRef(false);
   const selectedPathRef = useLatestRef(editor.selectedPath);
@@ -99,14 +99,22 @@ export function useEditMode() {
   };
 
   const saveCurrentFile = async () => {
-    if (!slug || !editor.selectedPath || editor.buffer === null) return;
-    const saved = editor.buffer;
+    if (!slug || !editor.selectedPath) return;
+    const saved = editorApiRef.current?.getContent();
+    if (saved == null) return;
     await write(editor.selectedPath, saved);
     editorDispatch({ type: "FILE_SAVED", savedContent: saved });
+    // If the user kept typing during the write round-trip, FILE_SAVED's
+    // dirty-clear would falsely signal "clean"; re-mark so the indicator
+    // reflects the un-persisted edits.
+    const current = editorApiRef.current?.getContent();
+    if (current != null && current !== saved) {
+      editorDispatch({ type: "MARK_DIRTY" });
+    }
   };
 
-  const handleDocChange = (content: string) => {
-    editorDispatch({ type: "UPDATE_BUFFER", content });
+  const markDirty = () => {
+    editorDispatch({ type: "MARK_DIRTY" });
   };
 
   const navigatePending = async () => {
@@ -232,11 +240,11 @@ export function useEditMode() {
   return {
     treeEntries,
     selectedPath: editor.selectedPath,
-    fileContent,
+    baseline,
     dirty,
     selectFile,
     saveCurrentFile,
-    handleDocChange,
+    markDirty,
     unsavedDialogOpen: pendingPath !== null,
     handleUnsavedSave,
     handleUnsavedDiscard,


### PR DESCRIPTION
## 배경

웹 UI 에디터에서 빠른 연속 입력(백스페이스 길게 누르기 등) 시 입력이 버벅인다. 이전 refactor 커밋(442b601 \"client-first 동기 모델로 회귀\") 이후에도 `buffer`가 React state에 남아있어 매 keystroke마다 아래 사슬이 돌고 있었다:

1. CodeMirror `updateListener` → `state.doc.toString()` (O(n) 직렬화)
2. `editorDispatch({ type: \"UPDATE_BUFFER\", content })` → `EditorContext` value 객체 교체
3. `setTokenCount(estimateTokens(text))` — estimateTokens는 문자별 O(n) 루프
4. `useEditMode()` 재실행 → `EditModePanel` → `FileTree` + `FileEditor` 전체 리렌더

`useReducer`가 매번 새 state 객체를 반환하므로 React Compiler도 context value identity 교체를 막지 못한다. **CodeMirror가 이미 텍스트의 source of truth이므로 `buffer`를 React state에 이중 저장할 이유가 없다** — 이 관찰에서 출발한 수정.

## 변경 요약

### State 모델 단순화
- `EditorState`에서 `buffer: string | null` 제거, `dirty: boolean` 추가
- `UPDATE_BUFFER` 액션 → `MARK_DIRTY` (idempotent: 이미 dirty면 같은 state 식별자 반환 → useReducer bail-out)
- `dirty`는 sticky — 한 번 true면 SELECT_FILE / FILE_SAVED / EXTERNAL_REFRESH / DESELECT_FILE에서만 clear. 원본으로 복귀해도 유지 (keystroke 경로에서 O(n) 문자열 비교 제거)

### CodeMirror → React 통신은 이제 edge-trigger
- FileEditor가 `EditorAPI = { getContent: () => string | null }`를 ref prop으로 노출
- `updateListener`: dirty 미설정 상태에서만 `onMarkDirty()` 1회 호출, 이후 모든 keystroke는 ref guard로 no-op
- `saveCurrentFile`: `editorApiRef.current?.getContent()`로 live buffer 조회
- sync effect는 baseline 변경 시에만 발화 (SELECT_FILE / FILE_SAVED / EXTERNAL_REFRESH) — programmatic `view.dispatch`는 `suppressDirtyRef`로 가드해 markDirty 오인 방지

### 토큰 카운트 300ms debounce
- estimateTokens가 keystroke당 핫패스를 지배 — 타이핑 정착 후 1회만 계산
- 파일 선택/external refresh 시에는 즉시 갱신

### Save race 보정
- save 중 유저가 추가 편집한 경우 FILE_SAVED가 dirty를 잘못 clear하지 않도록 post-save에 `getContent()` 재조회 → 저장된 값과 다르면 재-MARK_DIRTY

## 관찰된 효과

- 1800줄 renderer.ts(~11k 토큰)에서 rapid backspace · 연속 타이핑 스무딩 확인
- dirty 플립, save, UnsavedDialog, 파일 전환, 이미지 파일 렌더 시나리오 회귀 없음
- 이론상 keystroke당 React 리렌더 0회(dirty 플립 1회 제외) + 300ms마다 토큰 카운트 commit 1회

## 변경 파일

- `apps/webui/src/client/entities/editor/editor.types.ts`
- `apps/webui/src/client/entities/editor/EditorContext.tsx`
- `apps/webui/src/client/entities/editor/index.ts` (`EditorAPI` re-export)
- `apps/webui/src/client/features/editor/FileEditor.tsx`
- `apps/webui/src/client/features/editor/EditModePanel.tsx`
- `apps/webui/src/client/features/editor/useEditMode.ts`

## 주의

- **의도된 UX 변경**: 원본과 동일한 상태로 타이핑+되돌리기를 해도 dirty 표시(\`•\`)가 유지됨. save까지 유지되는 sticky 플래그. keystroke 핫패스에서 O(n) 문자열 비교를 없애기 위한 설계 결정.
- out-of-scope: BottomInput 리사이징, StreamProvider 분리, FileTree의 buildTree 메모화(React Compiler 영역).

## Test plan

- [ ] 대형 파일(renderer.ts 등)에서 백스페이스 3초 이상 길게 누르기 — 끊김 없이 연속 삭제 확인
- [ ] 파일 열기 → 타이핑 → 헤더·트리에 \`•\` 즉시 표시
- [ ] Mod-S 저장 → \`•\` 사라짐, 디스크 반영 확인
- [ ] 저장 안 한 상태로 다른 파일 클릭 → UnsavedDialog → \"저장\"/\"버리기\" 모두 정상 동작
- [ ] 타이핑 멈춘 뒤 ~300ms 후 토큰 카운트 갱신
- [ ] 에이전트가 동일 파일 수정 후 스트림 종료 시 에디터 내용 자동 갱신, \`•\` 없음
- [ ] 이미지 파일(\`.png\` 등) 선택 시 미리보기 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)