### PR TITLE
refactor(agent): split orchestration helpers

### DIFF
--- a/packages/creative-agent/src/agent/logging.ts
+++ b/packages/creative-agent/src/agent/logging.ts
@@ -1,0 +1,78 @@
+import type { Agent, AgentEvent } from "@mariozechner/pi-agent-core";
+import { streamSimple, type AssistantMessage } from "@mariozechner/pi-ai";
+import { formatTokens } from "@agentchan/estimate-tokens";
+
+import { analyzeContext } from "./context-analysis.js";
+import * as log from "../logger.js";
+
+function truncateArgs(args: unknown): string | undefined {
+  if (args == null) return undefined;
+  const str = typeof args === "string" ? args : JSON.stringify(args);
+  return str.length > 200 ? str.slice(0, 200) + "..." : str;
+}
+
+export function createLoggedStreamFn(model: { contextWindow: number }) {
+  return (
+    m: Parameters<typeof streamSimple>[0],
+    ctx: Parameters<typeof streamSimple>[1],
+    opts: Parameters<typeof streamSimple>[2],
+  ) => {
+    const a = analyzeContext(ctx, model.contextWindow);
+    const pct = a.contextWindow > 0 ? Math.round((a.total / a.contextWindow) * 100) : 0;
+    log.info(
+      "context",
+      `system ${formatTokens(a.system)} + tools ${formatTokens(a.tools)} + msgs ${formatTokens(a.messages)} = ${formatTokens(a.total)} / ${formatTokens(a.contextWindow)} (${pct}%)`,
+    );
+    return streamSimple(m, ctx, opts);
+  };
+}
+
+export function subscribeAgentLogging(agent: Agent): void {
+  const toolStartTimes = new Map<string, number>();
+
+  agent.subscribe((event: AgentEvent) => {
+    switch (event.type) {
+      case "tool_execution_start":
+        toolStartTimes.set(event.toolCallId, Date.now());
+        if (log.isEnabled("debug")) {
+          log.debug("agent", `↳ ${event.toolName}`, truncateArgs(event.args));
+        }
+        break;
+
+      case "tool_execution_end": {
+        const started = toolStartTimes.get(event.toolCallId);
+        const dur = started
+          ? ((Date.now() - started) / 1000).toFixed(1)
+          : "?";
+        toolStartTimes.delete(event.toolCallId);
+        if (event.isError) {
+          log.error("agent", `✗ ${event.toolName} (${dur}s)`);
+        } else {
+          log.info("agent", `✓ ${event.toolName} (${dur}s)`);
+        }
+        break;
+      }
+
+      case "message_end": {
+        const msg = event.message as AssistantMessage;
+        if (msg.role !== "assistant") break;
+        const toolCallCount = msg.content.filter(
+          (b) => b.type === "toolCall",
+        ).length;
+        if (msg.stopReason === "error" || msg.stopReason === "aborted") {
+          log.error(
+            "agent",
+            `llm error: ${msg.stopReason}${msg.errorMessage ? " - " + msg.errorMessage : ""}`,
+          );
+        } else {
+          log.info(
+            "agent",
+            `llm response: ${msg.stopReason}, ${formatTokens(msg.usage.input)} in + ${formatTokens(msg.usage.output)} out, $${msg.usage.cost.total.toFixed(4)}` +
+              (toolCallCount > 0 ? `, ${toolCallCount} tool calls` : ""),
+          );
+        }
+        break;
+      }
+    }
+  });
+}

--- a/packages/creative-agent/src/agent/model.ts
+++ b/packages/creative-agent/src/agent/model.ts
@@ -1,0 +1,52 @@
+import { getModel, type ThinkingLevel } from "@mariozechner/pi-ai";
+
+export function mapThinkingLevel(level?: string): ThinkingLevel | undefined {
+  if (!level || level === "off") return undefined;
+  return level as ThinkingLevel;
+}
+
+export function resolveModel(
+  provider: string,
+  modelId: string,
+  overrides?: { baseUrl?: string; apiFormat?: string },
+) {
+  // Custom provider with explicit baseUrl/apiFormat: build synthetic model
+  if (overrides?.baseUrl && overrides?.apiFormat) {
+    return {
+      id: modelId,
+      name: modelId,
+      api: overrides.apiFormat as any,
+      provider,
+      baseUrl: overrides.baseUrl,
+      reasoning: true,
+      input: ["text"] as ("text" | "image")[],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128_000,
+      maxTokens: 16_000,
+    };
+  }
+
+  try {
+    const model = getModel(provider as any, modelId as any);
+    if (model) return model;
+  } catch {
+    // Fall through to synthetic model
+  }
+  const apiMap: Record<string, string> = {
+    anthropic: "anthropic-messages",
+    openai: "openai-completions",
+    google: "google-generative-ai",
+  };
+  return {
+    id: modelId,
+    name: modelId,
+    api: (apiMap[provider] ?? "openai-completions") as any,
+    provider,
+    baseUrl: "",
+    reasoning: false,
+    input: ["text"] as ("text" | "image")[],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 16_000,
+  };
+}

