### PR TITLE
fix(webui): StreamingMessage 멀티스텝 툴 호출 플리커 제거

### DIFF
--- a/apps/webui/src/client/entities/agent-state/agentState.ts
+++ b/apps/webui/src/client/entities/agent-state/agentState.ts
@@ -3,6 +3,7 @@ import type {
   ToolResultMessage,
   UserMessage,
 } from "@mariozechner/pi-ai";
+import type { AssistantContentBlock } from "@/client/entities/session/index.js";
 
 export type AgentMessage = UserMessage | AssistantMessage | ToolResultMessage;
 
@@ -32,3 +33,23 @@ export const EMPTY_AGENT_STATE: AgentState = {
   isStreaming: false,
   pendingToolCalls: EMPTY_PENDING,
 };
+
+/**
+ * 현재 진행 중인 턴의 assistant content 블록을 한 배열로 복원한다.
+ * 마지막 user 메시지 이후의 완료된 assistant 메시지 content +
+ * in-flight `streamingMessage.content`를 시간순으로 이어 붙인다.
+ *
+ * 서버는 턴 전체가 끝나야 `assistant_nodes` SSE를 보내므로, 멀티스텝 중간에
+ * 완료된 step은 `state.messages`에만 존재한다. `streamingMessage`만 보면
+ * 그 구간에서 이전 step의 toolCall이 사라지는 플리커가 생긴다 — 이 병합이
+ * 그 공백을 메운다.
+ */
+export function selectCurrentTurnBlocks(state: AgentState): AssistantContentBlock[] {
+  const lastUserIdx = state.messages.findLastIndex((m) => m.role === "user");
+  const turnMessages = state.messages.slice(lastUserIdx + 1);
+  const blocks = turnMessages.flatMap((m) =>
+    m.role === "assistant" ? m.content : [],
+  );
+  if (state.streamingMessage) blocks.push(...state.streamingMessage.content);
+  return blocks;
+}

--- a/apps/webui/src/client/entities/agent-state/index.ts
+++ b/apps/webui/src/client/entities/agent-state/index.ts
@@ -5,7 +5,7 @@ export type {
   ToolResultMessage,
   UserMessage,
 } from "./agentState.js";
-export { EMPTY_AGENT_STATE } from "./agentState.js";
+export { EMPTY_AGENT_STATE, selectCurrentTurnBlocks } from "./agentState.js";
 
 export {
   AgentStateProvider,

--- a/apps/webui/src/client/features/chat/StreamingMessage.tsx
+++ b/apps/webui/src/client/features/chat/StreamingMessage.tsx
@@ -1,4 +1,4 @@
-import { useAgentState } from "@/client/entities/agent-state/index.js";
+import { useAgentState, selectCurrentTurnBlocks } from "@/client/entities/agent-state/index.js";
 import { useI18n } from "@/client/i18n/index.js";
 import { parseInlineMarkdown } from "@/client/shared/inlineMarkdown.js";
 import { BubbleWrap } from "./MessageBubble.js";
@@ -15,10 +15,10 @@ function Sentence({ text, animating }: { text: string; animating: boolean }) {
 }
 
 /**
- * 스트리밍 중 in-flight 어시스턴트 버블. `state.streamingMessage.content`를
- * `MessageContent`로 그대로 그려, 완료 후 `AssistantTurnBubble`이 그리는 순서와
- * 동일한 path를 공유한다 — 이게 "텍스트 위 / 툴 아래" 하드코딩으로 인한 플리커를
- * 제거하는 핵심.
+ * 스트리밍 중 in-flight 어시스턴트 버블. 현재 턴의 완료된 assistant 메시지
+ * content + in-flight streamingMessage.content를 `selectCurrentTurnBlocks`로
+ * 병합해 `MessageContent`로 그린다. 완료 후 `AssistantTurnBubble`이 그리는
+ * 순서와 동일한 path를 공유한다.
  *
  * 마지막 content block이 text인 경우(스트림 끝쪽이 텍스트일 때) 그 부분에만
  * sentence animation을 적용한다. 그 외 블록은 `MessageContent` 통합 경로로.
@@ -28,7 +28,7 @@ export function StreamingMessage({ variant = "compact" }: { variant?: "compact" 
   const { t } = useI18n();
 
   const isWide = variant === "wide";
-  const content = state.streamingMessage?.content ?? [];
+  const content = selectCurrentTurnBlocks(state);
   const lastBlock = content.length > 0 ? content[content.length - 1] : null;
   const liveText = lastBlock?.type === "text" ? lastBlock.text : "";
 
@@ -60,7 +60,7 @@ export function StreamingMessage({ variant = "compact" }: { variant?: "compact" 
 
   if (!state.isStreaming && !state.streamingMessage) return null;
 
-  const showCursor = lastBlock?.type === "text";
+  const showCursor = lastBlock?.type === "text" && state.isStreaming;
   const head = lastBlock?.type === "text" ? content.slice(0, -1) : content;
 
   return (


### PR DESCRIPTION
## Summary
- 멀티스텝 툴 턴(Step 1 텍스트→툴 → 툴 결과 → Step 2 …) 중 이전 step의 toolCall이 \`streamingMessage\` 비워지는 순간 사라졌다가 턴 종료 후에야 되돌아오던 플리커 수정
- \`entities/agent-state\`에 \`selectCurrentTurnBlocks\` 셀렉터 추가: \`state.messages\` 중 마지막 user 이후 assistant content + in-flight \`streamingMessage.content\`를 시간순으로 병합
- \`StreamingMessage\`가 새 셀렉터를 통해 턴 전체 content를 \`MessageContent\`로 렌더 → \`AssistantTurnBubble\`과 동일한 path를 공유해 전환 점프 제거

## 근본 원인
서버(\`creative-agent/src/agent/prompt.ts\`)는 턴 전체가 끝나야 \`assistant_nodes\` SSE를 한 번에 보낸다. 반면 pi reducer(\`AgentStateContext.tsx\`)는 step마다 \`message_end\`에서 완료 메시지를 \`state.messages\`에 push하고 \`streamingMessage\`를 비운다. 기존 \`StreamingMessage\`는 \`streamingMessage?.content\`만 렌더했기 때문에, 두 사건 사이 구간에서 이전 step의 toolCall을 전혀 보여주지 못했다.

## 변경
- \`apps/webui/src/client/entities/agent-state/agentState.ts\`: \`selectCurrentTurnBlocks(state)\` 셀렉터 추가 (\`findLastIndex\` 기반 역추적 → \`flatMap\`으로 블록 병합)
- \`apps/webui/src/client/entities/agent-state/index.ts\`: 셀렉터 export
- \`apps/webui/src/client/features/chat/StreamingMessage.tsx\`: \`content\` 계산을 셀렉터로 교체, \`showCursor\`에 \`isStreaming\` AND 추가, JSDoc 갱신

## Test plan
- [x] \`cd apps/webui && bunx tsc --noEmit\` — clean
- [x] \`bun run lint\` — clean
- [x] \`bun run test\` — 78/78 pass
- [x] 브라우저 검증 (agent-browser): Sentinel 템플릿 프로젝트에서 멀티스텝 프롬프트 전송 → 스트리밍 중 \`script → read × N → thinking\` 블록이 **연속적으로 유지**되며 사라지지 않음 확인 (streaming-t1~t4 스냅샷)
- [x] 단일 step 회귀(단순 인사): 커서/애니메이션 정상, 턴 종료 후 AssistantTurnBubble로 매끄럽게 전환

🤖 Generated with [Claude Code](https://claude.com/claude-code)