### PR TITLE
feat(i18n): 슬래시 커맨드 description 다국어 적용

### DIFF
--- a/apps/webui/src/client/features/chat/commands.ts
+++ b/apps/webui/src/client/features/chat/commands.ts
@@ -1,5 +1,6 @@
 import commandScore from "command-score";
 import type { SkillMetadata, SkillEnvironment } from "@/client/entities/skill/index.js";
+import type { TFunction, TranslationKey } from "@/client/i18n/index.js";
 
 export interface LocalSlashCommand {
   kind: "local";
@@ -18,22 +19,36 @@ export interface SkillSlashCommand {
 
 export type SlashEntry = LocalSlashCommand | SkillSlashCommand;
 
-export const LOCAL_COMMANDS: LocalSlashCommand[] = [
-  { kind: "local", name: "new", description: "Create new session", needsArg: false },
-  { kind: "local", name: "compact", description: "Summarize and continue in new session", needsArg: false },
-  { kind: "local", name: "edit", description: "Toggle edit mode", needsArg: false },
-  { kind: "local", name: "readme", description: "Show project README", needsArg: false },
-  { kind: "local", name: "model", description: "Change model", needsArg: true, argPlaceholder: "<model-name>" },
-  { kind: "local", name: "provider", description: "Change provider", needsArg: true, argPlaceholder: "<provider-name>" },
+interface LocalSlashCommandDef {
+  name: string;
+  descriptionKey: TranslationKey;
+  needsArg: boolean;
+  argPlaceholder?: string;
+}
+
+export const LOCAL_COMMAND_DEFS: readonly LocalSlashCommandDef[] = [
+  { name: "new", descriptionKey: "slash.new", needsArg: false },
+  { name: "compact", descriptionKey: "slash.compact", needsArg: false },
+  { name: "edit", descriptionKey: "slash.edit", needsArg: false },
+  { name: "readme", descriptionKey: "slash.readme", needsArg: false },
+  { name: "model", descriptionKey: "slash.model", needsArg: true, argPlaceholder: "<model-name>" },
+  { name: "provider", descriptionKey: "slash.provider", needsArg: true, argPlaceholder: "<provider-name>" },
 ];
 
 // All skills are invocable via slash command. disableModelInvocation skills
 // are only reachable through the slash path.
-export function buildSlashEntries(skills: SkillMetadata[]): SlashEntry[] {
+export function buildSlashEntries(skills: SkillMetadata[], t: TFunction): SlashEntry[] {
+  const local: LocalSlashCommand[] = LOCAL_COMMAND_DEFS.map((def) => ({
+    kind: "local",
+    name: def.name,
+    description: t(def.descriptionKey),
+    needsArg: def.needsArg,
+    argPlaceholder: def.argPlaceholder,
+  }));
   const skillEntries: SkillSlashCommand[] = skills
     .map((s) => ({ kind: "skill" as const, name: s.name, description: s.description, environment: s.environment }))
     .sort((a, b) => a.name.localeCompare(b.name));
-  return [...LOCAL_COMMANDS, ...skillEntries];
+  return [...local, ...skillEntries];
 }
 
 // command-score returns tiny non-zero scores for unrelated subsequences,

--- a/apps/webui/src/client/features/chat/useSlashCommands.ts
+++ b/apps/webui/src/client/features/chat/useSlashCommands.ts
@@ -6,9 +6,10 @@ import {
 } from "@/client/entities/session/index.js";
 import { useProjectSelectionState } from "@/client/entities/project/index.js";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
+import { useI18n } from "@/client/i18n/index.js";
 import { useSession } from "./useSession.js";
 import { useStreaming } from "./useStreaming.js";
-import { buildSlashEntries, LOCAL_COMMANDS, type SlashEntry, type SkillSlashCommand } from "./commands.js";
+import { buildSlashEntries, LOCAL_COMMAND_DEFS, type SlashEntry, type SkillSlashCommand } from "./commands.js";
 import { useCommandPalette } from "./useCommandPalette.js";
 
 export function useSlashCommands(text: string, setText: (s: string) => void) {
@@ -21,8 +22,9 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
   const uiDispatch = useUIDispatch();
   const { create, compact } = useSession();
   const { send } = useStreaming();
+  const { t } = useI18n();
 
-  const entries = buildSlashEntries(skills);
+  const entries = buildSlashEntries(skills, t);
 
   const executeLocalCommand = async (name: string, arg: string) => {
     switch (name) {
@@ -68,7 +70,7 @@ export function useSlashCommands(text: string, setText: (s: string) => void) {
     const cmdName = spaceIdx >= 0 ? withoutSlash.slice(0, spaceIdx) : withoutSlash;
     const arg = spaceIdx >= 0 ? withoutSlash.slice(spaceIdx + 1).trim() : "";
 
-    const local = LOCAL_COMMANDS.find((c) => c.name === cmdName);
+    const local = LOCAL_COMMAND_DEFS.find((c) => c.name === cmdName);
     if (local) {
       if (local.needsArg && !arg) return false;
       void executeLocalCommand(cmdName, arg);

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -65,6 +65,12 @@ export const translations = {
   "slash.listboxLabel": "Slash commands",
   "slash.noMatches": "No commands match",
   "slash.skillTag": "skill",
+  "slash.new": "Create new session",
+  "slash.compact": "Summarize and continue in new session",
+  "slash.edit": "Toggle edit mode",
+  "slash.readme": "Show project README",
+  "slash.model": "Change model",
+  "slash.provider": "Change provider",
 
   // Project tabs
   "project.new": "New project",
@@ -118,7 +124,6 @@ export const translations = {
   // README modal (in-project)
   "readme.modalTitle": "README",
   "readme.close": "Close",
-  "readme.commandDescription": "Show project README",
 
   // Save as template
   "project.saveAsTemplate": "Save as template",

--- a/apps/webui/src/client/i18n/index.ts
+++ b/apps/webui/src/client/i18n/index.ts
@@ -16,7 +16,7 @@ export type LanguagePreference = "system" | "en" | "ko";
 export type ResolvedLanguage = "en" | "ko";
 export type { TranslationKey };
 
-type TFunction = (key: TranslationKey, params?: Record<string, string | number>) => string;
+export type TFunction = (key: TranslationKey, params?: Record<string, string | number>) => string;
 
 interface I18nContextValue {
   preference: LanguagePreference;

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -67,6 +67,12 @@ export const translations: Record<TranslationKey, string> = {
   "slash.listboxLabel": "슬래시 명령",
   "slash.noMatches": "일치하는 명령이 없습니다",
   "slash.skillTag": "skill",
+  "slash.new": "새 세션 시작",
+  "slash.compact": "요약 후 새 세션에서 이어가기",
+  "slash.edit": "편집 모드 전환",
+  "slash.readme": "프로젝트 README 보기",
+  "slash.model": "모델 변경",
+  "slash.provider": "프로바이더 변경",
 
   // Project tabs
   "project.new": "새 프로젝트",
@@ -120,7 +126,6 @@ export const translations: Record<TranslationKey, string> = {
   // README modal (in-project)
   "readme.modalTitle": "README",
   "readme.close": "닫기",
-  "readme.commandDescription": "프로젝트 README 보기",
 
   // Save as template
   "project.saveAsTemplate": "템플릿으로 저장",


### PR DESCRIPTION
## Summary
- 하드코딩 로컬 슬래시 커맨드 6종(`/new`, `/compact`, `/edit`, `/readme`, `/model`, `/provider`)의 description을 `slash.*` 번역 키로 치환해 언어 토글에 따라 영/한 전환되도록 적용.
- 스킬에서 동적으로 추가되는 커맨드는 `SKILL.md` frontmatter의 원본이므로 i18n 대상 제외.
- `buildSlashEntries`가 `TFunction`을 받아 빌드 시점에 description을 resolve하는 "translate-at-boundary" 구조로 리팩터. 기존 `description: string` shape는 다운스트림(팝업·스코어링)에서 그대로 유지.
- 부수 정리: `i18n/index.ts`의 `TFunction` 타입 export, 더 이상 참조되지 않는 `readme.commandDescription` 키 제거.

## Test plan
- [x] `cd apps/webui && bunx tsc --noEmit` — 타입 체크 통과
- [x] `bun run lint` — 린트 통과
- [x] `bun run test` — creative-agent 테스트 97건 통과
- [x] 브라우저(EN): `/` 입력 시 팝업에 `/new Create new session` 등 영문 description 노출
- [x] 브라우저(KO): `/new 새 세션 시작`, `/compact 요약 후 새 세션에서 이어가기` 등 한글 description 노출
- [x] `/new` 실행 경로 회귀 없음 (팝업 닫기 + 입력 초기화, 콘솔 에러 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)