### PR TITLE
렌더러 외부 폰트 링크 지원

### DIFF
--- a/apps/webui/src/client/entities/renderer/projectTheme.ts
+++ b/apps/webui/src/client/entities/renderer/projectTheme.ts
@@ -8,7 +8,8 @@ import type {
  * Renderer-owned theme: 렌더러가 프로젝트 페이지 한정으로 전역 CSS custom property를
  * 오버라이드할 수 있도록 하는 계약.
  *
- * - 색상 전용. 폰트는 렌더러 자체 `<style>` 안에서 `font-family`로 직접 지정한다.
+ * - 색상 전용. 폰트 적용은 renderer CSS에서 `font-family`로 지정한다.
+ *   외부 폰트 로딩이 필요하면 renderer component의 React 19 `<link>`를 사용한다.
  * - `base`만 있으면 단일 모드, `dark`가 있으면 듀얼 모드.
  * - `prefersScheme`이 명시되면 프로젝트 페이지에서만 사용자 Appearance 토글을 강제 오버라이드.
  * - `theme(snapshot)` 함수는 현재 files를 보고 팔레트를 다르게 반환할 수 있다.

--- a/apps/webui/src/client/features/chat/useSentenceAnimation.ts
+++ b/apps/webui/src/client/features/chat/useSentenceAnimation.ts
@@ -33,7 +33,6 @@ export function useSentenceAnimation(
       for (let i = prevCount; i < currentCount; i++) {
         newIndices.add(i);
       }
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- 새 문장 확정 시 애니메이션 상태를 즉시 반영한다.
       setAnimatingIndices(newIndices);
       animatedCountRef.current = currentCount;
 

--- a/apps/webui/src/client/features/onboarding/useOnboarding.ts
+++ b/apps/webui/src/client/features/onboarding/useOnboarding.ts
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/set-state-in-effect -- onboarding opens once after SWR resolves persisted setup status. */
 import { useState, useEffect } from "react";
 import {
   useProviders,

--- a/apps/webui/src/server/index.ts
+++ b/apps/webui/src/server/index.ts
@@ -32,6 +32,7 @@ import { createConfigRoutes } from "./routes/config.routes.js";
 import { createProjectRoutes } from "./routes/projects.routes.js";
 import { createTemplateRoutes } from "./routes/template.routes.js";
 import { createUpdateRoutes } from "./routes/update.routes.js";
+import { CONTENT_SECURITY_POLICY } from "./security.js";
 
 // ===== 1. Repositories =====
 const settingsRepo = createSettingsRepo(DATA_DIR);
@@ -83,6 +84,11 @@ await migrateConversationsToSessions(PROJECTS_DIR);
 
 // ===== 4. Hono App =====
 const app = new Hono<AppEnv>();
+
+app.use("*", async (c, next) => {
+  c.header("Content-Security-Policy", CONTENT_SECURITY_POLICY);
+  await next();
+});
 
 // Global error handler — log full stack traces to console
 app.onError((err, c) => {

--- a/apps/webui/src/server/security.ts
+++ b/apps/webui/src/server/security.ts
@@ -1,0 +1,25 @@
+const EXTERNAL_STYLESHEET_ORIGINS = [
+  "https://fonts.googleapis.com",
+  "https://cdn.jsdelivr.net",
+] as const;
+
+const EXTERNAL_FONT_ORIGINS = [
+  "https://fonts.gstatic.com",
+  "https://cdn.jsdelivr.net",
+] as const;
+
+const EXTERNAL_PRECONNECT_ORIGINS = Array.from(new Set([
+  ...EXTERNAL_STYLESHEET_ORIGINS,
+  ...EXTERNAL_FONT_ORIGINS,
+]));
+
+export const CONTENT_SECURITY_POLICY = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "object-src 'none'",
+  "img-src 'self' data: blob:",
+  "script-src 'self' 'unsafe-inline' blob:",
+  `style-src 'self' 'unsafe-inline' ${EXTERNAL_STYLESHEET_ORIGINS.join(" ")}`,
+  `font-src 'self' data: ${EXTERNAL_FONT_ORIGINS.join(" ")}`,
+  `connect-src 'self' ${EXTERNAL_PRECONNECT_ORIGINS.join(" ")}`,
+].join("; ");

--- a/docs/adr/0001-renderer-primary-surface-react-contract.md
+++ b/docs/adr/0001-renderer-primary-surface-react-contract.md
@@ -42,6 +42,8 @@ export function theme(snapshot: Agentchan.RendererSnapshot): Agentchan.RendererT
 - `agentchan:renderer/v1`
 - `react`
 - `renderer/` 내부 relative import와 CSS import
+- React 19 metadata/resource `<link>` 태그 중 `rel="stylesheet"`와
+  `rel="preconnect"`로 선언한 외부 스타일시트/폰트 리소스
 
 `RendererSnapshot`은 `{ slug, baseUrl, files, state }`다. `ProjectFile`의
 `digest`는 opaque cache identity다. Renderer-visible
@@ -61,6 +63,10 @@ transport는 runtime 구현 세부사항이며 renderer 작성 API가 아니다.
   내부 relative import, CSS import로 제한한다.
 - renderer code는 host DOM global, browser storage, `node:*`, 외부 URL import,
   임의 npm package에 의존하지 않는다.
+- 외부 폰트는 React 19 `<link rel="stylesheet" precedence="...">`와
+  `<link rel="preconnect">`로 선언할 수 있다. Host CSP가 허용한 origin만
+  로드된다. 외부 stylesheet의 selector가 ShadowRoot 내부 DOM을 스타일링한다고
+  가정하지 말고, font-face 등록 용도로 사용한다.
 - 파일 URL은 가능하면 `Agentchan.fileUrl()`을 사용해 digest cache key를
   일관되게 붙인다.
 

--- a/example_data/library/templates/character-chat/SYSTEM.meta.md
+++ b/example_data/library/templates/character-chat/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/character-chat/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/character-chat/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/empty/SYSTEM.meta.md
+++ b/example_data/library/templates/empty/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/empty/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/empty/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/impersonate-chat/SYSTEM.meta.md
+++ b/example_data/library/templates/impersonate-chat/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/impersonate-chat/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/impersonate-chat/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/interactive-chat/SYSTEM.meta.md
+++ b/example_data/library/templates/interactive-chat/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/memory-chat/SYSTEM.meta.md
+++ b/example_data/library/templates/memory-chat/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/memory-chat/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/memory-chat/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/novel/SYSTEM.meta.md
+++ b/example_data/library/templates/novel/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/novel/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/novel/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/sentinel/SYSTEM.meta.md
+++ b/example_data/library/templates/sentinel/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/three-winds-ledger/SYSTEM.meta.md
+++ b/example_data/library/templates/three-winds-ledger/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/three-winds-ledger/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/three-winds-ledger/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/example_data/library/templates/tides-of-moonhaven/SYSTEM.meta.md
+++ b/example_data/library/templates/tides-of-moonhaven/SYSTEM.meta.md
@@ -17,6 +17,9 @@ Renderer rules:
   inputs. Use `actions.fill(text)` and `actions.send(text)` for host actions.
 - Use `Agentchan.fileUrl(snapshot, file)` for assets under `files/` when
   practical.
+- Declare external fonts with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`; apply them from
+  renderer CSS with `font-family`.
 - Do not import host app modules, npm packages other than `react`, URLs,
   `node:*`, or browser storage APIs. Vendored browser libraries must live
   under `renderer/`.

--- a/example_data/library/templates/tides-of-moonhaven/skills/build-renderer/SKILL.md
+++ b/example_data/library/templates/tides-of-moonhaven/skills/build-renderer/SKILL.md
@@ -51,6 +51,9 @@ Rules:
 - CSS must be part of the renderer graph, usually `import "./index.css"`.
 - Relative imports must stay inside `renderer/`.
 - External browser libraries must be vendored under `renderer/`.
+- External fonts may be declared with React 19 `<link rel="preconnect">` and
+  `<link rel="stylesheet" precedence="renderer-fonts">`. Host CSP controls
+  allowed origins; keep actual styling in renderer CSS.
 - Allowed bare imports are `agentchan:renderer/v1` and `react` only.
 - Do not import URL modules, `node:*`, host app internals, or browser storage.
 - Do not emit `<script>` tags or inline event-handler attributes.

--- a/packages/creative-agent/tests/renderer/builder.test.ts
+++ b/packages/creative-agent/tests/renderer/builder.test.ts
@@ -124,6 +124,31 @@ describe("Renderer V1 bundle", () => {
     expect(bundle?.css[0]).toContain(".root");
   });
 
+  test("React 19 stylesheet links can be declared by renderer components", async () => {
+    await writeRenderer(
+      "index.tsx",
+      `
+        export default function Renderer() {
+          return (
+            <main>
+              <link
+                rel="stylesheet"
+                href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;700&display=swap"
+                precedence="renderer-fonts"
+              />
+              <div style={{ fontFamily: '"Noto Sans KR", system-ui, sans-serif' }} />
+            </main>
+          );
+        }
+      `,
+    );
+
+    const bundle = await buildRendererBundle(projectDir);
+
+    expect(bundle?.js).toContain("fonts.googleapis.com");
+    expect(bundle?.js).toContain("renderer-fonts");
+  });
+
   test("Agentchan.fileUrl encodes paths and appends digest consistently", async () => {
     await writeRenderer(
       "index.tsx",


### PR DESCRIPTION
## 요약
- Renderer V1 계약에 React 19 `<link rel="stylesheet">` / `<link rel="preconnect">` 기반 외부 폰트 리소스 선언을 추가했습니다.
- Web UI 서버에 CSP 헤더를 추가해 허용된 stylesheet/font/preconnect origin만 로드되도록 했습니다.
- 템플릿 메타 지침과 build-renderer 스킬 지침에 외부 폰트 사용법을 반영했습니다.
- renderer 빌더 테스트에 React 19 stylesheet link 번들링 케이스를 추가했습니다.
- 전체 lint를 통과시키기 위해 기존 hooks lint 지점 2곳을 최소 정리했습니다.

## 검증
- `bunx tsc --noEmit`
- `cd packages/creative-agent && bunx tsc --noEmit`
- `cd packages/creative-agent && bun test tests/renderer/builder.test.ts`
- `bun run skills:check`
- `bun run lint`
- `bun run test`
- `bun run build`
- `bun run example-data:copy -- --force`