### PR TITLE
feat(webui): 템플릿 저작용 Workbench intent 도입

### DIFF
--- a/apps/webui/src/client/app/Sidebar.tsx
+++ b/apps/webui/src/client/app/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, PanelLeftClose, Settings } from "lucide-react";
+import { BookOpen, PanelLeftClose, Settings, Wrench } from "lucide-react";
 import { useUIState, useUIDispatch } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { IconButton, ScrollArea } from "@/client/shared/ui/index.js";
@@ -55,14 +55,21 @@ export function Sidebar() {
         </button>
       </div>
 
-      {/* Projects */}
+      {/* Workbench + Projects */}
       <ScrollArea className="flex-1 border-t border-edge/6" viewportClassName="pt-1 pb-2">
-        <div className="px-5 pt-3 pb-1">
+        <div className="px-5 pt-3 pb-1 flex items-center gap-1.5">
+          <Wrench size={11} strokeWidth={2} className="text-fg-3" />
+          <label className="text-[11px] font-semibold text-fg-3 uppercase tracking-[0.12em]">
+            {t("sidebar.workbench")}
+          </label>
+        </div>
+        <ProjectTabs intent="workbench" />
+        <div className="px-5 pt-4 pb-1">
           <label className="text-[11px] font-semibold text-fg-3 uppercase tracking-[0.12em]">
             {t("sidebar.projects")}
           </label>
         </div>
-        <ProjectTabs />
+        <ProjectTabs intent="creative" />
       </ScrollArea>
 
       {/* Bottom panel */}

--- a/apps/webui/src/client/entities/project/index.ts
+++ b/apps/webui/src/client/entities/project/index.ts
@@ -3,11 +3,13 @@ export {
   useProjectSelectionState,
   useProjectSelectionDispatch,
 } from "./ProjectSelectionContext.js";
-export type { Project } from "./project.types.js";
+export type { Project, ProjectIntent } from "./project.types.js";
 export {
   fetchProjects, createProject, updateProject, deleteProject, duplicateProject,
   fetchWorkspaceFiles, fetchTranspiledRenderer, fetchProjectReadme,
+  type CreateProjectOptions,
 } from "./project.api.js";
 export {
   useProjects, useProjectReadme, useWorkspaceFiles, useRendererJs, useProjectMutations,
 } from "./useProjects.js";
+export { useActiveProject } from "./useActiveProject.js";

--- a/apps/webui/src/client/entities/project/project.api.ts
+++ b/apps/webui/src/client/entities/project/project.api.ts
@@ -1,6 +1,11 @@
 import { json } from "@/client/shared/api.js";
 import type { ReadmeDoc } from "@/client/shared/ReadmeView.js";
-import type { Project, ProjectFile } from "./project.types.js";
+import type { Project, ProjectFile, ProjectIntent } from "./project.types.js";
+
+export interface CreateProjectOptions {
+  fromTemplate?: string;
+  intent?: ProjectIntent;
+}
 
 // --- Project CRUD ---
 
@@ -8,11 +13,15 @@ export function fetchProjects(): Promise<Project[]> {
   return json("/projects");
 }
 
-export function createProject(name: string, fromTemplate?: string): Promise<Project> {
+export function createProject(name: string, opts?: CreateProjectOptions): Promise<Project> {
   return json("/projects", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name, ...(fromTemplate ? { fromTemplate } : {}) }),
+    body: JSON.stringify({
+      name,
+      ...(opts?.fromTemplate ? { fromTemplate: opts.fromTemplate } : {}),
+      ...(opts?.intent ? { intent: opts.intent } : {}),
+    }),
   });
 }
 
@@ -31,11 +40,18 @@ export function deleteProject(slug: string): Promise<void> {
   return json(`/projects/${encodeURIComponent(slug)}`, { method: "DELETE" });
 }
 
-export function duplicateProject(sourceSlug: string, name: string): Promise<Project> {
+export function duplicateProject(
+  sourceSlug: string,
+  name: string,
+  opts?: { intent?: ProjectIntent },
+): Promise<Project> {
   return json(`/projects/${encodeURIComponent(sourceSlug)}/duplicate`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({
+      name,
+      ...(opts?.intent ? { intent: opts.intent } : {}),
+    }),
   });
 }
 

--- a/apps/webui/src/client/entities/project/project.types.ts
+++ b/apps/webui/src/client/entities/project/project.types.ts
@@ -1,5 +1,8 @@
 import type { ProjectFile } from "@agentchan/creative-agent";
 
