### PR TITLE
fix(webui): 알림 클릭 시 탭 배지 즉시 해제

### DIFF
--- a/apps/webui/src/client/shared/notifications.ts
+++ b/apps/webui/src/client/shared/notifications.ts
@@ -146,6 +146,7 @@ export function notifyBackgroundCompletion(opts: NotifyOpts): void {
       try {
         window.focus();
       } catch { /* ignore */ }
+      markSeen(opts.projectSlug);
       opts.onClick();
       notif.close();
     };


### PR DESCRIPTION
## Summary
- 완료 알림을 클릭해도 브라우저 탭 제목의 `(1)` 배지가 남는 버그를 수정했습니다.
- `notifyBackgroundCompletion`의 onClick 래퍼에서 `markSeen(opts.projectSlug)`을 직접 호출하도록 했습니다.

## 원인
배지 제거는 두 트리거에만 반응했습니다:
1. `activeProjectSlug` 변경 (AppShell useEffect)
2. `visibilitychange` 이벤트

하지만 **이미 해당 프로젝트가 active**인 상태(같은 프로젝트 내 다른 세션을 보고 있는데 배경 세션이 완료된 경우)에서는 \`useStreaming\`의 onClick이 \`selectProject\`를 조기 리턴합니다:

\`\`\`ts
if (projectSelectionRef.current.activeProjectSlug !== projectSlug) {
  void selectProjectRef.current(projectSlug);
}
\`\`\`

→ activeProjectSlug 불변 → effect 미실행 → 배지가 남음.

## 해결
\`notifyBackgroundCompletion\`의 onClick 래퍼(모든 발신자가 공유하는 단일 지점)에서 \`markSeen(opts.projectSlug)\`을 호출하도록 했습니다. \`markSeen\`은 idempotent이므로 AppShell의 기존 로직과 중복 실행되어도 안전합니다.

## Test plan
- [ ] 프로젝트 A의 세션 X를 열어둔 상태에서, 같은 프로젝트 A의 세션 Y를 백그라운드로 스트리밍 완료시킴 → 탭 배지 \`(1)\` 표시 확인
- [ ] OS 알림을 클릭 → 탭 제목의 \`(1)\` 배지가 즉시 사라지는지 확인
- [ ] 다른 프로젝트 B에서 백그라운드 완료 → 알림 클릭 시 프로젝트 B로 전환 + 배지 해제 확인
- [ ] 여러 프로젝트에서 동시에 백그라운드 완료 → 각 알림을 클릭하면 해당 배지만 해제되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)