### PR TITLE
refactor(webui): split config service helpers

### DIFF
--- a/apps/webui/src/server/services/config.persistence.ts
+++ b/apps/webui/src/server/services/config.persistence.ts
@@ -1,0 +1,176 @@
+import { DEFAULT_THINKING_LEVEL } from "@agentchan/creative-agent";
+import type { ServerConfig, CustomProviderDef } from "../types.js";
+import type { SettingsRepo } from "../repositories/settings.repo.js";
+import { DEFAULT_PROVIDER, type ProviderRegistry } from "./config.providers.js";
+
+const CUSTOM_PROVIDERS_KEY = "custom-providers";
+
+export function createCustomProviderStore(settingsRepo: SettingsRepo) {
+  function load(): CustomProviderDef[] {
+    const raw = settingsRepo.getAppSetting(CUSTOM_PROVIDERS_KEY);
+    if (!raw) return [];
+    try {
+      return JSON.parse(raw) as CustomProviderDef[];
+    } catch {
+      return [];
+    }
+  }
+
+  function save(providers: CustomProviderDef[]): void {
+    settingsRepo.setAppSetting(CUSTOM_PROVIDERS_KEY, JSON.stringify(providers));
+  }
+
+  return {
+    load,
+
+    saveProvider(provider: CustomProviderDef): CustomProviderDef[] {
+      const providers = load();
+      const idx = providers.findIndex((p) => p.name === provider.name);
+      if (idx >= 0) {
+        providers[idx] = provider;
+      } else {
+        providers.push(provider);
+      }
+      save(providers);
+      return providers;
+    },
+
+    deleteProvider(name: string): CustomProviderDef[] {
+      const providers = load().filter((p) => p.name !== name);
+      save(providers);
+      return providers;
+    },
+  };
+}
+
+function loadNumber(
+  settingsRepo: SettingsRepo,
+  key: string,
+  parse: (raw: string) => number,
+  min: number,
+  max?: number,
+): number | undefined {
+  const raw = settingsRepo.getAppSetting(key);
+  if (raw == null) return undefined;
+  const value = parse(raw);
+  if (!Number.isFinite(value)) return undefined;
+  if (value < min) return undefined;
+  if (max !== undefined && value > max) return undefined;
+  return value;
+}
+
+function loadThinkingLevel(settingsRepo: SettingsRepo) {
+  const raw = settingsRepo.getAppSetting("config.thinkingLevel");
+  if (raw === "off" || raw === "low" || raw === "medium" || raw === "high") return raw;
+  return undefined;
+}
+
+function resolveSavedModel(
+  savedModel: string | null,
+  provider: string,
+  registry: ProviderRegistry,
+): string {
+  const providerInfo = registry.findProvider(provider);
+  if (providerInfo?.custom) {
+    return savedModel ?? (providerInfo.defaultModel ?? "");
+  }
+
+  if (registry.isOAuthProvider(provider)) {
+    const known = new Set(providerInfo?.models.map((m) => m.id) ?? []);
+    return savedModel && known.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
+  }
+
+  return savedModel && registry.isAllowedBuiltinModel(savedModel)
+    ? savedModel
+    : (providerInfo?.defaultModel ?? "");
+}
+
+function loadConfig(settingsRepo: SettingsRepo, registry: ProviderRegistry): ServerConfig {
+  const savedProvider = settingsRepo.getAppSetting("config.provider");
+  const savedModel = settingsRepo.getAppSetting("config.model");
+  const provider = savedProvider && registry.isKnownProvider(savedProvider) ? savedProvider : DEFAULT_PROVIDER;
+
+  return {
+    provider,
+    model: resolveSavedModel(savedModel, provider, registry),
+    temperature: loadNumber(settingsRepo, "config.temperature", parseFloat, 0, 2),
+    maxTokens: loadNumber(settingsRepo, "config.maxTokens", (s) => parseInt(s, 10), 1),
+    contextWindow: loadNumber(settingsRepo, "config.contextWindow", (s) => parseInt(s, 10), 1024),
+    thinkingLevel: loadThinkingLevel(settingsRepo) ?? DEFAULT_THINKING_LEVEL,
+  };
+}
+
+export function createConfigState(settingsRepo: SettingsRepo, registry: ProviderRegistry) {
+  const currentConfig: ServerConfig = loadConfig(settingsRepo, registry);
+
+  function persistProviderAndModel(): void {
+    settingsRepo.setAppSetting("config.provider", currentConfig.provider);
+    settingsRepo.setAppSetting("config.model", currentConfig.model);
+  }
+
+  function setProviderToDefault(): void {
+    currentConfig.provider = DEFAULT_PROVIDER;
+    currentConfig.model = registry.findProvider(DEFAULT_PROVIDER)?.defaultModel ?? "";
+    persistProviderAndModel();
+  }
+
+  function persistOptionalNumber(
+    body: Partial<ServerConfig>,
+    field: "temperature" | "maxTokens" | "contextWindow",
+  ): void {
+    if (!(field in body)) return;
+    const key = `config.${field}`;
+    const value = body[field];
+    if (value == null) {
+      currentConfig[field] = undefined;
+      settingsRepo.deleteAppSetting(key);
+    } else {
+      currentConfig[field] = value;
+      settingsRepo.setAppSetting(key, String(value));
+    }
+  }
+
+  function persistThinkingLevel(body: Partial<ServerConfig>): void {
+    if (!("thinkingLevel" in body)) return;
+    const level = body.thinkingLevel;
+    if (level == null) {
+      currentConfig.thinkingLevel = DEFAULT_THINKING_LEVEL;
+      settingsRepo.deleteAppSetting("config.thinkingLevel");
+    } else {
+      currentConfig.thinkingLevel = level;
+      settingsRepo.setAppSetting("config.thinkingLevel", level);
+    }
+  }
+
+  return {
+    getConfig(): ServerConfig {
+      return { ...currentConfig };
+    },
+
+    updateConfig(body: Partial<ServerConfig>): ServerConfig {
+      if (body.provider) {
+        currentConfig.provider = body.provider;
+        if (!body.model) {
+          currentConfig.model = registry.findProvider(body.provider)?.defaultModel ?? currentConfig.model;
+        }
+      }
+      if (body.model) {
+        currentConfig.model = body.model;
+      }
+
+      persistOptionalNumber(body, "temperature");
+      persistOptionalNumber(body, "maxTokens");
+      persistOptionalNumber(body, "contextWindow");
+      persistThinkingLevel(body);
+      persistProviderAndModel();
+
+      return { ...currentConfig };
+    },
+
+    resetIfActiveProvider(provider: string): void {
+      if (currentConfig.provider === provider) {
+        setProviderToDefault();
+      }
+    },
+  };
+}

