### PR TITLE
fix(script-tool): description을 LLM 호출 인터페이스로 복원

### DIFF
--- a/packages/creative-agent/src/tools/script.ts
+++ b/packages/creative-agent/src/tools/script.ts
@@ -15,7 +15,7 @@ const ScriptParams = Type.Object({
   args: Type.Optional(
     Type.Array(Type.String(), {
       description:
-        "Arguments passed to the script as the first parameter. Each element becomes one entry — no shell quoting needed.",
+        "Arguments passed to the script. Each element becomes one entry — no shell quoting needed.",
     }),
   ),
   timeout: Type.Optional(
@@ -27,21 +27,12 @@ type ScriptInput = Static<typeof ScriptParams>;
 
 const DESCRIPTION = `Run a TypeScript or JavaScript file from the project directory.
 
-The script must \`export default function (args, ctx)\` (sync or async). It receives:
-- \`args\` — the args[] passed to this tool, as a readonly string[]
-- \`ctx\` — {
-    project: { readFile, writeFile, exists, listDir, stat(path) → {mtime,size}|null },
-    sqlite: { open(relPath) → handle },
-    yaml: { parse, stringify },
-    random: { int(minIncl, maxExcl) },
-    util: { parseArgs(config) }
-  }
-- \`ctx.util.parseArgs\` mirrors \`node:util.parseArgs\` — pass {args, options, strict, allowPositionals} as usual.
-- \`ctx.sqlite.open(path)\` returns { exec(sql), all(sql, params?), run(sql, params?), batch(fn), close() }. batch runs fn() inside a single transaction — only exec/all/run on the same handle are allowed inside, throwing rolls back.
+Usage:
+- file: path relative to the project root (e.g. "scripts/word-count.ts"). Must be a .ts, .js, or .mjs file that exists in the project.
+- args: array of strings passed to the script. Each element becomes one argument, with no shell quoting or escaping needed.
+- timeout: milliseconds before the script is killed (default: 120000).
 
-The function's return value becomes the tool's output: \`string\` is passed through, \`object\` is JSON.stringify'd, \`undefined\` yields "(no output)". Throw an Error to fail; the message is surfaced to the caller and the script exits non-zero. Output is truncated to roughly the last 50KB / 2000 lines.
-
-\`fs\`, \`process\`, \`Bun\`, \`fetch\`, \`require\` are not exposed — use the ctx capabilities instead. Top-level \`import\` of host modules will not be available in future runtimes; \`import type\` only.`;
+The script runs with cwd set to the project root. Captured stdout and stderr are returned together; non-zero exit codes are surfaced. Output is truncated to roughly the last 50KB / 2000 lines.`;
 
 /**
  * Wrapper source executed inside the spawned Bun process. Self-contained


### PR DESCRIPTION
## Summary

- \`packages/creative-agent/src/tools/script.ts\` 의 \`DESCRIPTION\` 을 #105 이전의 파라미터 중심(file/args/timeout + 출력 포맷) 문구로 되돌린다.
- \`ScriptParams.args\` 의 설명에서 \"as the first parameter\" 문구를 제거해 구현 중립 표현으로 복원한다.
- #105 의 내부 리팩토링(runtime · wrapper · ctx scope · example_data 스크립트 12개 마이그레이션)은 그대로 유지한다.

## Why

#105 (\`refactor(script-tool): (args, ctx) 패턴으로 주입 인터페이스 확정\`) 는 스크립트 *작성 규약* 을 \`export default function (args, ctx)\` 로 통일하는 리팩토링이었다. 이 과정에서 \`DESCRIPTION\` 상수까지 \"스크립트 작성자\" 시점으로 다시 쓰여, 매 턴 LLM 에 노출되는 문자열이 실제 도구 인자(file/args/timeout) 와 동떨어진 내용(ctx.project / ctx.sqlite / ctx.yaml scope, \`fs\` · \`process\` · \`Bun\` 미노출 규칙 등) 을 서술하게 되었다.

CLAUDE.md 의 도구 가이드 2층 원칙과 어긋난다:

> Agent 도구 LLM 가이드는 2층: 시스템 프롬프트(\`creative-agent/src/agent/orchestrator.ts\`)는 선택 규칙(\"X 대신 Y\", 부재 도구 명시), 각 도구의 \`description\` 은 사용법(파라미터/출력 형식). \`tools/edit.ts\` 의 \`DESCRIPTION\` 상수가 모범.

스크립트 작성 규약은 템플릿 제작자 · meta 세션 스킬(\`build-renderer\` 류) 의 관심사이며, 이미 작성 · 배포된 스크립트를 호출만 하는 LLM 은 알 필요가 없다. 따라서 내부 구현은 #105 를 유지하되 LLM 에 노출되는 description 만 인터페이스 중심으로 되돌린다.

## Before → After

\`\`\`
  Run a TypeScript or JavaScript file from the project directory.

- The script must \`export default function (args, ctx)\` (sync or async). It receives:
- - \`args\` — the args[] passed to this tool, as a readonly string[]
- - \`ctx\` — { project: {…}, sqlite: {…}, yaml: {…}, random: {…}, util: {…} }
- - \`ctx.util.parseArgs\` mirrors \`node:util.parseArgs\` …
- - \`ctx.sqlite.open(path)\` returns { exec, all, run, batch, close } …
-
- The function's return value becomes the tool's output: …
-
- \`fs\`, \`process\`, \`Bun\`, \`fetch\`, \`require\` are not exposed …
+ Usage:
+ - file: path relative to the project root (e.g. \"scripts/word-count.ts\"). Must be a .ts, .js, or .mjs file that exists in the project.
+ - args: array of strings passed to the script. Each element becomes one argument, with no shell quoting or escaping needed.
+ - timeout: milliseconds before the script is killed (default: 120000).
+
+ The script runs with cwd set to the project root. Captured stdout and stderr are returned together; non-zero exit codes are surfaced. Output is truncated to roughly the last 50KB / 2000 lines.
\`\`\`

## Non-Goals

- \`SCRIPT_RUNNER_SOURCE\`, \`runtime/script-context.ts\`, \`ctx.*\` 구조 변경 없음 — #105 의 내부 규약은 그대로.
- example_data 스크립트 원복 없음 — \`(args, ctx)\` 패턴으로 마이그레이션된 12개 스크립트는 유지.
- \`orchestrator.ts\` 의 DEFAULT_SYSTEM_PROMPT 수정 없음.

## Test plan

- [x] \`cd packages/creative-agent && bunx tsc --noEmit\`
- [x] \`bun run lint\`
- [x] \`bun run test\` — 105 pass / 0 fail (\`tests/tools/script.test.ts\` 포함, 동작 회귀 없음 확인)
- [ ] 실제 에이전트가 \`script\` 도구를 호출할 때 description 과 파라미터가 일치하는지는 다음 세션에서 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)