--- a/packages/creative-agent/src/agent/orchestrator.ts
+++ b/packages/creative-agent/src/agent/orchestrator.ts
@@ -5,24 +5,25 @@
  * The consumer (webui) subscribes to AgentEvent and maps to its transport (SSE).
  */
 
-import { Agent, type AgentMessage, type AgentEvent } from "@mariozechner/pi-agent-core";
-import { getModel, getEnvApiKey, streamSimple, type AssistantMessage, type Message, type ThinkingLevel } from "@mariozechner/pi-ai";
-import { join } from "node:path";
-import { readFile } from "node:fs/promises";
-
-import { createProjectTools } from "../tools/index.js";
-import { createValidateRendererTool } from "../tools/validate-renderer.js";
-import { discoverProjectSkills } from "../skills/discovery.js";
-import { generateCatalog } from "../skills/catalog.js";
-import { createActivateSkillTool } from "../skills/manager.js";
-import type { SkillMetadata, SkillEnvironment, SkillRecord } from "../skills/types.js";
+import { Agent, type AgentMessage } from "@mariozechner/pi-agent-core";
+import { getEnvApiKey, type Message } from "@mariozechner/pi-ai";
+import type { SkillMetadata } from "../skills/types.js";
 import type { SessionMode } from "../session/format.js";
 import { microCompact, clearCompactState } from "./compact.js";
 import type { ResolvedAgentConfig } from "./config.js";
-import { analyzeContext } from "./context-analysis.js";
 import { createGoogleCacheHook, clearGoogleCache } from "./google-cache.js";
-import { formatTokens } from "@agentchan/estimate-tokens";
+import { createLoggedStreamFn, subscribeAgentLogging } from "./logging.js";
+import { mapThinkingLevel, resolveModel as resolveConfiguredModel } from "./model.js";
+import {
+  getProjectSkillMetadata,
+  getSessionSkillEnvironment,
+  loadEnvironmentSkills,
+} from "./skill-environment.js";
+import { buildSystemPrompt } from "./system-prompt.js";
+import { assembleAgentTools } from "./tool-assembly.js";
 import * as log from "../logger.js";
+
+export { resolveModel } from "./model.js";
 
 // --- Public types ---
 
