### PR TITLE
refactor(webui): move project file serving into service

### DIFF
--- a/apps/webui/src/server/repositories/project.repo.ts
+++ b/apps/webui/src/server/repositories/project.repo.ts
@@ -3,13 +3,18 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve, sep } from "node:path";
 import { slugify, scanWorkspaceFiles, type ProjectFile } from "@agentchan/creative-agent";
 import type { Project, ProjectMeta } from "../types.js";
-import { probeCover } from "../paths.js";
+import { IMAGE_EXTS, probeCover } from "../paths.js";
 
 export interface TreeEntry {
   path: string;
   type: "file" | "dir";
   modifiedAt?: number;
 }
+
+export type WorkspaceFileResult =
+  | { status: "found"; file: ReturnType<typeof Bun.file>; cacheControl?: string }
+  | { status: "invalid-path" }
+  | { status: "not-found" };
 
 const HIDDEN_ROOTS = new Set(["_project.json", "sessions"]);
 
@@ -92,6 +97,10 @@ export function createProjectRepo(projectsDir: string) {
       if (!existsSync(metaPath)) return null;
       const meta = JSON.parse(await readFile(metaPath, "utf-8")) as ProjectMeta;
       return { ...meta, slug };
+    },
+
+    exists(slug: string): boolean {
+      return existsSync(projectMetaPath(slug));
     },
 
     async create(name: string): Promise<Project> {
@@ -194,6 +203,27 @@ export function createProjectRepo(projectsDir: string) {
       if (HIDDEN_ROOTS.has(topSegment)) return null;
 
       return { fullPath };
+    },
+
+    async getWorkspaceFile(slug: string, filePath: string): Promise<WorkspaceFileResult> {
+      const resolved = this.resolveProjectFile(slug, `files/${filePath}`);
+      if (!resolved) return { status: "invalid-path" };
+
+      const file = Bun.file(resolved.fullPath);
+      if (await file.exists()) return { status: "found", file };
+
+      for (const ext of IMAGE_EXTS) {
+        const fallback = Bun.file(`${resolved.fullPath}.${ext}`);
+        if (await fallback.exists()) {
+          return {
+            status: "found",
+            file: fallback,
+            cacheControl: "public, max-age=3600",
+          };
+        }
+      }
+
+      return { status: "not-found" };
     },
 
     async readProjectFile(slug: string, filePath: string): Promise<string | null> {

--- a/apps/webui/src/server/routes/projects.routes.ts
+++ b/apps/webui/src/server/routes/projects.routes.ts
@@ -3,9 +3,14 @@ import type { AppEnv } from "../types.js";
 import { createSessionRoutes } from "./sessions.routes.js";
 import { createSkillRoutes } from "./skills.routes.js";
 
-import { IMAGE_EXTS } from "../paths.js";
 import { readmeResponse } from "../readme.js";
 import { TrustRequiredError } from "../services/template-trust.service.js";
+
+const PROJECT_NOT_FOUND = { error: "Project not found" } as const;
+
+function errorMessage(err: unknown, fallback: string): string {
+  return err instanceof Error ? err.message : fallback;
+}
 
 export function createProjectRoutes() {
   const app = new Hono<AppEnv>();
@@ -38,28 +43,24 @@ export function createProjectRoutes() {
     const slug = c.req.param("slug");
     const body = await c.req.json<{ name?: string; notes?: string }>();
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     const updates: { name?: string; notes?: string } = {};
     if (body.name?.trim()) updates.name = body.name.trim();
     if (body.notes !== undefined) updates.notes = body.notes;
 
     const updated = await c.get("projectService").update(slug, updates);
+    if (!updated) return c.json(PROJECT_NOT_FOUND, 404);
     return c.json(updated);
   });
 
   app.delete("/:slug", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
 
     try {
-      await c.get("projectService").delete(slug);
+      const deleted = await c.get("projectService").delete(slug);
+      if (!deleted) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to delete project";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to delete project") }, 400);
     }
   });
 
@@ -72,8 +73,7 @@ export function createProjectRoutes() {
       const project = await c.get("projectService").duplicate(slug, name.trim());
       return c.json(project, 201);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to duplicate project";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to duplicate project") }, 400);
     }
   });
 
@@ -89,8 +89,7 @@ export function createProjectRoutes() {
 
     if (!name?.trim()) return c.json({ error: "Name is required" }, 400);
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
+    if (!c.get("projectService").exists(slug)) return c.json(PROJECT_NOT_FOUND, 404);
 
     try {
       const result = await c.get("templateService").saveProjectAsTemplate(slug, {
@@ -104,17 +103,14 @@ export function createProjectRoutes() {
       }
       return c.json({ ok: true }, 201);
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to save as template";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to save as template") }, 400);
     }
   });
 
   app.get("/:slug/workspace/files", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     const files = await c.get("projectService").scanWorkspaceFiles(slug);
+    if (!files) return c.json(PROJECT_NOT_FOUND, 404);
     return c.json({ files });
   });
 