--- a/apps/webui/src/server/services/config.providers.ts
+++ b/apps/webui/src/server/services/config.providers.ts
@@ -1,0 +1,140 @@
+import { getProviders, getModels, type ModelInfo } from "@agentchan/creative-agent";
+import type { ProviderInfo, CustomProviderDef } from "../types.js";
+import type { SettingsRepo } from "../repositories/settings.repo.js";
+
+type PiModel = ReturnType<typeof getModels>[number];
+
+const BUILTIN_PROVIDERS = new Set([
+  "google",
+  "google-vertex",
+  "openai",
+  "anthropic",
+  "vercel-ai-gateway",
+  "zai",
+  "github-copilot",
+]);
+
+const OAUTH_PROVIDER_NAMES = new Set(["github-copilot"]);
+
+const ALLOWED_MODELS = new Set([
+  // Anthropic
+  "claude-opus-4-6",
+  "claude-sonnet-4-6",
+  "claude-haiku-4-5",
+  // Google
+  "gemini-3.1-pro-preview",
+  "gemini-3-flash-preview",
+  "gemini-3.1-flash-lite-preview",
+  // OpenAI
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.2",
+  "gpt-5.1",
+  "o4-mini",
+  "o3-mini",
+  // Vercel AI Gateway
+  "anthropic/claude-opus-4-6",
+  "anthropic/claude-sonnet-4-6",
+  "anthropic/claude-haiku-4-5",
+  "openai/gpt-5.4",
+  "openai/gpt-5.4-mini",
+  "openai/o4-mini",
+  "openai/o3-mini",
+  "google/gemini-3.1-pro-preview",
+  "google/gemini-3-flash",
+  "google/gemini-3.1-flash-lite-preview",
+  "deepseek/deepseek-v3.2",
+  "xai/grok-4.1-fast-non-reasoning",
+  // Z.ai
+  "glm-5",
+  "glm-5.1",
+]);
+
+export const DEFAULT_PROVIDER = "google";
+
+function toModelInfo(m: PiModel): ModelInfo {
+  return {
+    id: m.id,
+    name: m.name,
+    reasoning: m.reasoning,
+    contextWindow: m.contextWindow,
+    maxTokens: m.maxTokens,
+  };
+}
+
+function toCustomProviderInfo(provider: CustomProviderDef): ProviderInfo {
+  return {
+    name: provider.name,
+    defaultModel: provider.models[0]?.id ?? "",
+    models: provider.models.map((m) => ({ id: m.id, name: m.name, reasoning: false })),
+    custom: { url: provider.url, format: provider.format },
+  };
+}
+
+export function isOAuthProviderName(provider: string): boolean {
+  return OAUTH_PROVIDER_NAMES.has(provider);
+}
+
+export function createProviderRegistry(
+  settingsRepo: SettingsRepo,
+  loadCustomProviders: () => CustomProviderDef[],
+) {
+  let providerListCache: ProviderInfo[] | null = null;
+
+  function hasOAuthCredentials(provider: string): boolean {
+    return settingsRepo.getOAuthCredentials(provider) != null;
+  }
+
+  function toBuiltInProviderInfo(name: string): ProviderInfo {
+    if (isOAuthProviderName(name)) {
+      const models = hasOAuthCredentials(name) ? getModels(name).map(toModelInfo) : [];
+      return { name, defaultModel: models[0]?.id ?? "", models, oauth: true };
+    }
+
+    const models = getModels(name)
+      .filter((m) => ALLOWED_MODELS.has(m.id))
+      .map(toModelInfo);
+    return {
+      name,
+      defaultModel: models[0]?.id ?? "",
+      models,
+    };
+  }
+
+  function buildProviderList(): ProviderInfo[] {
+    const builtIn = getProviders()
+      .filter((name) => BUILTIN_PROVIDERS.has(name))
+      .map(toBuiltInProviderInfo);
+    const custom = loadCustomProviders().map(toCustomProviderInfo);
+    return [...builtIn, ...custom];
+  }
+
+  function getProviderList(): ProviderInfo[] {
+    if (!providerListCache) providerListCache = buildProviderList();
+    return providerListCache;
+  }
+
+  return {
+    getProviderList,
+
+    findProvider(name: string): ProviderInfo | undefined {
+      return getProviderList().find((p) => p.name === name);
+    },
+
+    isKnownProvider(name: string): boolean {
+      return getProviderList().some((p) => p.name === name);
+    },
+
+    isAllowedBuiltinModel(model: string): boolean {
+      return ALLOWED_MODELS.has(model);
+    },
+
+    isOAuthProvider: isOAuthProviderName,
+
+    invalidate(): void {
+      providerListCache = null;
+    },
+  };
+}
+
+export type ProviderRegistry = ReturnType<typeof createProviderRegistry>;

