### PR TITLE
feat(config): 기본 추론 effort를 medium으로 변경

### DIFF
--- a/apps/webui/src/client/entities/config/index.ts
+++ b/apps/webui/src/client/entities/config/index.ts
@@ -1,4 +1,5 @@
 export type { ProviderInfo, ModelInfo, ThinkingLevel, CustomProviderDef, CustomApiFormat } from "@agentchan/creative-agent";
+export { DEFAULT_THINKING_LEVEL } from "@agentchan/creative-agent";
 export { FORMAT_OPTIONS, DEFAULT_CONTEXT_WINDOW, DEFAULT_MAX_TOKENS } from "./config.constants.js";
 export {
   fetchConfig, updateConfig, fetchProviders,

--- a/apps/webui/src/client/features/settings/ModelBar.tsx
+++ b/apps/webui/src/client/features/settings/ModelBar.tsx
@@ -7,6 +7,7 @@ import {
   useConfigMutations,
   DEFAULT_CONTEXT_WINDOW,
   DEFAULT_MAX_TOKENS,
+  DEFAULT_THINKING_LEVEL,
 } from "@/client/entities/config/index.js";
 import type { ThinkingLevel } from "@/client/entities/config/index.js";
 import { useI18n } from "@/client/i18n/index.js";
@@ -83,7 +84,7 @@ export function ModelBar() {
 
   const handleThinkingChange = (level: ThinkingLevel) => {
     if (level === config?.thinkingLevel) return;
-    void update({ thinkingLevel: level === "off" ? null : level });
+    void update({ thinkingLevel: level });
   };
 
   const showThinking = !!currentProvider?.custom || (currentModel?.reasoning ?? false);
@@ -211,7 +212,7 @@ export function ModelBar() {
             <FormField label={t("params.thinking")}>
               <SegmentedControl
                 options={THINKING_LEVELS}
-                value={config?.thinkingLevel ?? "off"}
+                value={config?.thinkingLevel ?? DEFAULT_THINKING_LEVEL}
                 onChange={handleThinkingChange}
               />
             </FormField>

--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -1,4 +1,4 @@
-import { getProviders, getModels, type ModelInfo } from "@agentchan/creative-agent";
+import { getProviders, getModels, DEFAULT_THINKING_LEVEL, type ModelInfo } from "@agentchan/creative-agent";
 import {
   getOAuthApiKey,
   getOAuthProvider,
@@ -188,7 +188,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
 
   function loadThinkingLevel() {
     const raw = settingsRepo.getAppSetting("config.thinkingLevel");
-    if (raw === "low" || raw === "medium" || raw === "high") return raw;
+    if (raw === "off" || raw === "low" || raw === "medium" || raw === "high") return raw;
     return undefined;
   }
 
@@ -216,7 +216,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
       temperature: loadNumber("config.temperature", parseFloat, 0, 2),
       maxTokens: loadNumber("config.maxTokens", (s) => parseInt(s, 10), 1),
       contextWindow: loadNumber("config.contextWindow", (s) => parseInt(s, 10), 1024),
-      thinkingLevel: loadThinkingLevel(),
+      thinkingLevel: loadThinkingLevel() ?? DEFAULT_THINKING_LEVEL,
     };
   }
 
@@ -258,9 +258,8 @@ export function createConfigService(settingsRepo: SettingsRepo) {
 
       if ("thinkingLevel" in body) {
         const level = body.thinkingLevel;
-        // "off" and null both map to "unset" — reasoning stays disabled by default.
-        if (level == null || level === "off") {
-          currentConfig.thinkingLevel = undefined;
+        if (level == null) {
+          currentConfig.thinkingLevel = DEFAULT_THINKING_LEVEL;
           settingsRepo.deleteAppSetting("config.thinkingLevel");
         } else {
           currentConfig.thinkingLevel = level;

--- a/packages/creative-agent/src/config-types.ts
+++ b/packages/creative-agent/src/config-types.ts
@@ -34,3 +34,5 @@ export interface CustomProviderDef {
 }
 
 export type ThinkingLevel = "off" | "low" | "medium" | "high";
+
+export const DEFAULT_THINKING_LEVEL: ThinkingLevel = "medium";

--- a/packages/creative-agent/src/index.ts
+++ b/packages/creative-agent/src/index.ts
@@ -11,6 +11,7 @@ export { slugify } from "./slug.js";
 // Types
 export type { AgentMessage, TokenUsage, TreeNode, TreeNodeWithChildren, Session } from "./types.js";
 export type { ModelInfo, CustomApiFormat, ProviderInfo, CustomProviderDef, ThinkingLevel } from "./config-types.js";
+export { DEFAULT_THINKING_LEVEL } from "./config-types.js";
 
 // Agent — orchestrator
 export {


### PR DESCRIPTION
## Summary

- 설정 미저장 시 `thinkingLevel` fallback을 `"off"` → `"medium"`으로 변경. 새 사용자/신규 worktree는 추론 가능한 모델에 대해 medium 사고가 켜진 상태로 시작.
- `"off"`를 명시 영구화 가능한 값으로 승격: 사용자가 SegmentedControl에서 off를 선택하면 DB에 `"off"` 그대로 저장되어 추론 비활성 상태가 유지됨 (기존엔 "off" = 키 삭제 동치라 fallback이 바뀌면 영영 끌 수 없었음).
- `DEFAULT_THINKING_LEVEL` 상수를 `packages/creative-agent/src/config-types.ts`에 추가하여 server/client 양쪽이 단일 진실 소스를 공유.

## 변경 파일

- `packages/creative-agent/src/config-types.ts` — `DEFAULT_THINKING_LEVEL` 상수 추가
- `packages/creative-agent/src/index.ts` — barrel export
- `apps/webui/src/server/services/config.service.ts` — `loadThinkingLevel`이 `"off"`도 인정, `loadConfig` fallback 적용, `updateConfig`의 `null` 분기를 reset-to-default 의미로 명확화
- `apps/webui/src/client/entities/config/index.ts` — barrel re-export
- `apps/webui/src/client/features/settings/ModelBar.tsx` — `handleThinkingChange`가 선택값을 그대로 전송, SegmentedControl `value` fallback에 상수 적용

## API 시맨틱 정리

`PUT /api/config` body의 `thinkingLevel`:
- `"off" | "low" | "medium" | "high"` → 해당 값을 영구 저장
- `null` → 설정 삭제 + `DEFAULT_THINKING_LEVEL` 복귀 (외부 클라이언트용 reset 경로, UI는 사용 안 함)

## Test plan

- [x] `bunx tsc --noEmit` (apps/webui, packages/creative-agent)
- [x] `bun run lint`
- [x] `bun run test` (105 pass)
- [x] **Scenario 1 — 신규 기본값 = medium**: 설정 없는 상태에서 ModelBar SegmentedControl이 `med` 활성, 하단 메타에 `think=medium` 노출
- [x] **Scenario 2 — off 영구화**: off 선택 후 새로고침 시 off 유지 + DB `app_settings` 테이블에 `config.thinkingLevel="off"` 직접 확인
- [x] **Scenario 3 — low/high 영구화**: 각 값 선택 시 DB에 정확히 저장됨 확인
- [ ] **Scenario 4 — 추론 모델 실제 적용 (수동)**: 추론 가능한 모델에서 medium 기본으로 thinking_* 이벤트 수신, off 전환 후 미수신 확인 (LLM API 키 필요로 머지 전 reviewer가 직접 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)