@@ -138,9 +134,8 @@ export function createProjectRoutes() {
 
   app.get("/:slug/readme", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-    const raw = (await c.get("projectService").readProjectFile(slug, "README.md")) ?? "";
+    const raw = await c.get("projectService").getReadme(slug);
+    if (raw === null) return c.json(PROJECT_NOT_FOUND, 404);
     return c.json(readmeResponse(raw));
   });
 
@@ -150,31 +145,19 @@ export function createProjectRoutes() {
     const filePath = c.req.param("path");
     if (!filePath) return c.json({ error: "Invalid path" }, 400);
 
-    const resolved = c.get("projectService").serveWorkspaceFile(slug, filePath);
-    if (!resolved) return c.json({ error: "Invalid path" }, 400);
-
-    const file = Bun.file(resolved.fullPath);
-    if (await file.exists()) return new Response(file);
-
-    for (const ext of IMAGE_EXTS) {
-      const probe = Bun.file(`${resolved.fullPath}.${ext}`);
-      if (await probe.exists()) {
-        c.header("Cache-Control", "public, max-age=3600");
-        return new Response(probe);
-      }
-    }
-
-    return c.json({ error: "File not found" }, 404);
+    const result = await c.get("projectService").serveWorkspaceFile(slug, filePath);
+    if (result.status === "invalid-path") return c.json({ error: "Invalid path" }, 400);
+    if (result.status === "not-found") return c.json({ error: "File not found" }, 404);
+    if (result.cacheControl) c.header("Cache-Control", result.cacheControl);
+    return new Response(result.file);
   });
 
   // --- Project tree (for edit mode) ---
 
   app.get("/:slug/tree", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     const entries = await c.get("projectService").scanProjectTree(slug);
+    if (!entries) return c.json(PROJECT_NOT_FOUND, 404);
     return c.json({ entries });
   });
 
@@ -195,35 +178,29 @@ export function createProjectRoutes() {
     const path = c.req.query("path");
     if (!path) return c.json({ error: "path query parameter is required" }, 400);
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     const { content } = await c.req.json<{ content: string }>();
     if (typeof content !== "string") return c.json({ error: "content is required" }, 400);
 
     try {
-      await c.get("projectService").writeProjectFile(slug, path, content);
+      const written = await c.get("projectService").writeProjectFile(slug, path, content);
+      if (written === false) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to write file";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to write file") }, 400);
     }
   });
 
-  app.post("/:slug/file/reveal", async (c) => {
+  app.post("/:slug/file/reveal", (c) => {
     const slug = c.req.param("slug");
     const path = c.req.query("path");
     if (!path) return c.json({ error: "path query parameter is required" }, 400);
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     try {
-      c.get("projectService").revealFileInExplorer(slug, path);
+      const revealed = c.get("projectService").revealFileInExplorer(slug, path);
+      if (!revealed) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to reveal file";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to reveal file") }, 400);
     }
   });
 
@@ -232,15 +209,12 @@ export function createProjectRoutes() {
     const path = c.req.query("path");
     if (!path) return c.json({ error: "path query parameter is required" }, 400);
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     try {
-      await c.get("projectService").deleteProjectFile(slug, path);
+      const deleted = await c.get("projectService").deleteProjectFile(slug, path);
+      if (!deleted) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to delete file";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to delete file") }, 400);
     }
   });
 
@@ -249,49 +223,42 @@ export function createProjectRoutes() {
     const path = c.req.query("path");
     if (!path) return c.json({ error: "path query parameter is required" }, 400);
 
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
-
     try {
-      await c.get("projectService").deleteProjectDir(slug, path);
+      const deleted = await c.get("projectService").deleteProjectDir(slug, path);
+      if (!deleted) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to delete directory";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to delete directory") }, 400);
     }
   });
 
   app.post("/:slug/file/rename", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
 
     const { from, to } = await c.req.json<{ from: string; to: string }>();
     if (!from || !to) return c.json({ error: "from and to are required" }, 400);
 
     try {
-      await c.get("projectService").renameProjectEntry(slug, from, to);
+      const renamed = await c.get("projectService").renameProjectEntry(slug, from, to);
+      if (!renamed) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to rename";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to rename") }, 400);
     }
   });
 
   app.post("/:slug/dir", async (c) => {
     const slug = c.req.param("slug");
-    const existing = await c.get("projectService").get(slug);
-    if (!existing) return c.json({ error: "Project not found" }, 404);
 
     const { path } = await c.req.json<{ path: string }>();
     if (!path) return c.json({ error: "path is required" }, 400);
 
     try {
-      await c.get("projectService").createProjectDir(slug, path);
+      const created = await c.get("projectService").createProjectDir(slug, path);
+      if (!created) return c.json(PROJECT_NOT_FOUND, 404);
       return c.json({ ok: true });
     } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : "Failed to create directory";
-      return c.json({ error: message }, 400);
+      return c.json({ error: errorMessage(err, "Failed to create directory") }, 400);
     }
   });
 

