### PR TITLE
feat(creative-agent): session header에 version 필드 추가

### DIFF
--- a/packages/creative-agent/src/session/format.ts
+++ b/packages/creative-agent/src/session/format.ts
@@ -13,8 +13,12 @@ import { computeActivePath, generateTitle } from "./tree.js";
 
 export type SessionMode = "creative" | "meta";
 
+/** Session file format version. Bump when on-disk shape changes. */
+export const CURRENT_SESSION_VERSION = 1;
+
 export interface SessionHeader {
   _header: true;
+  version: number;
   createdAt: number;
   provider: string;
   model: string;
@@ -50,7 +54,8 @@ export function parseSessionFile(content: string): ParsedSession {
     const first = JSON.parse(firstLine!);
     if (first._header) {
       headerLine = firstLine!;
-      header = first as SessionHeader;
+      // Pre-versioning files match the v1 shape; never bump this with CURRENT_SESSION_VERSION.
+      header = { version: 1, ...first } as SessionHeader;
       startIdx = 1;
     }
   } catch { /* not valid JSON — treat all as nodes */ }

--- a/packages/creative-agent/src/session/storage.ts
+++ b/packages/creative-agent/src/session/storage.ts
@@ -8,6 +8,7 @@ import {
   switchBranch as switchBranchInTree,
 } from "./tree.js";
 import {
+  CURRENT_SESSION_VERSION,
   type SessionHeader,
   type SessionMode,
   type BranchMarker,
@@ -170,7 +171,7 @@ export function createSessionStorage(projectsDir: string): SessionStorage {
       const now = Date.now();
 
       const header: SessionHeader = {
-        _header: true, createdAt: now, provider, model,
+        _header: true, version: CURRENT_SESSION_VERSION, createdAt: now, provider, model,
         ...(compactedFrom ? { compactedFrom } : {}),
         ...(mode ? { mode } : {}),
       };

--- a/packages/creative-agent/tests/session/format.test.ts
+++ b/packages/creative-agent/tests/session/format.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
+  CURRENT_SESSION_VERSION,
   parseSessionFile,
   buildTreeMap,
   deriveSession,
@@ -28,6 +29,14 @@ function makeTreeNode(
 }
 
 const HEADER_LINE = JSON.stringify({
+  _header: true,
+  version: CURRENT_SESSION_VERSION,
+  createdAt: 1000,
+  provider: "google",
+  model: "gemini-test",
+});
+
+const LEGACY_HEADER_LINE = JSON.stringify({
   _header: true,
   createdAt: 1000,
   provider: "google",
@@ -132,6 +141,18 @@ describe("parseSessionFile", () => {
     expect(result.nodes[0].activeChildId).toBeUndefined();
   });
 
+  test("parses version field from current header", () => {
+    const content = buildJSONL(HEADER_LINE);
+    const result = parseSessionFile(content);
+    expect(result.header!.version).toBe(CURRENT_SESSION_VERSION);
+  });
+
+  test("legacy header without version field falls back to v1", () => {
+    const content = buildJSONL(LEGACY_HEADER_LINE);
+    const result = parseSessionFile(content);
+    expect(result.header!.version).toBe(1);
+  });
+
   test("header with compactedFrom and mode", () => {
     const header = JSON.stringify({
       _header: true,
@@ -204,6 +225,7 @@ describe("deriveSession", () => {
     const tree = buildTreeMap(nodes);
     const session = deriveSession("sess-1", {
       _header: true,
+      version: CURRENT_SESSION_VERSION,
       createdAt: 1000,
       provider: "google",
       model: "gemini-test",
@@ -240,7 +262,7 @@ describe("deriveSession", () => {
     ];
     const tree = buildTreeMap(nodes);
     const session = deriveSession("s", {
-      _header: true, createdAt: 1000, provider: "old-provider", model: "old-model",
+      _header: true, version: CURRENT_SESSION_VERSION, createdAt: 1000, provider: "old-provider", model: "old-model",
     }, nodes, tree);
 
     expect(session.provider).toBe("google");
@@ -251,7 +273,7 @@ describe("deriveSession", () => {
     const nodes: TreeNode[] = [makeTreeNode("n1", null, "user", "hello")];
     const tree = buildTreeMap(nodes);
     const session = deriveSession("s", {
-      _header: true, createdAt: 1000, provider: "google", model: "gemini-test",
+      _header: true, version: CURRENT_SESSION_VERSION, createdAt: 1000, provider: "google", model: "gemini-test",
     }, nodes, tree);
 
     expect(session.provider).toBe("google");
@@ -269,7 +291,7 @@ describe("deriveSession", () => {
 
   test("compactedFrom and mode propagated from header", () => {
     const session = deriveSession("s", {
-      _header: true, createdAt: 1000, provider: "g", model: "m",
+      _header: true, version: CURRENT_SESSION_VERSION, createdAt: 1000, provider: "g", model: "m",
       compactedFrom: "old-id", mode: "meta",
     }, []);
     expect(session.compactedFrom).toBe("old-id");


### PR DESCRIPTION
## Summary
- `SessionHeader`에 `version: number` 필드를 추가하고 `CURRENT_SESSION_VERSION = 1`로 신규 세션을 기록
- 버전 필드 없는 기존 파일은 파서에서 리터럴 `1`로 폴백 — pre-versioning 파일은 v1 shape과 동일하므로 v1로 고정
- 이후 포맷이 실제로 바뀔 때 `CURRENT_SESSION_VERSION`을 bump하면서 분기 도입. 폴백 값은 레거시 파일의 실제 세대를 가리켜야 하므로 `CURRENT`가 아닌 고정 리터럴

## Test plan
- [x] `bun test ./tests/session/format.test.ts` — 26/26 통과 (신규 2개 포함: current version 파싱, version 누락 시 v1 폴백)
- [x] `bunx tsc --noEmit` — creative-agent, apps/webui 양쪽 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)