### PR TITLE
sec(creative-agent): 도구 7종 path containment 1차 방어선

### DIFF
--- a/packages/creative-agent/src/tools/_paths.ts
+++ b/packages/creative-agent/src/tools/_paths.ts
@@ -1,0 +1,28 @@
+import { resolve, relative, sep, isAbsolute } from "node:path";
+
+/**
+ * Resolve `userPath` relative to `projectDir`, throwing if the result escapes
+ * the project directory. Pure lexical check — does not follow symlinks.
+ *
+ * Rejects: absolute paths, parent traversal (`../foo`), and Windows
+ * alternate-drive paths (which `relative()` returns as absolute).
+ *
+ * Allows: empty string and "." (= projectDir itself), and any path that
+ * lexically resolves inside projectDir.
+ *
+ * Distinct from the server's `resolveProjectFile` (project.repo.ts), which
+ * returns `null` for HTTP 404 mapping and adds a `HIDDEN_ROOTS` policy. This
+ * tool-side variant throws so the agent receives an error result and can
+ * self-correct, and does not block `SYSTEM.md`/`skills/` access.
+ */
+export function resolveInProject(projectDir: string, userPath: string): string {
+  const abs = resolve(projectDir, userPath);
+  const rel = relative(projectDir, abs);
+  if (
+    rel === "" ||
+    (rel !== ".." && !rel.startsWith(".." + sep) && !isAbsolute(rel))
+  ) {
+    return abs;
+  }
+  throw new Error(`path outside project: ${userPath}`);
+}

--- a/packages/creative-agent/src/tools/append.ts
+++ b/packages/creative-agent/src/tools/append.ts
@@ -1,8 +1,9 @@
 import { appendFile, mkdir } from "node:fs/promises";