--- a/apps/webui/src/server/services/project.service.ts
+++ b/apps/webui/src/server/services/project.service.ts
@@ -14,11 +14,17 @@ export function createProjectService(
     async list() { return projectRepo.list(); },
     async getCoverFile(slug: string) { return projectRepo.getCoverFile(slug); },
     async get(slug: string) { return projectRepo.get(slug); },
+    exists(slug: string) { return projectRepo.exists(slug); },
     async create(name: string) { return projectRepo.create(name); },
     async update(slug: string, updates: { name?: string; notes?: string }) {
+      if (!projectRepo.exists(slug)) return null;
       return projectRepo.update(slug, updates);
     },
-    async delete(slug: string) { return projectRepo.delete(slug); },
+    async delete(slug: string) {
+      if (!projectRepo.exists(slug)) return false;
+      await projectRepo.delete(slug);
+      return true;
+    },
     async duplicate(sourceSlug: string, name: string) { return projectRepo.duplicate(sourceSlug, name); },
     async createFromTemplate(name: string, templateName: string) {
       if (!trustService.isTrusted(templateName)) {
@@ -28,11 +34,18 @@ export function createProjectService(
       return projectRepo.createFromSource(name, templateDir);
     },
     async scanWorkspaceFiles(slug: string) {
+      if (!projectRepo.exists(slug)) return null;
       return projectRepo.scanWorkspaceFiles(slug);
     },
 
     async scanProjectTree(slug: string) {
+      if (!projectRepo.exists(slug)) return null;
       return projectRepo.scanProjectTree(slug);
+    },
+
+    async getReadme(slug: string) {
+      if (!projectRepo.exists(slug)) return null;
+      return (await projectRepo.readProjectFile(slug, "README.md")) ?? "";
     },
 
     async readProjectFile(slug: string, filePath: string) {
@@ -40,34 +53,44 @@ export function createProjectService(
     },
 
     async writeProjectFile(slug: string, filePath: string, content: string) {
+      if (!projectRepo.exists(slug)) return false;
       return projectRepo.writeProjectFile(slug, filePath, content);
     },
 
     async deleteProjectFile(slug: string, filePath: string) {
-      return projectRepo.deleteProjectFile(slug, filePath);
+      if (!projectRepo.exists(slug)) return false;
+      await projectRepo.deleteProjectFile(slug, filePath);
+      return true;
     },
 
     async deleteProjectDir(slug: string, dirPath: string) {
-      return projectRepo.deleteProjectDir(slug, dirPath);
+      if (!projectRepo.exists(slug)) return false;
+      await projectRepo.deleteProjectDir(slug, dirPath);
+      return true;
     },
 
     async renameProjectEntry(slug: string, fromPath: string, toPath: string) {
-      return projectRepo.renameProjectEntry(slug, fromPath, toPath);
+      if (!projectRepo.exists(slug)) return false;
+      await projectRepo.renameProjectEntry(slug, fromPath, toPath);
+      return true;
     },
 
     async createProjectDir(slug: string, dirPath: string) {
-      return projectRepo.createProjectDir(slug, dirPath);
+      if (!projectRepo.exists(slug)) return false;
+      await projectRepo.createProjectDir(slug, dirPath);
+      return true;
     },
 
     async buildRenderer(slug: string) {
       return buildRendererBundle(join(projectsDir, slug));
     },
 
-    serveWorkspaceFile(slug: string, filePath: string): { fullPath: string } | null {
-      return projectRepo.resolveProjectFile(slug, `files/${filePath}`);
+    async serveWorkspaceFile(slug: string, filePath: string) {
+      return projectRepo.getWorkspaceFile(slug, filePath);
     },
 
-    revealFileInExplorer(slug: string, filePath: string): void {
+    revealFileInExplorer(slug: string, filePath: string): boolean {
+      if (!projectRepo.exists(slug)) return false;
       const resolved = projectRepo.resolveProjectFile(slug, filePath);
       if (!resolved) throw new Error(`Invalid path: ${filePath}`);
 
@@ -79,6 +102,7 @@ export function createProjectService(
             ? ["open", "-R", fullPath]
             : ["xdg-open", dirname(fullPath)];
       Bun.spawn(cmd, { stdio: ["ignore", "ignore", "ignore"] });
+      return true;
     },
   };
 }


### PR DESCRIPTION
## 현재 동작
- Project routes는 기존 API path, status code, response shape를 유지한다.
- `files/` static serving은 기존처럼 extensionless image fallback을 지원한다.
- project file CRUD의 에러 매핑은 기존 route behavior를 유지한다.

## 구조 개선
- `projects.routes.ts`에서 `IMAGE_EXTS`, `Bun.file`, fallback probing 직접 처리를 제거했다.
- file serving과 project existence 정책을 service/repository 경계로 이동했다.
- route는 request parsing, validation, HTTP response mapping에 더 집중하게 정리했다.

## 검증
- `bunx tsc --noEmit`
- `bun run --cwd apps/webui lint`
- `git diff --check`

## 남은 리스크
- webui server route 전용 테스트가 없어 HTTP runtime smoke는 별도 후속 검증이 필요하다.