+/** Project의 목적. 기본값은 "creative"(창작용). "workbench"는 새 템플릿 저작용 */
+export type ProjectIntent = "creative" | "workbench";
+
 export interface Project {
   slug: string;
   name: string;
@@ -7,6 +10,7 @@ export interface Project {
   updatedAt: number;
   notes?: string;
   hasCover?: boolean;
+  intent?: ProjectIntent;
 }
 
 export type { ProjectFile };

--- a/apps/webui/src/client/entities/project/useActiveProject.ts
+++ b/apps/webui/src/client/entities/project/useActiveProject.ts
@@ -1,0 +1,14 @@
+import { useProjectSelectionState } from "./ProjectSelectionContext.js";
+import { useProjects } from "./useProjects.js";
+import type { Project } from "./project.types.js";
+
+/**
+ * 현재 활성화된 프로젝트 객체를 반환한다. slug만 필요하면 `useProjectSelectionState`를 쓰고,
+ * intent나 name 같은 프로젝트 메타가 필요할 때 이 훅을 쓴다.
+ */
+export function useActiveProject(): Project | null {
+  const { activeProjectSlug } = useProjectSelectionState();
+  const { data: projects = [] } = useProjects();
+  if (!activeProjectSlug) return null;
+  return projects.find((p) => p.slug === activeProjectSlug) ?? null;
+}

--- a/apps/webui/src/client/entities/project/useProjects.ts
+++ b/apps/webui/src/client/entities/project/useProjects.ts
@@ -8,8 +8,9 @@ import {
   updateProject as apiUpdate,
   deleteProject as apiDelete,
   duplicateProject as apiDuplicate,
+  type CreateProjectOptions,
 } from "./project.api.js";
-import type { Project, ProjectFile } from "./project.types.js";
+import type { Project, ProjectFile, ProjectIntent } from "./project.types.js";
 
 export function useProjects() {
   return useSWR<Project[]>(qk.projects());
@@ -41,8 +42,8 @@ export function useRendererJs(slug: string | null) {
 export function useProjectMutations() {
   const { mutate } = useSWRConfig();
 
-  const create = async (name: string, fromTemplate?: string) => {
-    const project = await apiCreate(name, fromTemplate);
+  const create = async (name: string, opts?: CreateProjectOptions) => {
+    const project = await apiCreate(name, opts);
     await mutate(qk.projects());
     return project;
   };
@@ -64,8 +65,12 @@ export function useProjectMutations() {
     await mutate(matchesSlug(slug), undefined, { revalidate: false });
   };
 
-  const duplicate = async (sourceSlug: string, name: string) => {
-    const project = await apiDuplicate(sourceSlug, name);
+  const duplicate = async (
+    sourceSlug: string,
+    name: string,
+    opts?: { intent?: ProjectIntent },
+  ) => {
+    const project = await apiDuplicate(sourceSlug, name, opts);
     await mutate(qk.projects());
     return project;
   };

--- a/apps/webui/src/client/features/chat/SessionTabs.tsx
+++ b/apps/webui/src/client/features/chat/SessionTabs.tsx
@@ -3,7 +3,7 @@ import {
   useSessions,
   useActiveSessionSelection,
 } from "@/client/entities/session/index.js";
-import { useProjectSelectionState } from "@/client/entities/project/index.js";
+import { useProjectSelectionState, useActiveProject } from "@/client/entities/project/index.js";
 import { useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { ScrollArea } from "@/client/shared/ui/index.js";
@@ -13,6 +13,7 @@ export function SessionTabs() {
   const selection = useActiveSessionSelection();
   const { activeProjectSlug } = useProjectSelectionState();
   const { data: sessions = [] } = useSessions(activeProjectSlug);
+  const isWorkbench = useActiveProject()?.intent === "workbench";
   const uiDispatch = useUIDispatch();
   const { t } = useI18n();
   const { create, load, remove } = useSession();
@@ -58,9 +59,8 @@ export function SessionTabs() {
           );
         })}
 
-        {/* New session */}
         <button
-          onClick={() => create()}
+          onClick={() => create(isWorkbench ? "meta" : undefined)}
           className="flex-shrink-0 p-1.5 rounded-md text-fg-3 hover:text-accent hover:bg-accent/8 transition-all duration-150"
           title={t("session.new")}
         >

--- a/apps/webui/src/client/features/onboarding/useOnboarding.ts
+++ b/apps/webui/src/client/features/onboarding/useOnboarding.ts
@@ -66,7 +66,7 @@ export function useOnboarding() {
     if (creatingSlug) return;
     setCreatingSlug(slug);
     try {
-      await createProject(name, slug);
+      await createProject(name, { fromTemplate: slug });
       await mutateCompleteOnboarding();
       setWizardOpen(false);
       uiDispatch({ type: "NAVIGATE", route: { page: "main" } });

--- a/apps/webui/src/client/features/project/ProjectTabs.tsx
+++ b/apps/webui/src/client/features/project/ProjectTabs.tsx
@@ -6,6 +6,7 @@ import { useI18n } from "@/client/i18n/index.js";
 import { Indicator, CoverImage } from "@/client/shared/ui/index.js";
 import { useTemplates } from "@/client/entities/template/index.js";
 import { useStreamState, selectStreamSlot } from "@/client/entities/stream/index.js";
+import type { ProjectIntent } from "@/client/entities/project/index.js";
 import { useProject } from "./useProject.js";
 import { ProjectSettingsModal } from "./ProjectSettingsModal.js";
 import { SaveAsTemplateModal } from "./SaveAsTemplateModal.js";
@@ -61,9 +62,27 @@ function tabsReducer(state: TabsMode, action: TabsAction): TabsMode {
 
 // -- Component ---
 
-export function ProjectTabs() {
+/**
+ * intent가 전달되면 해당 intent의 프로젝트만 렌더링하고, 새 프로젝트 생성 시
+ * 자동으로 그 intent를 부여한다. 기본값 "creative"는 기존 Projects 섹션 동작.
+ */
+interface ProjectTabsProps {
+  intent?: ProjectIntent;
+}
+
+export function ProjectTabs({ intent = "creative" }: ProjectTabsProps) {
   const { t } = useI18n();
-  const { projects, activeProjectSlug, selectProject, createProject, duplicateProject, renameProject, deleteProject } = useProject();
+  const {
+    projects: allProjects,
+    activeProjectSlug,
+    selectProject,
+    createProject,
+    duplicateProject,
+    renameProject,
+    deleteProject,
+  } = useProject();
+  const projects = allProjects.filter((p) => (p.intent ?? "creative") === intent);
+  const isWorkbench = intent === "workbench";
   const streamState = useStreamState();
   const [mode, modeDispatch] = useReducer(tabsReducer, { type: "idle" });
   const { data: templates } = useTemplates();
@@ -94,7 +113,10 @@ export function ProjectTabs() {
     }
     submittingRef.current = true;
     try {
-      await createProject(name, mode.templateName);
+      await createProject(name, {
+        ...(mode.templateName ? { fromTemplate: mode.templateName } : {}),
+        intent,
+      });
       modeDispatch({ type: "RESET" });
     } finally {
       submittingRef.current = false;
@@ -112,7 +134,7 @@ export function ProjectTabs() {
     }
     submittingRef.current = true;
     try {
-      await duplicateProject(mode.sourceSlug, name);
+      await duplicateProject(mode.sourceSlug, name, { intent });
       modeDispatch({ type: "RESET" });
     } finally {
       submittingRef.current = false;
@@ -183,24 +205,33 @@ export function ProjectTabs() {
             }
           >
             <Plus size={12} strokeWidth={2.5} />
-            {t("project.new")}
+            {isWorkbench ? t("workbench.new") : t("project.new")}
           </Menu.Trigger>
           <Menu.Portal>
             <Menu.Positioner sideOffset={6} align="start">
               <Menu.Popup className={`${MENU_POPUP_CLASS} min-w-[220px]`}>
                 <Menu.Item
-                  onClick={() => modeDispatch({ type: "START_CREATE" })}
+                  onClick={() =>
+                    modeDispatch({
+                      type: "START_CREATE",
+                      // Workbench의 "빈" 시작점은 build-renderer 스킬이 들어있는
+                      // empty 템플릿을 복제해야 메타 에이전트가 즉시 동작한다.
+                      ...(isWorkbench ? { templateName: "empty" } : {}),
+                    })
+                  }
                   className={`${MENU_ITEM_CLASS} flex items-center gap-2`}
                 >
                   <Plus size={12} strokeWidth={2.5} />
-                  {t("project.newOptionsEmpty")}
+                  {isWorkbench ? t("workbench.newOptionsEmpty") : t("project.newOptionsEmpty")}
                 </Menu.Item>
                 {templates && templates.length > 0 && (
                   <>
                     <div className="my-1 border-t border-edge/8" role="separator" />
                     <Menu.Group>
                       <Menu.GroupLabel className="px-4 py-1 text-[10px] uppercase tracking-wider text-fg-4">
-                        {t("project.newOptionsFromTemplate")}
+                        {isWorkbench
+                          ? t("workbench.newOptionsFromTemplate")
+                          : t("project.newOptionsFromTemplate")}
                       </Menu.GroupLabel>
                       {templates.map((s) => (
                         <Menu.Item

--- a/apps/webui/src/client/features/project/WorkbenchHeader.tsx
+++ b/apps/webui/src/client/features/project/WorkbenchHeader.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { Rocket, Wrench } from "lucide-react";
+import { useI18n } from "@/client/i18n/index.js";
+import { SaveAsTemplateModal } from "./SaveAsTemplateModal.js";
+
+interface WorkbenchHeaderProps {
+  slug: string;
+}
+
+/**
+ * Workbench-intent 프로젝트에서만 AgentPanel 상단에 노출되는 헤더.
+ * Publish as Template 진입점을 눈에 띄는 위치로 끌어올려 템플릿 저작 흐름을
+ * 사이드바 우클릭에 의존하지 않게 한다.
+ */
+export function WorkbenchHeader({ slug }: WorkbenchHeaderProps) {
+  const { t } = useI18n();
+  const [publishOpen, setPublishOpen] = useState(false);
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-2 px-3 py-2 border-b border-edge/6 bg-accent/[0.03]"
+        data-testid="workbench-header"
+      >
+        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md bg-accent/10 border border-accent/20 text-[10px] font-semibold tracking-wider uppercase text-accent">
+          <Wrench size={10} strokeWidth={2.5} />
+          {t("workbench.badge")}
+        </span>
+        <span className="flex-1 text-[11px] text-fg-3 truncate tracking-wide">
+          {t("workbench.description")}
+        </span>
+        <button
+          onClick={() => setPublishOpen(true)}
+          className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md bg-accent text-void text-[11px] font-semibold tracking-wide hover:bg-accent/90 active:scale-[0.98] transition-all"
+          data-testid="workbench-publish"
+        >
+          <Rocket size={10} strokeWidth={2.5} />
+          {t("workbench.publish")}
+        </button>
+      </div>
+      <SaveAsTemplateModal
+        slug={publishOpen ? slug : null}
+        onClose={() => setPublishOpen(false)}
+      />
+    </>
+  );
+}

--- a/apps/webui/src/client/features/project/index.ts
+++ b/apps/webui/src/client/features/project/index.ts
@@ -2,3 +2,4 @@ export { ProjectTabs } from "./ProjectTabs.js";
 export { useProject } from "./useProject.js";
 export { RenderedView } from "./RenderedView.js";
 export { ProjectReadmeModal } from "./ProjectReadmeModal.js";
+export { WorkbenchHeader } from "./WorkbenchHeader.js";

--- a/apps/webui/src/client/features/project/useProject.ts
+++ b/apps/webui/src/client/features/project/useProject.ts
@@ -5,6 +5,8 @@ import {
   useProjectSelectionDispatch,
   useProjects,
   useProjectMutations,
+  type CreateProjectOptions,
+  type ProjectIntent,
 } from "@/client/entities/project/index.js";
 import {
   useStreamDispatch,
@@ -89,15 +91,19 @@ export function useProject() {
     }
   };
 
-  const createProject = async (name: string, fromTemplate?: string) => {
-    const project = await createProjectMutation(name, fromTemplate);
+  const createProject = async (name: string, opts?: CreateProjectOptions) => {
+    const project = await createProjectMutation(name, opts);
     projectSelectionDispatch({ type: "SET_ACTIVE_PROJECT", slug: project.slug });
     rendererViewDispatch({ type: "CLEAR_HTML" });
     return project;
   };
 
-  const duplicateProject = async (sourceSlug: string, name: string) => {
-    const project = await duplicateProjectMutation(sourceSlug, name);
+  const duplicateProject = async (
+    sourceSlug: string,
+    name: string,
+    opts?: { intent?: ProjectIntent },
+  ) => {
+    const project = await duplicateProjectMutation(sourceSlug, name, opts);
     await activateProject(project.slug);
     return project;
   };

--- a/apps/webui/src/client/i18n/en.ts
+++ b/apps/webui/src/client/i18n/en.ts
@@ -84,6 +84,15 @@ export const translations = {
   "project.newOptionsEmpty": "Empty project",
   "project.newOptionsFromTemplate": "From template",
 
+  // Workbench (intent=workbench projects — template authoring)
+  "sidebar.workbench": "Workbench",
+  "workbench.new": "New workbench",
+  "workbench.newOptionsEmpty": "Blank workbench",
+  "workbench.newOptionsFromTemplate": "Start from template",
+  "workbench.publish": "Publish as Template",
+  "workbench.badge": "Workbench",
+  "workbench.description": "Author new templates with the meta agent, then publish.",
+
   // Project settings
   "settings.back": "Back",
   "settings.general": "General",

--- a/apps/webui/src/client/i18n/ko.ts
+++ b/apps/webui/src/client/i18n/ko.ts
@@ -86,6 +86,15 @@ export const translations: Record<TranslationKey, string> = {
   "project.newOptionsEmpty": "빈 프로젝트",
   "project.newOptionsFromTemplate": "템플릿에서",
 
+  // Workbench (intent=workbench 프로젝트 — 템플릿 저작)
+  "sidebar.workbench": "Workbench",
+  "workbench.new": "새 Workbench",
+  "workbench.newOptionsEmpty": "빈 Workbench",
+  "workbench.newOptionsFromTemplate": "템플릿에서 시작",
+  "workbench.publish": "템플릿으로 Publish",
+  "workbench.badge": "Workbench",
+  "workbench.description": "메타 에이전트와 대화하며 새 템플릿을 만들고 Publish합니다.",
+
   // Project settings
   "settings.back": "뒤로",
   "settings.general": "일반",

--- a/apps/webui/src/client/pages/ProjectPage.tsx
+++ b/apps/webui/src/client/pages/ProjectPage.tsx
@@ -1,9 +1,9 @@
 import { useState, useRef, Suspense, lazy } from "react";
 import { ChevronsLeft } from "lucide-react";
-import { useProjectSelectionState } from "@/client/entities/project/index.js";
+import { useProjectSelectionState, useActiveProject } from "@/client/entities/project/index.js";
 import { useUIState, useUIDispatch, EditModeToggle } from "@/client/entities/ui/index.js";
 import { useI18n } from "@/client/i18n/index.js";
-import { RenderedView } from "@/client/features/project/index.js";
+import { RenderedView, WorkbenchHeader } from "@/client/features/project/index.js";
 import { AgentPanel, BottomInput } from "@/client/features/chat/index.js";
 import { ResizeHandle } from "@/client/shared/ui/ResizeHandle.js";
 
@@ -27,11 +27,13 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
   const ui = useUIState();
   const uiDispatch = useUIDispatch();
   const { t } = useI18n();
+  const activeProject = useActiveProject();
   const [panelWidth, setPanelWidth] = useState(DEFAULT_PANEL_WIDTH);
   const containerRef = useRef<HTMLDivElement>(null);
   const dragStartRef = useRef(0);
 
   const isEdit = ui.viewMode === "edit";
+  const isWorkbench = activeProject?.intent === "workbench";
 
   const handlePanelResize = (delta: number) => {
     const container = containerRef.current;
@@ -87,6 +89,9 @@ export function ProjectPage({ agentPanelOpen, onToggleAgentPanel }: ProjectPageP
             style={{ width: panelWidth }}
             className="flex-shrink-0 flex flex-col min-h-0 bg-base/40 transition-colors duration-300 hidden lg:flex"
           >
+            {isWorkbench && project.activeProjectSlug && (
+              <WorkbenchHeader slug={project.activeProjectSlug} />
+            )}
             <AgentPanel />
             {isEdit && <BottomInput variant="embedded" />}
           </div>

--- a/apps/webui/src/client/pages/TemplatesPage.tsx
+++ b/apps/webui/src/client/pages/TemplatesPage.tsx
@@ -152,7 +152,7 @@ export function TemplatesPage() {
     }
     setCreating(true);
     try {
-      await createProject(name, selectedSlug);
+      await createProject(name, { fromTemplate: selectedSlug });
       uiDispatch({ type: "NAVIGATE", route: { page: "main" } });
     } finally {
       setCreating(false);

--- a/apps/webui/src/server/repositories/project.repo.ts
+++ b/apps/webui/src/server/repositories/project.repo.ts
@@ -2,7 +2,7 @@ import { readFile, mkdir, readdir, rename, rm, cp, stat, unlink } from "node:fs/
 import { existsSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { slugify, scanWorkspaceFiles, type ProjectFile } from "@agentchan/creative-agent";
-import type { Project, ProjectMeta } from "../types.js";
+import type { Project, ProjectMeta, ProjectIntent } from "../types.js";
 import { probeCover } from "../paths.js";
 
 export interface TreeEntry {
@@ -40,20 +40,33 @@ export function createProjectRepo(projectsDir: string) {
     return slug;
   }
 
-  async function createFromSource(name: string, srcDir: string): Promise<Project> {
+  async function createFromSource(
+    name: string,
+    srcDir: string,
+    opts?: { intent?: ProjectIntent },
+  ): Promise<Project> {
     const slug = uniqueSlug(name);
     const now = Date.now();
-    const meta: ProjectMeta = { name, createdAt: now, updatedAt: now };
+    const meta: ProjectMeta = {
+      name,
+      createdAt: now,
+      updatedAt: now,
+      ...(opts?.intent ? { intent: opts.intent } : {}),
+    };
 
     await ensureProjectDir(slug);
-    await Bun.write(projectMetaPath(slug), JSON.stringify(meta, null, 2));
 
     const destDir = projectDir(slug);
+    // 원본의 _project.json은 제외하고 나머지만 복사 — intent/메타는 새 프로젝트 기준으로 덮어쓴다
     const entries = await readdir(srcDir, { withFileTypes: true });
-    const copies = entries.map((e) =>
-      cp(join(srcDir, e.name), join(destDir, e.name), { recursive: e.isDirectory() }),
-    );
+    const copies = entries
+      .filter((e) => e.name !== "_project.json")
+      .map((e) =>
+        cp(join(srcDir, e.name), join(destDir, e.name), { recursive: e.isDirectory() }),
+      );
     await Promise.all(copies);
+
+    await Bun.write(projectMetaPath(slug), JSON.stringify(meta, null, 2));
     return { ...meta, slug };
   }
 
@@ -94,10 +107,15 @@ export function createProjectRepo(projectsDir: string) {
       return { ...meta, slug };
     },
 
-    async create(name: string): Promise<Project> {
+    async create(name: string, opts?: { intent?: ProjectIntent }): Promise<Project> {
       const slug = uniqueSlug(name);
       const now = Date.now();
-      const meta: ProjectMeta = { name, createdAt: now, updatedAt: now };
+      const meta: ProjectMeta = {
+        name,
+        createdAt: now,
+        updatedAt: now,
+        ...(opts?.intent ? { intent: opts.intent } : {}),
+      };
 
       await ensureProjectDir(slug);
       await Bun.write(projectMetaPath(slug), JSON.stringify(meta, null, 2));
@@ -135,11 +153,15 @@ export function createProjectRepo(projectsDir: string) {
       await rm(dir, { recursive: true });
     },
 
-    async duplicate(sourceSlug: string, name: string): Promise<Project> {
+    async duplicate(
+      sourceSlug: string,
+      name: string,
+      opts?: { intent?: ProjectIntent },
+    ): Promise<Project> {
       if (!existsSync(projectMetaPath(sourceSlug))) {
         throw new Error(`Source project not found: ${sourceSlug}`);
       }
-      return createFromSource(name, projectDir(sourceSlug));
+      return createFromSource(name, projectDir(sourceSlug), opts);
     },
 
     createFromSource,

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -1,10 +1,14 @@
 import { Hono } from "hono";
-import type { AppEnv } from "../types.js";
+import type { AppEnv, ProjectIntent } from "../types.js";
 import { createSessionRoutes } from "./sessions.routes.js";
 import { createSkillRoutes } from "./skills.routes.js";
 
 import { IMAGE_EXTS } from "../paths.js";
 import { readmeResponse } from "../readme.js";
+
+function normalizeIntent(raw: unknown): ProjectIntent | undefined {
+  return raw === "workbench" || raw === "creative" ? raw : undefined;
+}
 
 export function createProjectRoutes() {
   const app = new Hono<AppEnv>();
@@ -14,12 +18,20 @@ export function createProjectRoutes() {
   });
 
   app.post("/", async (c) => {
-    const { name, fromTemplate } = await c.req.json<{ name: string; fromTemplate?: string }>();
+    const body = await c.req.json<{
+      name: string;
+      fromTemplate?: string;
+      intent?: ProjectIntent;
+    }>();
+    const { name, fromTemplate } = body;
+    const intent = normalizeIntent(body.intent);
     if (!name?.trim()) return c.json({ error: "Name is required" }, 400);
 
     if (fromTemplate) {
       try {
-        const project = await c.get("projectService").createFromTemplate(name.trim(), fromTemplate);
+        const project = await c
+          .get("projectService")
+          .createFromTemplate(name.trim(), fromTemplate, intent ? { intent } : undefined);
         return c.json(project, 201);
       } catch (err: unknown) {
         const message = err instanceof Error ? err.message : "Failed to create from template";
@@ -27,7 +39,10 @@ export function createProjectRoutes() {
       }
     }
 
-    return c.json(await c.get("projectService").create(name.trim()), 201);
+    return c.json(
+      await c.get("projectService").create(name.trim(), intent ? { intent } : undefined),
+      201,
+    );
   });
 
   app.put("/:slug", async (c) => {
@@ -61,11 +76,15 @@ export function createProjectRoutes() {
 
   app.post("/:slug/duplicate", async (c) => {
     const slug = c.req.param("slug");
-    const { name } = await c.req.json<{ name: string }>();
+    const body = await c.req.json<{ name: string; intent?: ProjectIntent }>();
+    const { name } = body;
+    const intent = normalizeIntent(body.intent);
     if (!name?.trim()) return c.json({ error: "Name is required" }, 400);
 
     try {
-      const project = await c.get("projectService").duplicate(slug, name.trim());
+      const project = await c
+        .get("projectService")
+        .duplicate(slug, name.trim(), intent ? { intent } : undefined);
       return c.json(project, 201);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : "Failed to duplicate project";

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs";
 import { dirname, join } from "node:path";
 import type { ProjectRepo } from "../repositories/project.repo.js";
 import type { TemplateRepo } from "../repositories/template.repo.js";
+import type { ProjectIntent } from "../types.js";
 
 export function createProjectService(projectRepo: ProjectRepo, templateRepo: TemplateRepo, projectsDir: string) {
   const transpiler = new Bun.Transpiler({ loader: "ts" });
@@ -10,15 +11,17 @@ export function createProjectService(projectRepo: ProjectRepo, templateRepo: Tem
     async list() { return projectRepo.list(); },
     async getCoverFile(slug: string) { return projectRepo.getCoverFile(slug); },
     async get(slug: string) { return projectRepo.get(slug); },
-    async create(name: string) { return projectRepo.create(name); },
+    async create(name: string, opts?: { intent?: ProjectIntent }) { return projectRepo.create(name, opts); },
     async update(slug: string, updates: { name?: string; notes?: string }) {
       return projectRepo.update(slug, updates);
     },
     async delete(slug: string) { return projectRepo.delete(slug); },
-    async duplicate(sourceSlug: string, name: string) { return projectRepo.duplicate(sourceSlug, name); },
-    async createFromTemplate(name: string, templateName: string) {
+    async duplicate(sourceSlug: string, name: string, opts?: { intent?: ProjectIntent }) {
+      return projectRepo.duplicate(sourceSlug, name, opts);
+    },
+    async createFromTemplate(name: string, templateName: string, opts?: { intent?: ProjectIntent }) {
       const templateDir = templateRepo.getSourceDir(templateName);
-      return projectRepo.createFromSource(name, templateDir);
+      return projectRepo.createFromSource(name, templateDir, opts);
     },
     async scanWorkspaceFiles(slug: string) {
       return projectRepo.scanWorkspaceFiles(slug);

--- a/apps/webui/src/server/services/template.service.ts
+++ b/apps/webui/src/server/services/template.service.ts
@@ -61,7 +61,7 @@ export function createTemplateService(templateRepo: TemplateRepo, projectsDir: s
       const copies: Promise<void>[] = [];
       const readmeSrc = join(srcDir, "README.md");
       const readmeWasCopied = existsSync(readmeSrc);
-      for (const file of ["SYSTEM.md", "renderer.ts", "README.md"] as const) {
+      for (const file of ["SYSTEM.md", "SYSTEM.meta.md", "renderer.ts", "README.md"] as const) {
         const src = join(srcDir, file);
         if (existsSync(src)) {
           copies.push(cp(src, join(destDir, file)));

--- a/apps/webui/src/server/types.ts
+++ b/apps/webui/src/server/types.ts
@@ -47,12 +47,16 @@ export type AppEnv = {
 
 // --- Project (folder) - webui-specific ---
 
+/** Project의 목적. 기본값은 "creative"(창작용). "workbench"는 새 템플릿 저작용 */
+export type ProjectIntent = "creative" | "workbench";
+
 /** Disk format stored in _project.json (no slug — derived from folder name). */
 export interface ProjectMeta {
   name: string;
   createdAt: number;
   updatedAt: number;
   notes?: string;
+  intent?: ProjectIntent;
 }
 
 /** Runtime / API response format (slug derived from folder name on disk). */


### PR DESCRIPTION
## Summary

- Project에 `intent: \"creative\" | \"workbench\"` 필드를 추가해 템플릿을 직접 저작하려는 사용자를 위한 1급 진입점을 Sidebar에 만들었다
- Workbench intent 프로젝트는 Sidebar의 별도 섹션에 모이고, 새 세션이 meta 모드로 기본 생성되며, AgentPanel 상단에 Publish 버튼이 노출된다
- `template.service.saveProjectAsTemplate`의 allowlist에서 `SYSTEM.meta.md`가 누락되던 버그도 함께 수정

## Why this shape

기존 Template/Project 구조는 **복제(fork)** 모델이다 — Project는 Template의 snapshot 인스턴스이고 이후로는 독립적이다. Anthropic Workbench처럼 \"버전을 바라본다\"는 upstream dependency 모델이 아니기 때문에 Workbench를 별도 엔티티로 두면 같은 복제 관계가 한 단계 더 생길 뿐이다. 대신 Project에 intent 플래그 하나를 추가하면:

- 엔티티/저장소/API 구조 변경 불필요 (19 파일, 202 insertions)
- 기존 SaveAsTemplateModal/복제 경로 전부 재사용
- \"Workbench는 창작용 프로젝트와 목적만 다른 같은 성격의 작업 인스턴스\"라는 멘탈 모델이 복제 모델과 일관

## 주요 변경점

### Server
- `ProjectMeta.intent?: \"creative\" | \"workbench\"` 추가, `_project.json`은 마이그레이션 불필요(undefined → creative 기본값)
- `project.repo.create/duplicate/createFromSource` 모두 `opts?: { intent? }` 전달
- `createFromSource`에서 원본 `_project.json` 제외 후 새 메타로 덮어쓰기 — Workbench가 기존 Project에서 파생돼도 `createdAt/updatedAt/intent`가 올바르게 새로 기록됨
- `POST /api/projects`, `POST /api/projects/:slug/duplicate`에 intent 파라미터 + `normalizeIntent` 가드
- `template.service.saveProjectAsTemplate`의 allowlist에 `SYSTEM.meta.md` 추가(기존 버그)

### Client
- `entities/project`: `ProjectIntent` 타입, `CreateProjectOptions`, `useActiveProject` 훅 신설
- `features/project/ProjectTabs`: `intent` prop으로 섹션별 필터/생성 분기. Sidebar에서 `intent=\"workbench\"`와 `intent=\"creative\"`로 두 번 렌더
- `features/project/WorkbenchHeader`: Workbench 프로젝트에서만 AgentPanel 상단에 노출되는 Publish 배너 (기존 `SaveAsTemplateModal` 재활용)
- `features/chat/SessionTabs`: 활성 프로젝트가 Workbench이면 새 세션 기본 mode를 `meta`로
- `pages/ProjectPage`: Workbench면 AgentPanel 위에 WorkbenchHeader 렌더
- `app/Sidebar`: Templates 아래에 \"🔧 Workbench\" 섹션 신설
- `i18n/en.ts`, `ko.ts`: workbench 관련 7개 키

### Workbench의 \"빈 시작점\"

Workbench Plus 메뉴의 \"빈 Workbench\"는 실제로 **`empty` 템플릿을 복제**한다. `empty` 템플릿이 이미 `SYSTEM.meta.md`와 `skills/build-renderer/`를 포함하도록 설계되어 있어 메타 에이전트가 즉시 동작하기 때문. 글로벌 meta skill 승격은 후속 PR 범위.

## 이 PR에서 의도적으로 제외

- Checkpoint(스냅샷/복원) 기능
- Sample play 토글(일회성 creative 세션)
- 메타 에이전트 tool call의 액션 로그 카드 시각화
- Onboarding과의 통합

모두 \"Workbench가 성립한다\"는 뼈대가 먼저 필요한 후속 UX 개선이라 별도 PR로 분리. Plan file: `C:\Users\ha\.claude\plans\stateless-kindling-quokka.md`

## Test plan

- [x] `bunx tsc --noEmit` (apps/webui)
- [x] `bunx tsc --noEmit` (packages/creative-agent) — 변경 없음, 회귀 확인
- [x] `bun run lint` (turbo 전체)
- [x] `bun run test` (creative-agent tests — 105 pass)
- [ ] 수동 UI 검증:
  - [ ] Sidebar에 \"🔧 Workbench\" / \"Projects\" 두 섹션이 보이는가
  - [ ] Workbench Plus 메뉴 \"빈 Workbench\" 클릭 → empty 템플릿 기반 프로젝트가 intent=workbench로 생성되는가
  - [ ] 해당 Workbench 프로젝트 진입 시 AgentPanel 위 \"🔧 Workbench … [Publish as Template]\" 헤더가 노출되는가
  - [ ] Workbench에서 새 세션 + 버튼 클릭 시 meta 세션이 생성되는가(⚙ 아이콘)
  - [ ] Publish 버튼 → SaveAsTemplateModal → 정상 저장되고 Templates 페이지에 반영되는가
  - [ ] 기존 창작 Project에는 Workbench 헤더가 뜨지 않고 기존 동작 그대로인가
  - [ ] Save As Template(기존 우클릭 메뉴)로 만든 템플릿에 SYSTEM.meta.md가 포함되는가(버그 수정 확인)

🤖 Generated with [Claude Code](https://claude.com/claude-code)