-import { resolve, dirname } from "node:path";
+import { dirname } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 
 const AppendParams = Type.Object({
   file_path: Type.String({
@@ -30,7 +31,7 @@ export function createAppendTool(cwd?: string): AgentTool<typeof AppendParams, v
       _toolCallId: string,
       params: AppendInput,
     ): Promise<AgentToolResult<void>> {
-      const filePath = resolve(workDir, params.file_path);
+      const filePath = resolveInProject(workDir, params.file_path);
       await mkdir(dirname(filePath), { recursive: true });
       await appendFile(filePath, params.content, "utf-8");
       return textResult("Content appended successfully.");

--- a/packages/creative-agent/src/tools/edit.ts
+++ b/packages/creative-agent/src/tools/edit.ts
@@ -1,8 +1,8 @@
 import { readFile, writeFile } from "node:fs/promises";
-import { resolve } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 
 const EditParams = Type.Object({
   file_path: Type.String({
@@ -178,7 +178,7 @@ export function createEditTool(cwd?: string): AgentTool<typeof EditParams, void>
       _toolCallId: string,
       params: EditInput,
     ): Promise<AgentToolResult<void>> {
-      const filePath = resolve(workDir, params.file_path);
+      const filePath = resolveInProject(workDir, params.file_path);
       const content = await readFile(filePath, "utf-8");
 
       const { match, count, fuzzy } = findMatch(content, params.old_string);

--- a/packages/creative-agent/src/tools/grep.ts
+++ b/packages/creative-agent/src/tools/grep.ts
@@ -1,8 +1,8 @@
-import { resolve } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { grep } from "@agentchan/grep";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 
 const GrepParams = Type.Object({
   pattern: Type.String({
@@ -57,7 +57,7 @@ export function createGrepTool(
       params: GrepInput,
     ): Promise<AgentToolResult<void>> {
       const searchPath = params.path
-        ? resolve(projectDir, params.path)
+        ? resolveInProject(projectDir, params.path)
         : projectDir;
 
       const result = await grep({

--- a/packages/creative-agent/src/tools/read.ts
+++ b/packages/creative-agent/src/tools/read.ts
@@ -1,8 +1,8 @@
 import { readFile } from "node:fs/promises";
-import { resolve } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 import { MAX_LINES, MAX_OUTPUT_BYTES } from "./util.js";
 
 const ReadParams = Type.Object({
@@ -37,7 +37,7 @@ export function createReadTool(cwd?: string): AgentTool<typeof ReadParams, void>
       _toolCallId: string,
       params: ReadInput,
     ): Promise<AgentToolResult<void>> {
-      const filePath = resolve(workDir, params.file_path);
+      const filePath = resolveInProject(workDir, params.file_path);
       const offset = (params.offset ?? 1) - 1;
       const limit = Math.min(params.limit ?? MAX_LINES, MAX_LINES);
 

--- a/packages/creative-agent/src/tools/script.ts
+++ b/packages/creative-agent/src/tools/script.ts
@@ -1,7 +1,7 @@
-import { resolve } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 import { truncateTail } from "./util.js";
 
 const ScriptParams = Type.Object({
@@ -48,7 +48,7 @@ export function createScriptTool(cwd?: string): AgentTool<typeof ScriptParams, v
       params: ScriptInput,
     ): Promise<AgentToolResult<void>> {
       const { file, args = [], timeout: timeoutMs = 120_000 } = params;
-      const scriptPath = resolve(workDir, file);
+      const scriptPath = resolveInProject(workDir, file);
 
       let proc: ReturnType<typeof Bun.spawn>;
       try {

--- a/packages/creative-agent/src/tools/tree.ts
+++ b/packages/creative-agent/src/tools/tree.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 import { MAX_OUTPUT_BYTES } from "./util.js";
 
 const MAX_ENTRIES = 1000;
@@ -45,7 +46,9 @@ export function createTreeTool(
         Math.max(params.depth ?? DEFAULT_DEPTH, 1),
         MAX_DEPTH,
       );
-      const dirPath = params.path ? resolve(workDir, params.path) : workDir;
+      const dirPath = params.path
+        ? resolveInProject(workDir, params.path)
+        : workDir;
 
       // Verify root directory is readable before walking
       let rootDirents;

--- a/packages/creative-agent/src/tools/write.ts
+++ b/packages/creative-agent/src/tools/write.ts
@@ -1,8 +1,9 @@
 import { writeFile, mkdir } from "node:fs/promises";
-import { resolve, dirname } from "node:path";
+import { dirname } from "node:path";
 import { Type, type Static } from "@sinclair/typebox";
 import type { AgentTool, AgentToolResult } from "@mariozechner/pi-agent-core";
 import { textResult } from "../tool-result.js";
+import { resolveInProject } from "./_paths.js";
 
 const WriteParams = Type.Object({
   file_path: Type.String({
@@ -28,7 +29,7 @@ export function createWriteTool(cwd?: string): AgentTool<typeof WriteParams, voi
       _toolCallId: string,
       params: WriteInput,
     ): Promise<AgentToolResult<void>> {
-      const filePath = resolve(workDir, params.file_path);
+      const filePath = resolveInProject(workDir, params.file_path);
       await mkdir(dirname(filePath), { recursive: true });
       await writeFile(filePath, params.content, "utf-8");
       return textResult("File written successfully.");

--- a/packages/creative-agent/tests/tools/_paths.test.ts
+++ b/packages/creative-agent/tests/tools/_paths.test.ts
@@ -1,0 +1,101 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join, sep } from "node:path";
+import { tmpdir } from "node:os";
+import { resolveInProject } from "../../src/tools/_paths.js";
+
+let root: string;
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), "paths-test-"));
+});
+
+afterEach(async () => {
+  await rm(root, { recursive: true, force: true });
+});
+
+describe("정상 경로", () => {
+  test("프로젝트 루트의 빈 문자열은 root 자신을 반환", () => {
+    expect(resolveInProject(root, "")).toBe(root);
+  });
+
+  test("'.'은 root 자신을 반환", () => {
+    expect(resolveInProject(root, ".")).toBe(root);
+  });
+
+  test("단순 파일명은 root 하위 절대경로", () => {
+    expect(resolveInProject(root, "file.txt")).toBe(join(root, "file.txt"));
+  });
+
+  test("중첩 경로는 그대로 join", () => {
+    expect(resolveInProject(root, "sub/dir/file.txt")).toBe(
+      join(root, "sub", "dir", "file.txt"),
+    );
+  });
+
+  test("내부에서 끝나는 정상화 가능 경로는 통과", () => {
+    expect(resolveInProject(root, "sub/../file.txt")).toBe(join(root, "file.txt"));
+  });
+});
+
+describe("escape 차단", () => {
+  test("'..' 단독은 throw", () => {
+    expect(() => resolveInProject(root, "..")).toThrow(/path outside project/);
+  });
+
+  test("'../foo'는 throw", () => {
+    expect(() => resolveInProject(root, "../foo")).toThrow(/path outside project/);
+  });
+
+  test("'../../escape'는 throw", () => {
+    expect(() => resolveInProject(root, "../../escape")).toThrow(
+      /path outside project/,
+    );
+  });
+
+  test("내부에서 .. 로 빠져나가는 경로는 throw", () => {
+    expect(() => resolveInProject(root, "sub/../../escape")).toThrow(
+      /path outside project/,
+    );
+  });
+});
+
+describe("절대 경로 차단", () => {
+  test("POSIX 스타일 절대경로는 throw", () => {
+    expect(() => resolveInProject(root, "/etc/passwd")).toThrow(
+      /path outside project/,
+    );
+  });
+
+  if (process.platform === "win32") {
+    test("Windows 절대경로는 throw", () => {
+      expect(() => resolveInProject(root, "C:\\Windows\\System32\\drivers\\etc\\hosts")).toThrow(
+        /path outside project/,
+      );
+    });
+
+    test("다른 드라이브 절대경로는 throw", () => {
+      // root는 보통 C: 또는 사용자 tmpdir 드라이브. 다른 드라이브로 명시.
+      const other = root.startsWith("D:") ? "Z:\\foo" : "D:\\foo";
+      expect(() => resolveInProject(root, other)).toThrow(/path outside project/);
+    });
+  }
+});
+
+describe("error 메시지", () => {
+  test("원본 userPath를 메시지에 포함", () => {
+    try {
+      resolveInProject(root, "../leak");
+      throw new Error("expected throw");
+    } catch (err) {
+      expect((err as Error).message).toContain("../leak");
+    }
+  });
+});
+
+describe("플랫폼 sep 일관성", () => {
+  test("결과는 항상 platform-native sep을 사용 (resolve 동작 확인용)", () => {
+    const got = resolveInProject(root, "a/b/c.txt");
+    expect(got).toContain(sep);
+  });
+});

--- a/packages/creative-agent/tests/tools/containment.test.ts
+++ b/packages/creative-agent/tests/tools/containment.test.ts
@@ -1,0 +1,229 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createReadTool } from "../../src/tools/read.js";
+import { createWriteTool } from "../../src/tools/write.js";
+import { createAppendTool } from "../../src/tools/append.js";
+import { createEditTool } from "../../src/tools/edit.js";
+import { createGrepTool } from "../../src/tools/grep.js";
+import { createTreeTool } from "../../src/tools/tree.js";
+import { createScriptTool } from "../../src/tools/script.js";
+
+let project: string;
+let outside: string;
+let secretRel: string;
+
+beforeEach(async () => {
+  const base = await mkdtemp(join(tmpdir(), "containment-"));
+  project = join(base, "project");
+  outside = join(base, "outside");
+  await mkdir(project, { recursive: true });
+  await mkdir(outside, { recursive: true });
+  await writeFile(join(outside, "secret.txt"), "TOP_SECRET", "utf-8");
+  await writeFile(join(project, "ok.txt"), "in-project", "utf-8");
+  secretRel = "../outside/secret.txt";
+});
+
+afterEach(async () => {
+  await rm(join(project, ".."), { recursive: true, force: true });
+});
+
+const ABSOLUTE_TARGET =
+  process.platform === "win32"
+    ? "C:\\Windows\\System32\\drivers\\etc\\hosts"
+    : "/etc/passwd";
+
+// ---------------------------------------------------------------------------
+// read
+// ---------------------------------------------------------------------------
+
+describe("read 도구", () => {
+  test("정상 in-project 파일은 읽힘", async () => {
+    const tool = createReadTool(project);
+    const r = await tool.execute("c", { file_path: "ok.txt" });
+    expect(JSON.stringify(r.content)).toContain("in-project");
+  });
+
+  test("../ escape는 throw", async () => {
+    const tool = createReadTool(project);
+    await expect(tool.execute("c", { file_path: secretRel })).rejects.toThrow(
+      /path outside project/,
+    );
+  });
+
+  test("절대경로는 throw", async () => {
+    const tool = createReadTool(project);
+    await expect(
+      tool.execute("c", { file_path: ABSOLUTE_TARGET }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// write
+// ---------------------------------------------------------------------------
+
+describe("write 도구", () => {
+  test("정상 in-project 파일은 쓰임", async () => {
+    const tool = createWriteTool(project);
+    const r = await tool.execute("c", {
+      file_path: "new.txt",
+      content: "hello",
+    });
+    expect(JSON.stringify(r.content)).toContain("File written");
+  });
+
+  test("../ escape는 throw", async () => {
+    const tool = createWriteTool(project);
+    await expect(
+      tool.execute("c", { file_path: "../outside/leak.txt", content: "x" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("절대경로는 throw", async () => {
+    const tool = createWriteTool(project);
+    await expect(
+      tool.execute("c", { file_path: ABSOLUTE_TARGET, content: "x" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// append
+// ---------------------------------------------------------------------------
+
+describe("append 도구", () => {
+  test("정상 in-project 파일은 append됨", async () => {
+    const tool = createAppendTool(project);
+    const r = await tool.execute("c", {
+      file_path: "ok.txt",
+      content: "+more",
+    });
+    expect(JSON.stringify(r.content)).toContain("Content appended");
+  });
+
+  test("../ escape는 throw", async () => {
+    const tool = createAppendTool(project);
+    await expect(
+      tool.execute("c", { file_path: secretRel, content: "x" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("절대경로는 throw", async () => {
+    const tool = createAppendTool(project);
+    await expect(
+      tool.execute("c", { file_path: ABSOLUTE_TARGET, content: "x" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// edit
+// ---------------------------------------------------------------------------
+
+describe("edit 도구", () => {
+  test("정상 in-project 파일은 편집됨", async () => {
+    const tool = createEditTool(project);
+    const r = await tool.execute("c", {
+      file_path: "ok.txt",
+      old_string: "in-project",
+      new_string: "edited",
+    });
+    expect(JSON.stringify(r.content)).toContain("File edited");
+  });
+
+  test("../ escape는 throw", async () => {
+    const tool = createEditTool(project);
+    await expect(
+      tool.execute("c", {
+        file_path: secretRel,
+        old_string: "TOP",
+        new_string: "X",
+      }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("절대경로는 throw", async () => {
+    const tool = createEditTool(project);
+    await expect(
+      tool.execute("c", {
+        file_path: ABSOLUTE_TARGET,
+        old_string: "x",
+        new_string: "y",
+      }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// grep
+// ---------------------------------------------------------------------------
+
+describe("grep 도구", () => {
+  test("path 미지정 시 정상 검색", async () => {
+    const tool = createGrepTool(project);
+    const r = await tool.execute("c", { pattern: "in-project" });
+    expect(JSON.stringify(r.content)).toContain("ok.txt");
+  });
+
+  test("path가 ../ escape면 throw", async () => {
+    const tool = createGrepTool(project);
+    await expect(
+      tool.execute("c", { pattern: "TOP_SECRET", path: "../outside" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("path가 절대경로면 throw", async () => {
+    const tool = createGrepTool(project);
+    await expect(
+      tool.execute("c", { pattern: "x", path: ABSOLUTE_TARGET }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tree
+// ---------------------------------------------------------------------------
+
+describe("tree 도구", () => {
+  test("path 미지정 시 정상 트리", async () => {
+    const tool = createTreeTool(project);
+    const r = await tool.execute("c", {});
+    expect(JSON.stringify(r.content)).toContain("ok.txt");
+  });
+
+  test("path가 ../ escape면 throw", async () => {
+    const tool = createTreeTool(project);
+    await expect(
+      tool.execute("c", { path: "../outside" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("path가 절대경로면 throw", async () => {
+    const tool = createTreeTool(project);
+    await expect(
+      tool.execute("c", { path: ABSOLUTE_TARGET }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// script
+// ---------------------------------------------------------------------------
+
+describe("script 도구", () => {
+  test("../ escape는 throw하고 spawn 안 됨", async () => {
+    const tool = createScriptTool(project);
+    await expect(
+      tool.execute("c", { file: "../outside/anything.ts" }),
+    ).rejects.toThrow(/path outside project/);
+  });
+
+  test("절대경로는 throw하고 spawn 안 됨", async () => {
+    const tool = createScriptTool(project);
+    await expect(
+      tool.execute("c", { file: ABSOLUTE_TARGET }),
+    ).rejects.toThrow(/path outside project/);
+  });
+});


### PR DESCRIPTION
## Summary

`research/SECURITY_HARDENING_PLAN.md`의 3-layer defense 중 **Layer A (Path Containment)** 실행. 7개 도구의 진입에서 `resolve(workDir, userPath)` → `resolveInProject(workDir, userPath)`로 일괄 교체.

## 동기

- `node:path`의 `resolve(a, b)`는 `b`가 절대경로면 `a`를 무시하고 `b`를 반환합니다. 따라서 adversarial prompt가 LLM을 조작해 `C:\Users\<user>\.claude\.credentials.json` 같은 절대경로를 `file_path`로 넘기면, 7개 도구(`read`/`edit`/`write`/`append`/`grep`/`tree`/`script`) 모두 그대로 통과시켰습니다 (PE-1, PE-2 공격 경로).
- `apps/webui/src/server/repositories/project.repo.ts:187`의 `resolveProjectFile`은 동일 데이터 평면에서 이미 올바르게 containment 중 — **창구별 불일치**가 노출되어 있었습니다.
- Plan의 Phase 2/3(WASM/iframe)이 들어와도 lexical 탈출은 여기서 1차로 막혀야 합니다.

## 변경

### 신규
- `packages/creative-agent/src/tools/_paths.ts` — `resolveInProject(projectDir, userPath)` 단일 유틸. `resolve` + `relative` 결과로 `..`/`..` + `sep`/절대경로(타 드라이브 포함)를 모두 throw로 차단. 순수 lexical 체크 — symlink는 따라가지 않음 (Plan 합의).

### 적용
- `read/edit/write/append/grep/tree/script.ts` 진입 1줄 교체. 시그니처/동작 무변경.

### 테스트
- `tests/tools/_paths.test.ts` — 유틸 자체 단위 테스트 12종 (정상 / `..`/절대경로/Windows alt-drive)
- `tests/tools/containment.test.ts` — 7개 도구 × 2~3 케이스 통합 테스트 22종. 정상 in-project 호출이 회귀 없음을 함께 검증.

## 의도적 제외

- **서버 `resolveProjectFile`과의 공용화**: `HIDDEN_ROOTS` 추가 정책이 있어 의미가 다름. `_paths.ts` JSDoc에 정책 차이를 명시. 후속 백로그.
- **Symlink realpath 추적**: Plan의 합의된 정책 = lexical-only. Symlink escape는 템플릿 신뢰 경계 문제 (Phase 2/3 책임).
- **Validate-renderer (PE-3)**: Plan의 Phase 4에서 별도 처리.

## Test plan

- [x] `bun test tests/tools/` — 78/78 통과 (신규 34 + 회귀 44)
- [x] `bunx tsc --noEmit` (creative-agent + webui) — 통과
- [x] `bun run lint` (Turbo 전체) — 통과
- [ ] 수동 회귀: dev 세션에서 에이전트가 정상 SYSTEM.md/files 접근 가능 + 절대경로/`../` 시도 시 도구가 거부 메시지 반환

## 방어 매트릭스 (Phase 1 후 상태)

| 위협 | Layer A (이 PR) | Layer B (예정) | Layer C (예정) |
|---|---|---|---|
| PE-1 Read/Edit 경로 이탈 | 차단 | — | — |
| PE-2 Script `file` 절대경로 | 차단 | — | — |
| PE-2 Script 내부에서 fs 접근 | (helper로 막을 예정) | WASM | — |
| PE-4 렌더러 main-origin | — | — | iframe |

🤖 Generated with [Claude Code](https://claude.com/claude-code)