### PR TITLE
context window 기본값을 모델 메타데이터에 연동

### DIFF
--- a/apps/webui/src/client/entities/config/config.constants.ts
+++ b/apps/webui/src/client/entities/config/config.constants.ts
@@ -1,5 +1,10 @@
 import type { CustomApiFormat } from "@agentchan/creative-agent";
 
+/** Fallback when the active model has no `contextWindow` (e.g. custom provider). */
+export const DEFAULT_CONTEXT_WINDOW = 128_000;
+/** Fallback when the active model has no `maxTokens` (e.g. custom provider). */
+export const DEFAULT_MAX_TOKENS = 16_000;
+
 export const FORMAT_OPTIONS: { value: CustomApiFormat; label: string }[] = [
   { value: "openai-completions", label: "OpenAI Completions" },
   { value: "anthropic-messages", label: "Anthropic Messages" },

--- a/apps/webui/src/client/entities/config/index.ts
+++ b/apps/webui/src/client/entities/config/index.ts
@@ -1,5 +1,5 @@
 export type { ProviderInfo, ModelInfo, ThinkingLevel, CustomProviderDef, CustomApiFormat } from "@agentchan/creative-agent";
-export { FORMAT_OPTIONS } from "./config.constants.js";
+export { FORMAT_OPTIONS, DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS } from "./config.constants.js";
 export {
   fetchConfig, updateConfig, fetchProviders,
   fetchApiKeys, updateApiKey, deleteApiKey,
@@ -9,5 +9,5 @@ export {
 } from "./config.api.js";
 export type { ApiKeyStatus, OAuthStatus, OAuthAuthInfo, LoginOAuthCallbacks } from "./config.api.js";
 export {
-  useConfig, useProviders, useApiKeys, useOauthStatus, useOnboarding, useConfigMutations,
+  useConfig, useProviders, useCurrentModel, useApiKeys, useOauthStatus, useOnboarding, useConfigMutations,
 } from "./useConfig.js";

--- a/apps/webui/src/client/entities/config/useConfig.ts
+++ b/apps/webui/src/client/entities/config/useConfig.ts
@@ -24,6 +24,20 @@ export function useProviders() {
   return useSWR<ProviderInfo[]>(qk.providers());
 }
 
+/**
+ * Resolve the ProviderInfo + ModelInfo objects pointed to by the active config.
+ * Returns `undefined` for either piece while the SWR caches are still loading
+ * or when the saved id no longer exists in the catalog (deleted custom provider,
+ * model removed from ALLOWED_MODELS, etc.).
+ */
+export function useCurrentModel() {
+  const { data: config } = useConfig();
+  const { data: providers = [] } = useProviders();
+  const provider = providers.find((p) => p.name === config?.provider);
+  const model = provider?.models.find((m) => m.id === config?.model);
+  return { provider, model };
+}
+
 export function useApiKeys() {
   return useSWR<ApiKeyStatus>(qk.apiKeys());
 }

--- a/apps/webui/src/client/features/chat/BottomInput.tsx
+++ b/apps/webui/src/client/features/chat/BottomInput.tsx
@@ -7,7 +7,7 @@ import {
   requestNotificationPermission,
 } from "@/client/shared/notifications.js";
 import { localStore } from "@/client/shared/storage.js";
-import { useConfig } from "@/client/entities/config/index.js";
+import { useConfig, useCurrentModel, DEFAULT_CONTEXT_WINDOW } from "@/client/entities/config/index.js";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import {
@@ -28,6 +28,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   const selection = useActiveSessionSelection();
   const usage = useActiveUsage();
   const { data: config } = useConfig();
+  const { model: currentModel } = useCurrentModel();
   const ui = useUIState();
   const uiDispatch = useUIDispatch();
   const { t } = useI18n();
@@ -40,7 +41,7 @@ export function BottomInput({ variant = "standalone" }: BottomInputProps) {
   const slash = useSlashCommands(text, setText);
 
   const contextTokens = usage.contextTokens;
-  const contextWindow = config?.contextWindow ?? 128_000;
+  const contextWindow = config?.contextWindow ?? currentModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
   const contextPercent = contextTokens > 0
     ? Math.round((contextTokens / contextWindow) * 100)
     : null;

--- a/apps/webui/src/client/features/settings/ModelBar.tsx
+++ b/apps/webui/src/client/features/settings/ModelBar.tsx
@@ -1,6 +1,13 @@
 import { useState } from "react";
 import { ChevronDown } from "lucide-react";
-import { useConfig, useProviders, useConfigMutations } from "@/client/entities/config/index.js";
+import {
+  useConfig,
+  useProviders,
+  useCurrentModel,
+  useConfigMutations,
+  DEFAULT_CONTEXT_WINDOW,
+  DEFAULT_MAX_TOKENS,
+} from "@/client/entities/config/index.js";
 import type { ThinkingLevel } from "@/client/entities/config/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { Badge, CollapsiblePanel, Select, FormField, SegmentedControl, TextInput } from "@/client/shared/ui/index.js";
@@ -15,6 +22,7 @@ const THINKING_LEVELS: { value: ThinkingLevel; label: string }[] = [
 export function ModelBar() {
   const { data: config } = useConfig();
   const { data: providers = [] } = useProviders();
+  const { provider: currentProvider, model: currentModel } = useCurrentModel();
   const { update } = useConfigMutations();
   const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
@@ -42,7 +50,6 @@ export function ModelBar() {
   // placeholder rather than a spurious "google/" line.
   const provider = config?.provider ?? "";
   const model = config?.model ?? "";
-  const currentProvider = providers.find((p) => p.name === provider);
 
   const handleProviderChange = (next: string) => void update({ provider: next });
   const handleModelChange = (next: string) => {
@@ -79,7 +86,6 @@ export function ModelBar() {
     void update({ thinkingLevel: level === "off" ? null : level });
   };
 
-  const currentModel = currentProvider?.models.find((m) => m.id === model);
   const showThinking = !!currentProvider?.custom || (currentModel?.reasoning ?? false);
 
   // Build compact param tags for collapsed view
@@ -185,7 +191,7 @@ export function ModelBar() {
               onChange={(e) => setMaxTokensInput(e.target.value)}
               onBlur={handleMaxTokensSubmit}
               onKeyDown={(e) => e.key === "Enter" && handleMaxTokensSubmit()}
-              placeholder="16000"
+              placeholder={String(currentModel?.maxTokens ?? DEFAULT_MAX_TOKENS)}
             />
           </FormField>
 
@@ -197,7 +203,7 @@ export function ModelBar() {
               onChange={(e) => setContextWindowInput(e.target.value)}
               onBlur={handleContextWindowSubmit}
               onKeyDown={(e) => e.key === "Enter" && handleContextWindowSubmit()}
-              placeholder="128000"
+              placeholder={String(currentModel?.contextWindow ?? DEFAULT_CONTEXT_WINDOW)}
             />
           </FormField>
 

--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -1,4 +1,4 @@
-import { getProviders, getModels } from "@agentchan/creative-agent";
+import { getProviders, getModels, type ModelInfo } from "@agentchan/creative-agent";
 import {
   getOAuthApiKey,
   getOAuthProvider,
@@ -7,6 +7,18 @@ import {
 } from "@mariozechner/pi-ai/oauth";
 import type { ServerConfig, ProviderInfo, CustomProviderDef } from "../types.js";
 import type { SettingsRepo } from "../repositories/settings.repo.js";
+
+type PiModel = ReturnType<typeof getModels>[number];
+
+function toModelInfo(m: PiModel): ModelInfo {
+  return {
+    id: m.id,
+    name: m.name,
+    reasoning: m.reasoning,
+    contextWindow: m.contextWindow,
+    maxTokens: m.maxTokens,
+  };
+}
 
 const BUILTIN_PROVIDERS = new Set([
   "google",
@@ -118,18 +130,12 @@ export function createConfigService(settingsRepo: SettingsRepo) {
         // OAuth provider (e.g. github-copilot): model list comes from pi-ai as-is,
         // but hidden until user signs in so selecting it can't silently fail.
         if (OAUTH_PROVIDERS.has(name)) {
-          const models = hasOAuthCredentials(name)
-            ? getModels(name).map((m) => ({ id: m.id, name: m.name, reasoning: m.reasoning }))
-            : [];
+          const models = hasOAuthCredentials(name) ? getModels(name).map(toModelInfo) : [];
           return { name, defaultModel: models[0]?.id ?? "", models, oauth: true };
         }
         const models = getModels(name)
           .filter((m) => ALLOWED_MODELS.has(m.id))
-          .map((m) => ({
-            id: m.id,
-            name: m.name,
-            reasoning: m.reasoning,
-          }));
+          .map(toModelInfo);
         return {
           name,
           defaultModel: models[0]?.id ?? "",

--- a/packages/creative-agent/src/config-types.ts
+++ b/packages/creative-agent/src/config-types.ts
@@ -4,6 +4,10 @@ export interface ModelInfo {
   id: string;
   name: string;
   reasoning: boolean;
+  /** Model's max input context (tokens). Absent for custom providers. */
+  contextWindow?: number;
+  /** Model's max single-turn output (tokens). Absent for custom providers. */
+  maxTokens?: number;
 }
 
 export type CustomApiFormat =


### PR DESCRIPTION
## Summary

- ModelBar의 Context Window/Max Tokens placeholder와 BottomInput의 fallback이 하드코딩 `128000`/`16000`을 쓰던 것을 pi-ai의 `Model.contextWindow` / `Model.maxTokens` 기반으로 동적 표시하도록 변경
- 사용자 명시 설정이 없을 때 BottomInput의 "context %" 계산 분모가 모델 max(예: gemini-3-flash-preview의 1,048,576)로 동작 — 기존엔 1M 컨텍스트 모델인데도 128k 기준 분모라 비율이 과장되었음
- Custom provider(pi-ai 메타가 없음)는 종전 안전망 `128000`/`16000` 유지

## 변경 요약

### 데이터 흐름 확장
- `ModelInfo`에 optional `contextWindow?`/`maxTokens?` 추가 (custom provider 호환)
- 서버 `buildProviderList()`가 두 분기(OAuth/built-in)에서 `toModelInfo` 헬퍼로 통일하여 5필드 매핑 중복 제거

### 클라이언트 셀렉터 추출
- `entities/config/useCurrentModel()` — `useConfig` + `useProviders`를 합성해 `{ provider, model }` 반환. SWR 키 dedup으로 추가 fetch 없음
- `DEFAULT_CONTEXT_WINDOW` / `DEFAULT_MAX_TOKENS` 상수로 magic number 통합
- ModelBar/BottomInput이 inline `providers.find().models.find()` 중복을 제거하고 셀렉터·상수 사용

## 설계 노트

- **에이전트 실행 경로(orchestrator.ts)는 손대지 않음** — 이미 `config.contextWindow !== undefined`일 때만 사용자 값으로 override하고 그렇지 않으면 `model.contextWindow`(pi-ai)를 그대로 쓰는 올바른 동작이었음. 진짜 문제는 클라이언트가 모델 메타를 못 본다는 것뿐이라 ProviderInfo→ModelInfo 표면을 넓히는 것으로 해결
- React Compiler 환경이므로 `useMemo`/`useCallback` 추가하지 않음 (CLAUDE.md 컨벤션)
- Custom provider 호환성은 optional 필드 + 폴백 체인으로 자동 보장 (타입 시스템이 `?? DEFAULT_CONTEXT_WINDOW` 강제)

## Test plan

수동 브라우저 검증으로 5개 시나리오 통과:
- [x] 기본 모델(gemini-3-flash-preview) 선택 시 Context Window placeholder=`1048576`, Max Tokens placeholder=`65536` 표시
- [x] 입력값 Clear → placeholder가 모델 max로 복귀 (서버 DB에서 `contextWindow` 필드 삭제 확인)
- [x] Provider/Model 변경(google→anthropic→opus→haiku) 시 placeholder가 각 모델 max로 즉시 갱신
- [x] BottomInput "context 0%" 표시 (4.2k 입력 / 1,048,576 모델 max = 0.4% → 반올림 0%, 종전 128k 기준이라면 3% 표시되었을 것)
- [x] Custom provider(메타 없음) 전환 시 placeholder=`128000`/`16000` 폴백 유지

빌드 검증:
- [x] `bunx tsc --noEmit` (apps/webui + packages/creative-agent)
- [x] `bun run lint` (eslint 통과)
- [x] `bun run test` (creative-agent 도구 단위 테스트 44 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)