--- a/apps/webui/src/server/services/config.service.ts
+++ b/apps/webui/src/server/services/config.service.ts
@@ -1,72 +1,14 @@
-import { getProviders, getModels, DEFAULT_THINKING_LEVEL, type ModelInfo } from "@agentchan/creative-agent";
+import { getModels } from "@agentchan/creative-agent";
 import {
   getOAuthApiKey,
   getOAuthProvider,
   getGitHubCopilotBaseUrl,
   type OAuthLoginCallbacks,
 } from "@mariozechner/pi-ai/oauth";
-import type { ServerConfig, ProviderInfo, CustomProviderDef } from "../types.js";
+import type { ServerConfig, CustomProviderDef } from "../types.js";
 import type { SettingsRepo } from "../repositories/settings.repo.js";
-
-type PiModel = ReturnType<typeof getModels>[number];
-
-function toModelInfo(m: PiModel): ModelInfo {
-  return {
-    id: m.id,
-    name: m.name,
-    reasoning: m.reasoning,
-    contextWindow: m.contextWindow,
-    maxTokens: m.maxTokens,
-  };
-}
-
-const BUILTIN_PROVIDERS = new Set([
-  "google",
-  "google-vertex",
-  "openai",
-  "anthropic",
-  "vercel-ai-gateway",
-  "zai",
-  "github-copilot",
-]);
-
-const OAUTH_PROVIDERS = new Set(["github-copilot"]);
-
-const ALLOWED_MODELS = new Set([
-  // Anthropic
-  "claude-opus-4-6",
-  "claude-sonnet-4-6",
-  "claude-haiku-4-5",
-  // Google
-  "gemini-3.1-pro-preview",
-  "gemini-3-flash-preview",
-  "gemini-3.1-flash-lite-preview",
-  // OpenAI
-  "gpt-5.4",
-  "gpt-5.4-mini",
-  "gpt-5.2",
-  "gpt-5.1",
-  "o4-mini",
-  "o3-mini",
-  // Vercel AI Gateway
-  "anthropic/claude-opus-4-6",
-  "anthropic/claude-sonnet-4-6",
-  "anthropic/claude-haiku-4-5",
-  "openai/gpt-5.4",
-  "openai/gpt-5.4-mini",
-  "openai/o4-mini",
-  "openai/o3-mini",
-  "google/gemini-3.1-pro-preview",
-  "google/gemini-3-flash",
-  "google/gemini-3.1-flash-lite-preview",
-  "deepseek/deepseek-v3.2",
-  "xai/grok-4.1-fast-non-reasoning",
-  // Z.ai
-  "glm-5",
-  "glm-5.1",
-]);
-
-const DEFAULT_PROVIDER = "google";
+import { createProviderRegistry } from "./config.providers.js";
+import { createConfigState, createCustomProviderStore } from "./config.persistence.js";
 
 const COPILOT_HEADERS: Record<string, string> = {
   "User-Agent": "GitHubCopilotChat/0.35.0",
@@ -77,9 +19,8 @@ const COPILOT_HEADERS: Record<string, string> = {
 
 async function enableAllCopilotModels(token: string): Promise<void> {
   const baseUrl = getGitHubCopilotBaseUrl(token);
-  const models = getModels("github-copilot");
   await Promise.all(
-    models.map(async (m) => {
+    getModels("github-copilot").map(async (m) => {
       try {
         await fetch(`${baseUrl}/models/${m.id}/policy`, {
           method: "POST",
@@ -107,214 +48,54 @@ export type OAuthStatus = {
 };
 
 export function createConfigService(settingsRepo: SettingsRepo) {
-  // --- Custom providers persistence ---
+  const customProviders = createCustomProviderStore(settingsRepo);
+  const providerRegistry = createProviderRegistry(settingsRepo, customProviders.load);
+  const configState = createConfigState(settingsRepo, providerRegistry);
 
-  function loadCustomProviders(): CustomProviderDef[] {
-    const raw = settingsRepo.getAppSetting("custom-providers");
-    if (!raw) return [];
-    try { return JSON.parse(raw); } catch { return []; }
+  function resetActiveProvider(provider: string): void {
+    providerRegistry.invalidate();
+    configState.resetIfActiveProvider(provider);
   }
-
-  function saveCustomProviders(providers: CustomProviderDef[]): void {
-    settingsRepo.setAppSetting("custom-providers", JSON.stringify(providers));
-  }
-
-  function hasOAuthCredentials(provider: string): boolean {
-    return settingsRepo.getOAuthCredentials(provider) != null;
-  }
-
-  function buildProviderList(): ProviderInfo[] {
-    const builtIn: ProviderInfo[] = getProviders()
-      .filter((name) => BUILTIN_PROVIDERS.has(name))
-      .map((name) => {
-        // OAuth provider (e.g. github-copilot): model list comes from pi-ai as-is,
-        // but hidden until user signs in so selecting it can't silently fail.
-        if (OAUTH_PROVIDERS.has(name)) {
-          const models = hasOAuthCredentials(name) ? getModels(name).map(toModelInfo) : [];
-          return { name, defaultModel: models[0]?.id ?? "", models, oauth: true };
-        }
-        const models = getModels(name)
-          .filter((m) => ALLOWED_MODELS.has(m.id))
-          .map(toModelInfo);
-        return {
-          name,
-          defaultModel: models[0]?.id ?? "",
-          models,
-        };
-      });
-
-    const custom: ProviderInfo[] = loadCustomProviders().map((p) => ({
-      name: p.name,
-      defaultModel: p.models[0]?.id ?? "",
-      models: p.models.map((m) => ({ id: m.id, name: m.name, reasoning: false })),
-      custom: { url: p.url, format: p.format },
-    }));
-
-    return [...builtIn, ...custom];
-  }
-
-  let providerListCache: ProviderInfo[] | null = null;
-  function getProviderList(): ProviderInfo[] {
-    if (!providerListCache) providerListCache = buildProviderList();
-    return providerListCache;
-  }
-
-  function invalidateProviderCache(): void {
-    providerListCache = null;
-  }
-
-  function findProvider(name: string): ProviderInfo | undefined {
-    return getProviderList().find((p) => p.name === name);
-  }
-
-  function isKnownProvider(name: string): boolean {
-    return getProviderList().some((p) => p.name === name);
-  }
-
-  function loadNumber(
-    key: string,
-    parse: (raw: string) => number,
-    min: number,
-    max?: number,
-  ): number | undefined {
-    const raw = settingsRepo.getAppSetting(key);
-    if (raw == null) return undefined;
-    const value = parse(raw);
-    if (!Number.isFinite(value)) return undefined;
-    if (value < min) return undefined;
-    if (max !== undefined && value > max) return undefined;
-    return value;
-  }
-
-  function loadThinkingLevel() {
-    const raw = settingsRepo.getAppSetting("config.thinkingLevel");
-    if (raw === "off" || raw === "low" || raw === "medium" || raw === "high") return raw;
-    return undefined;
-  }
-
-  function loadConfig(): ServerConfig {
-    const savedProvider = settingsRepo.getAppSetting("config.provider");
-    const savedModel = settingsRepo.getAppSetting("config.model");
-    const provider = savedProvider && isKnownProvider(savedProvider) ? savedProvider : DEFAULT_PROVIDER;
-    const providerInfo = getProviderList().find((p) => p.name === provider);
-
-    let model: string;
-    if (providerInfo?.custom) {
-      // Custom providers: accept any saved model, fallback to default
-      model = savedModel ?? (providerInfo?.defaultModel ?? "");
-    } else if (OAUTH_PROVIDERS.has(provider)) {
-      // OAuth providers: pi-ai is source of truth for model list, not ALLOWED_MODELS
-      const known = new Set(providerInfo?.models.map((m) => m.id) ?? []);
-      model = savedModel && known.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
-    } else {
-      model = savedModel && ALLOWED_MODELS.has(savedModel) ? savedModel : (providerInfo?.defaultModel ?? "");
-    }
-
-    return {
-      provider,
-      model,
-      temperature: loadNumber("config.temperature", parseFloat, 0, 2),
-      maxTokens: loadNumber("config.maxTokens", (s) => parseInt(s, 10), 1),
-      contextWindow: loadNumber("config.contextWindow", (s) => parseInt(s, 10), 1024),
-      thinkingLevel: loadThinkingLevel() ?? DEFAULT_THINKING_LEVEL,
-    };
-  }
-
-  const currentConfig: ServerConfig = loadConfig();
 
   return {
     getConfig(): ServerConfig {
-      return { ...currentConfig };
+      return configState.getConfig();
     },
 
     updateConfig(body: Partial<ServerConfig>): ServerConfig {
-      if (body.provider) {
-        currentConfig.provider = body.provider;
-        if (!body.model) {
-          const providerInfo = getProviderList().find((p) => p.name === body.provider);
-          currentConfig.model = providerInfo?.defaultModel ?? currentConfig.model;
-        }
-      }
-      if (body.model) {
-        currentConfig.model = body.model;
-      }
-
-      const persistNumber = (field: "temperature" | "maxTokens" | "contextWindow") => {
-        if (!(field in body)) return;
-        const key = `config.${field}`;
-        const value = body[field];
-        if (value == null) {
-          currentConfig[field] = undefined;
-          settingsRepo.deleteAppSetting(key);
-        } else {
-          currentConfig[field] = value;
-          settingsRepo.setAppSetting(key, String(value));
-        }
-      };
-
-      persistNumber("temperature");
-      persistNumber("maxTokens");
-      persistNumber("contextWindow");
-
-      if ("thinkingLevel" in body) {
-        const level = body.thinkingLevel;
-        if (level == null) {
-          currentConfig.thinkingLevel = DEFAULT_THINKING_LEVEL;
-          settingsRepo.deleteAppSetting("config.thinkingLevel");
-        } else {
-          currentConfig.thinkingLevel = level;
-          settingsRepo.setAppSetting("config.thinkingLevel", level);
-        }
-      }
-
-      settingsRepo.setAppSetting("config.provider", currentConfig.provider);
-      settingsRepo.setAppSetting("config.model", currentConfig.model);
-
-      return { ...currentConfig };
+      return configState.updateConfig(body);
     },
 
-    getProviderList,
+    getProviderList() {
+      return providerRegistry.getProviderList();
+    },
 
-    findProvider,
+    findProvider(name: string) {
+      return providerRegistry.findProvider(name);
+    },
 
     // --- Custom Providers ---
 
     getCustomProviders(): CustomProviderDef[] {
-      return loadCustomProviders();
+      return customProviders.load();
     },
 
     saveCustomProvider(provider: CustomProviderDef): CustomProviderDef[] {
-      const providers = loadCustomProviders();
-      const idx = providers.findIndex((p) => p.name === provider.name);
-      if (idx >= 0) {
-        providers[idx] = provider;
-      } else {
-        providers.push(provider);
-      }
-      saveCustomProviders(providers);
-      invalidateProviderCache();
+      const providers = customProviders.saveProvider(provider);
+      providerRegistry.invalidate();
       return providers;
     },
 
     deleteCustomProvider(name: string): CustomProviderDef[] {
-      const providers = loadCustomProviders().filter((p) => p.name !== name);
-      saveCustomProviders(providers);
-      invalidateProviderCache();
-      // If active provider was deleted, reset to default
-      if (currentConfig.provider === name) {
-        currentConfig.provider = DEFAULT_PROVIDER;
-        const providerInfo = getProviderList().find((p) => p.name === DEFAULT_PROVIDER);
-        currentConfig.model = providerInfo?.defaultModel ?? "";
-        settingsRepo.setAppSetting("config.provider", currentConfig.provider);
-        settingsRepo.setAppSetting("config.model", currentConfig.model);
-      }
+      const providers = customProviders.deleteProvider(name);
+      resetActiveProvider(name);
       return providers;
     },
 
     // --- API Keys ---
 
     getApiKey(provider: string): string | null {
-      if (OAUTH_PROVIDERS.has(provider)) {
+      if (providerRegistry.isOAuthProvider(provider)) {
         return settingsRepo.getOAuthCredentials(provider)?.access ?? null;
       }
       return settingsRepo.getApiKey(provider);
@@ -337,7 +118,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
     // --- OAuth ---
 
     isOAuthProvider(provider: string): boolean {
-      return OAUTH_PROVIDERS.has(provider);
+      return providerRegistry.isOAuthProvider(provider);
     },
 
     getOAuthStatus(provider: string): OAuthStatus {
@@ -357,7 +138,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
       }
       const creds = await oauthProvider.login(callbacks);
       settingsRepo.setOAuthCredentials(provider, creds);
-      invalidateProviderCache();
+      providerRegistry.invalidate();
       if (provider === "github-copilot") {
         callbacks.onProgress?.("enabling models");
         await enableAllCopilotModels(creds.access);
@@ -366,14 +147,7 @@ export function createConfigService(settingsRepo: SettingsRepo) {
 
     logoutOAuth(provider: string): void {
       settingsRepo.deleteOAuthCredentials(provider);
-      invalidateProviderCache();
-      if (currentConfig.provider === provider) {
-        currentConfig.provider = DEFAULT_PROVIDER;
-        const providerInfo = getProviderList().find((p) => p.name === DEFAULT_PROVIDER);
-        currentConfig.model = providerInfo?.defaultModel ?? "";
-        settingsRepo.setAppSetting("config.provider", currentConfig.provider);
-        settingsRepo.setAppSetting("config.model", currentConfig.model);
-      }
+      resetActiveProvider(provider);
     },
 
     /**
@@ -382,13 +156,13 @@ export function createConfigService(settingsRepo: SettingsRepo) {
      * `resolveAgentConfig` can read a fresh access token straight from the DB.
      */
     async ensureOAuthToken(provider: string): Promise<void> {
-      if (!OAUTH_PROVIDERS.has(provider)) return;
+      if (!providerRegistry.isOAuthProvider(provider)) return;
       const creds = settingsRepo.getOAuthCredentials(provider);
       if (!creds) return;
       const result = await getOAuthApiKey(provider, { [provider]: creds });
       if (!result) return;
       // pi-ai returns the same reference when the token was still valid, and a
-      // new object when it was refreshed — so identity compare is enough here.
+      // new object when it was refreshed, so identity compare is enough here.
       if (result.newCredentials !== creds) {
         settingsRepo.setOAuthCredentials(provider, result.newCredentials);
       }


### PR DESCRIPTION
## 현재 동작
- `ConfigService` public API는 유지한다.
- builtin/custom provider, OAuth provider, model fallback, onboarding 동작은 기존과 같다.
- custom provider 삭제와 OAuth logout은 active provider일 때 default provider/model로 되돌린다.

## 구조 개선
- provider registry 계산을 `config.providers.ts`로 분리했다.
- custom provider persistence와 config load/update state를 `config.persistence.ts`로 분리했다.
- `config.service.ts`는 public service 조립, OAuth/API key/onboarding 흐름 중심으로 줄였다.

## 검증
- `bunx tsc --noEmit`
- `bun run --cwd apps/webui lint`
- `git diff --check`

## 남은 리스크
- 실제 OAuth login/logout은 외부 인증이 필요해 수동 실행하지 않았다.