@@ -32,108 +33,6 @@ export interface CreativeAgentSetup {
   historyLength: number;
   /** The assembled system prompt sent to the model. */
   systemPrompt: string;
-}
-
-// --- Constants ---
-
-const DEFAULT_SYSTEM_PROMPT = `You are a creative AI assistant with access to file tools and a skill system. You help users write fiction, design characters, build worlds, and bring creative projects to life. You work within a project directory, using tools to read, write, and organize files.
-
-# Using your tools
-
-- To see the project directory structure, use tree.
-- To search file contents by pattern, use grep.
-- To run a helper script shipped with a skill (e.g. compile, validate, analyze), use script.
-
-There is no shell tool in this environment. Do not try to call bash, sh, cmd, powershell, cat, sed, find, or echo — those tools do not exist. Use script to execute helper code shipped with a skill.
-
-# Read before you act
-
-Always read relevant files before acting on them. Do not modify, append to, or make decisions based on a file you haven't read in this conversation. When a skill or the user references a file, read it first — then proceed.`;
-
-// --- System prompt composition ---
-
-async function tryReadFile(path: string): Promise<string | null> {
-  try {
-    return await readFile(path, "utf-8");
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Compose the system prompt from up to three layers:
- * [1] DEFAULT_SYSTEM_PROMPT — hardcoded tool rules and base behavior
- * [2] SYSTEM.md content — user-authored project instructions
- * [3] Skill catalog — auto-generated name+description list
- */
-function composeSystemPrompt(
-  base: string,
-  systemMd: string | null,
-  catalog: string | null,
-): string {
-  const layers = [base, systemMd, catalog].filter(
-    (s): s is string => s != null && s.trim().length > 0,
-  );
-  return layers.join("\n\n");
-}
-
-// --- Helpers ---
-
-function truncateArgs(args: unknown): string | undefined {
-  if (args == null) return undefined;
-  const str = typeof args === "string" ? args : JSON.stringify(args);
-  return str.length > 200 ? str.slice(0, 200) + "..." : str;
-}
-
-function mapThinkingLevel(level?: string): ThinkingLevel | undefined {
-  if (!level || level === "off") return undefined;
-  return level as ThinkingLevel;
-}
-
-export function resolveModel(
-  provider: string,
-  modelId: string,
-  overrides?: { baseUrl?: string; apiFormat?: string },
-) {
-  // Custom provider with explicit baseUrl/apiFormat: build synthetic model
-  if (overrides?.baseUrl && overrides?.apiFormat) {
-    return {
-      id: modelId,
-      name: modelId,
-      api: overrides.apiFormat as any,
-      provider,
-      baseUrl: overrides.baseUrl,
-      reasoning: true,
-      input: ["text"] as ("text" | "image")[],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 128_000,
-      maxTokens: 16_000,
-    };
-  }
-
-  try {
-    const model = getModel(provider as any, modelId as any);
-    if (model) return model;
-  } catch {
-    // Fall through to synthetic model
-  }
-  const apiMap: Record<string, string> = {
-    anthropic: "anthropic-messages",
-    openai: "openai-completions",
-    google: "google-generative-ai",
-  };
-  return {
-    id: modelId,
-    name: modelId,
-    api: (apiMap[provider] ?? "openai-completions") as any,
-    provider,
-    baseUrl: "",
-    reasoning: false,
-    input: ["text"] as ("text" | "image")[],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 128_000,
-    maxTokens: 16_000,
-  };
 }
 
 // --- Skill management ---
@@ -148,8 +47,7 @@ export function clearSessionAgentState(sessionId: string): void {
 }
 
 export async function getSkills(projectDir: string): Promise<SkillMetadata[]> {
-  const skills = await discoverProjectSkills(join(projectDir, "skills"));
-  return [...skills.values()].map((s) => s.meta);
+  return getProjectSkillMetadata(projectDir);
 }
 
 // --- Main entry ---
@@ -167,34 +65,17 @@ export async function setupCreativeAgent(
   sessionId: string,
   sessionMode?: SessionMode,
 ): Promise<CreativeAgentSetup> {
-  const allSkills = await discoverProjectSkills(join(projectDir, "skills"));
-  const env: SkillEnvironment = sessionMode === "meta" ? "meta" : "creative";
-
-  // Filter skills by environment
-  const envSkills = new Map<string, SkillRecord>();
-  for (const [name, skill] of allSkills) {
-    if ((skill.meta.environment ?? "creative") === env) {
-      envSkills.set(name, skill);
-    }
-  }
-
-  // Build tools
-  const tools: any[] = createProjectTools(projectDir);
-  if (envSkills.size > 0) tools.push(createActivateSkillTool(envSkills, projectDir));
-  if (sessionMode === "meta") tools.push(createValidateRendererTool(projectDir));
-
-  // Compose system prompt: DEFAULT + system file + skill catalog
-  const systemFile = sessionMode === "meta" ? "SYSTEM.meta.md" : "SYSTEM.md";
-  const systemMd = await tryReadFile(join(projectDir, systemFile));
-  const catalog = generateCatalog([...envSkills.values()]);
-  const systemPrompt = composeSystemPrompt(DEFAULT_SYSTEM_PROMPT, systemMd, catalog);
+  const env = getSessionSkillEnvironment(sessionMode);
+  const envSkills = await loadEnvironmentSkills(projectDir, env);
+  const tools = assembleAgentTools(projectDir, envSkills, sessionMode);
+  const systemPrompt = await buildSystemPrompt(projectDir, envSkills, sessionMode);
 
   // History is already AgentMessage[] — pass directly
   const historyLength = history.length;
 
   // Create Agent
   const thinkingLevel = mapThinkingLevel(config.thinkingLevel);
-  const model = resolveModel(config.provider, config.model,
+  const model = resolveConfiguredModel(config.provider, config.model,
     config.baseUrl ? { baseUrl: config.baseUrl, apiFormat: config.apiFormat } : undefined,
   );
   if (config.contextWindow !== undefined) {
@@ -225,15 +106,7 @@ export async function setupCreativeAgent(
     sessionId,
     toolExecution: "parallel",
     steeringMode: "all",
-    streamFn: (m, ctx, opts) => {
-      const a = analyzeContext(ctx, model.contextWindow);
-      const pct = a.contextWindow > 0 ? Math.round((a.total / a.contextWindow) * 100) : 0;
-      log.info(
-        "context",
-        `system ${formatTokens(a.system)} + tools ${formatTokens(a.tools)} + msgs ${formatTokens(a.messages)} = ${formatTokens(a.total)} / ${formatTokens(a.contextWindow)} (${pct}%)`,
-      );
-      return streamSimple(m, ctx, opts);
-    },
+    streamFn: createLoggedStreamFn(model),
     ...(googleCacheHook && { onPayload: googleCacheHook }),
     ...(config.temperature !== undefined && { temperature: config.temperature }),
     ...(config.maxTokens !== undefined && { maxTokens: config.maxTokens }),
@@ -245,53 +118,7 @@ export async function setupCreativeAgent(
     `setup: ${config.provider}/${config.model} [${env}], ${envSkills.size} skills, ${tools.length} tools, ${historyLength} history msgs`,
   );
 
-  const toolStartTimes = new Map<string, number>();
-
-  agent.subscribe((event: AgentEvent) => {
-    switch (event.type) {
-      case "tool_execution_start":
-        toolStartTimes.set(event.toolCallId, Date.now());
-        if (log.isEnabled("debug")) {
-          log.debug("agent", `↳ ${event.toolName}`, truncateArgs(event.args));
-        }
-        break;
-
-      case "tool_execution_end": {
-        const started = toolStartTimes.get(event.toolCallId);
-        const dur = started
-          ? ((Date.now() - started) / 1000).toFixed(1)
-          : "?";
-        toolStartTimes.delete(event.toolCallId);
-        if (event.isError) {
-          log.error("agent", `✗ ${event.toolName} (${dur}s)`);
-        } else {
-          log.info("agent", `✓ ${event.toolName} (${dur}s)`);
-        }
-        break;
-      }
-
-      case "message_end": {
-        const msg = event.message as AssistantMessage;
-        if (msg.role !== "assistant") break;
-        const toolCallCount = msg.content.filter(
-          (b) => b.type === "toolCall",
-        ).length;
-        if (msg.stopReason === "error" || msg.stopReason === "aborted") {
-          log.error(
-            "agent",
-            `llm error: ${msg.stopReason}${msg.errorMessage ? " - " + msg.errorMessage : ""}`,
-          );
-        } else {
-          log.info(
-            "agent",
-            `llm response: ${msg.stopReason}, ${formatTokens(msg.usage.input)} in + ${formatTokens(msg.usage.output)} out, $${msg.usage.cost.total.toFixed(4)}` +
-              (toolCallCount > 0 ? `, ${toolCallCount} tool calls` : ""),
-          );
-        }
-        break;
-      }
-    }
-  });
+  subscribeAgentLogging(agent);
 
   return { agent, historyLength, systemPrompt };
 }

--- a/packages/creative-agent/src/agent/skill-environment.ts
+++ b/packages/creative-agent/src/agent/skill-environment.ts
@@ -1,0 +1,35 @@
+import { join } from "node:path";
+
+import { discoverProjectSkills } from "../skills/discovery.js";
+import type { SkillEnvironment, SkillMetadata, SkillRecord } from "../skills/types.js";
+import type { SessionMode } from "../session/format.js";
+
+export function getSessionSkillEnvironment(sessionMode?: SessionMode): SkillEnvironment {
+  return sessionMode === "meta" ? "meta" : "creative";
+}
+
+export function filterSkillsByEnvironment(
+  skills: Map<string, SkillRecord>,
+  env: SkillEnvironment,
+): Map<string, SkillRecord> {
+  const filtered = new Map<string, SkillRecord>();
+  for (const [name, skill] of skills) {
+    if ((skill.meta.environment ?? "creative") === env) {
+      filtered.set(name, skill);
+    }
+  }
+  return filtered;
+}
+
+export async function loadEnvironmentSkills(
+  projectDir: string,
+  env: SkillEnvironment,
+): Promise<Map<string, SkillRecord>> {
+  const allSkills = await discoverProjectSkills(join(projectDir, "skills"));
+  return filterSkillsByEnvironment(allSkills, env);
+}
+
+export async function getProjectSkillMetadata(projectDir: string): Promise<SkillMetadata[]> {
+  const skills = await discoverProjectSkills(join(projectDir, "skills"));
+  return [...skills.values()].map((s) => s.meta);
+}

--- a/packages/creative-agent/src/agent/system-prompt.ts
+++ b/packages/creative-agent/src/agent/system-prompt.ts
@@ -1,0 +1,50 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+import { generateCatalog } from "../skills/catalog.js";
+import type { SkillRecord } from "../skills/types.js";
+import type { SessionMode } from "../session/format.js";
+
+const DEFAULT_SYSTEM_PROMPT = `You are a creative AI assistant with access to file tools and a skill system. You help users write fiction, design characters, build worlds, and bring creative projects to life. You work within a project directory, using tools to read, write, and organize files.
+
+# Using your tools
+
+- To see the project directory structure, use tree.
+- To search file contents by pattern, use grep.
+- To run a helper script shipped with a skill (e.g. compile, validate, analyze), use script.
+
+There is no shell tool in this environment. Do not try to call bash, sh, cmd, powershell, cat, sed, find, or echo — those tools do not exist. Use script to execute helper code shipped with a skill.
+
+# Read before you act
+
+Always read relevant files before acting on them. Do not modify, append to, or make decisions based on a file you haven't read in this conversation. When a skill or the user references a file, read it first — then proceed.`;
+
+async function tryReadFile(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export function composeSystemPrompt(
+  base: string,
+  systemMd: string | null,
+  catalog: string | null,
+): string {
+  const layers = [base, systemMd, catalog].filter(
+    (s): s is string => s != null && s.trim().length > 0,
+  );
+  return layers.join("\n\n");
+}
+
+export async function buildSystemPrompt(
+  projectDir: string,
+  envSkills: Map<string, SkillRecord>,
+  sessionMode?: SessionMode,
+): Promise<string> {
+  const systemFile = sessionMode === "meta" ? "SYSTEM.meta.md" : "SYSTEM.md";
+  const systemMd = await tryReadFile(join(projectDir, systemFile));
+  const catalog = generateCatalog([...envSkills.values()]);
+  return composeSystemPrompt(DEFAULT_SYSTEM_PROMPT, systemMd, catalog);
+}

--- a/packages/creative-agent/src/agent/tool-assembly.ts
+++ b/packages/creative-agent/src/agent/tool-assembly.ts
@@ -1,0 +1,18 @@
+import type { AgentTool } from "@mariozechner/pi-agent-core";
+
+import { createProjectTools } from "../tools/index.js";
+import { createValidateRendererTool } from "../tools/validate-renderer.js";
+import { createActivateSkillTool } from "../skills/manager.js";
+import type { SkillRecord } from "../skills/types.js";
+import type { SessionMode } from "../session/format.js";
+
+export function assembleAgentTools(
+  projectDir: string,
+  envSkills: Map<string, SkillRecord>,
+  sessionMode?: SessionMode,
+): AgentTool<any, any>[] {
+  const tools: AgentTool<any, any>[] = createProjectTools(projectDir);
+  if (envSkills.size > 0) tools.push(createActivateSkillTool(envSkills, projectDir));
+  if (sessionMode === "meta") tools.push(createValidateRendererTool(projectDir));
+  return tools;
+}

--- a/packages/creative-agent/tests/agent/orchestrator-helpers.test.ts
+++ b/packages/creative-agent/tests/agent/orchestrator-helpers.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { resolveModel } from "../../src/agent/orchestrator.js";
+import { loadEnvironmentSkills } from "../../src/agent/skill-environment.js";
+import { assembleAgentTools } from "../../src/agent/tool-assembly.js";
+import { buildSystemPrompt } from "../../src/agent/system-prompt.js";
+
+let projectDir: string;
+
+const CREATIVE_SKILL = `---
+name: creative-skill
+description: creative only
+---
+
+# Creative Skill`;
+
+const META_SKILL = `---
+name: meta-skill
+description: meta only
+environment: meta
+---
+
+# Meta Skill`;
+
+beforeEach(async () => {
+  projectDir = await mkdtemp(join(tmpdir(), "orchestrator-helpers-"));
+  await mkdir(join(projectDir, "skills", "creative-skill"), { recursive: true });
+  await mkdir(join(projectDir, "skills", "meta-skill"), { recursive: true });
+  await writeFile(join(projectDir, "skills", "creative-skill", "SKILL.md"), CREATIVE_SKILL);
+  await writeFile(join(projectDir, "skills", "meta-skill", "SKILL.md"), META_SKILL);
+  await writeFile(join(projectDir, "SYSTEM.md"), "creative system");
+  await writeFile(join(projectDir, "SYSTEM.meta.md"), "meta system");
+});
+
+afterEach(async () => {
+  await rm(projectDir, { recursive: true, force: true });
+});
+
+describe("orchestrator helpers", () => {
+  test("filters skills by session environment", async () => {
+    const creativeSkills = await loadEnvironmentSkills(projectDir, "creative");
+    const metaSkills = await loadEnvironmentSkills(projectDir, "meta");
+
+    expect([...creativeSkills.keys()]).toEqual(["creative-skill"]);
+    expect([...metaSkills.keys()]).toEqual(["meta-skill"]);
+  });
+
+  test("assembles creative and meta tools in the existing order", async () => {
+    const creativeSkills = await loadEnvironmentSkills(projectDir, "creative");
+    const metaSkills = await loadEnvironmentSkills(projectDir, "meta");
+
+    const creativeTools = assembleAgentTools(projectDir, creativeSkills);
+    const metaTools = assembleAgentTools(projectDir, metaSkills, "meta");
+
+    expect(creativeTools.map((tool) => tool.name)).toEqual([
+      "script",
+      "read",
+      "write",
+      "append",
+      "edit",
+      "grep",
+      "tree",
+      "activate_skill",
+    ]);
+    expect(metaTools.map((tool) => tool.name)).toEqual([
+      "script",
+      "read",
+      "write",
+      "append",
+      "edit",
+      "grep",
+      "tree",
+      "activate_skill",
+      "validate-renderer",
+    ]);
+  });
+
+  test("builds prompts from the matching system file and skill catalog", async () => {
+    const creativeSkills = await loadEnvironmentSkills(projectDir, "creative");
+    const metaSkills = await loadEnvironmentSkills(projectDir, "meta");
+
+    const creativePrompt = await buildSystemPrompt(projectDir, creativeSkills);
+    const metaPrompt = await buildSystemPrompt(projectDir, metaSkills, "meta");
+
+    expect(creativePrompt).toContain("creative system");
+    expect(creativePrompt).toContain("- creative-skill: creative only");
+    expect(creativePrompt).not.toContain("meta system");
+    expect(creativePrompt).not.toContain("- meta-skill: meta only");
+
+    expect(metaPrompt).toContain("meta system");
+    expect(metaPrompt).toContain("- meta-skill: meta only");
+    expect(metaPrompt).not.toContain("creative system");
+    expect(metaPrompt).not.toContain("- creative-skill: creative only");
+  });
+
+  test("keeps custom provider model resolution behavior", () => {
+    const model = resolveModel("custom", "local-model", {
+      baseUrl: "http://localhost:11434",
+      apiFormat: "openai-completions",
+    });
+
+    expect(model).toMatchObject({
+      id: "local-model",
+      name: "local-model",
+      api: "openai-completions",
+      provider: "custom",
+      baseUrl: "http://localhost:11434",
+      reasoning: true,
+      contextWindow: 128_000,
+      maxTokens: 16_000,
+    });
+  });
+});


### PR DESCRIPTION
## 현재 동작
- `setupCreativeAgent`, `resolveModel`, `getSkills` public API는 유지한다.
- system prompt 내용, skill environment filtering, tool order, Google cache, micro compact, streaming call path는 유지한다.
- JSONL/session format 코드는 변경하지 않았다.

## 구조 개선
- model resolution/thinking mapping을 `model.ts`로 분리했다.
- skill environment loading/filtering을 `skill-environment.ts`로 분리했다.
- project/meta tool assembly를 `tool-assembly.ts`로 분리했다.
- system prompt composition을 `system-prompt.ts`로 분리했다.
- context/agent logging을 `logging.ts`로 분리했다.
- helper behavior 회귀 테스트를 추가했다.

## 검증
- `cd packages/creative-agent && bunx tsc --noEmit`
- `cd packages/creative-agent && bun test tests/agent tests/session tests/tools` (146 pass)
- `git diff --check`

## 남은 리스크
- 실제 LLM streaming/abort 통합 실행은 별도 환경 의존이라 수행하지 않았다.